### PR TITLE
quick pass (ugly solution) at #67

### DIFF
--- a/funcx/sdk/client.py
+++ b/funcx/sdk/client.py
@@ -83,6 +83,12 @@ class FuncXClient(BaseClient):
         """
 
         r = self.get("{task_id}/status".format(task_id=task_id))
+        try: 
+            t = r["result"]
+            r = {"status": "COMPLETED", "task_id": r["task_id"]}
+        except KeyError:
+            pass
+
         return json.loads(r.text)
 
     def get_result(self, task_id):


### PR DESCRIPTION
This addresses #67, and enforces that completed tasks return a status dictionary similar to that of pending tasks. I don't think this is a particularly elegant fix and understand if we want to do something ... better.