### PR TITLE
Using correct path to executor in endpoint

### DIFF
--- a/funcx/endpoint/endpoint.py
+++ b/funcx/endpoint/endpoint.py
@@ -13,7 +13,8 @@ from funcx.sdk.client import FuncXClient
 from funcx.endpoint.utils.zmq_worker import ZMQWorker
 from funcx.endpoint.config import (_get_parsl_config, _load_auth_client)
 
-from parsl.executors import HighThroughputExecutor
+# from parsl.executors import HighThroughputExecutor
+from funcx.executor.high_throughput.executor import HighThroughputExecutor
 from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
 from parsl.config import Config


### PR DESCRIPTION
Before we were pointing to the Parsl project, but this was not pointing to the newly separated executor in funcx/funcx/executor. 