### PR TITLE
add worker_procs to manager and kill all worker procs at exit

### DIFF
--- a/funcx/executors/high_throughput/worker_map.py
+++ b/funcx/executors/high_throughput/worker_map.py
@@ -172,10 +172,10 @@ class WorkerMap(object):
             raise NameError("Invalid container launch mode.")
 
         try:
-            proc = subprocess.Popen(modded_cmd,
+            proc = subprocess.Popen(modded_cmd.split(),
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE,
-                                    shell=True)
+                                    shell=False)
 
         except Exception:
             logger.exception("Got an error in worker launch")


### PR DESCRIPTION
The PR

1. Changes the worker launch cmd to `shell=False`
2. Adds a `worker_procs` list at the manager and kills the worker procs at exit