### PR TITLE
Added request throttling to the SDK

### DIFF
--- a/funcx/sdk/client.py
+++ b/funcx/sdk/client.py
@@ -3,14 +3,14 @@ import os
 import logging
 import pickle as pkl
 
-from globus_sdk.base import BaseClient
 from fair_research_login import NativeClient, JSONTokenStorage
 from funcx.serialize import FuncXSerializer
 # from funcx.sdk.utils.futures import FuncXFuture
+from funcx.sdk.utils import throttling
 
 logger = logging.getLogger(__name__)
 
-class FuncXClient(BaseClient):
+class FuncXClient(throttling.ThrottledBaseClient):
     """Main class for interacting with the funcX service
 
     Holds helper operations for performing common tasks with the funcX service.

--- a/funcx/sdk/utils/throttling.py
+++ b/funcx/sdk/utils/throttling.py
@@ -1,7 +1,6 @@
 import time
 import json
-from globus_sdk.base import BaseClient
-
+import globus_sdk
 
 class ThrottlingException(Exception):
     pass
@@ -15,7 +14,7 @@ class MaxRequestsExceeded(ThrottlingException):
     pass
 
 
-class ThrottledBaseClient(BaseClient):
+class ThrottledBaseClient(globus_sdk.base.BaseClient):
     """
     Throttled base client allows for two different types of Throttling. Note,
     this is 'polite' client side throttling, to avoid well intentioned users

--- a/funcx/sdk/utils/throttling.py
+++ b/funcx/sdk/utils/throttling.py
@@ -1,0 +1,82 @@
+import time
+import json
+from globus_sdk.base import BaseClient
+
+
+class ThrottlingException(Exception):
+    pass
+
+
+class MaxRequestSizeExceeded(ThrottlingException):
+    pass
+
+
+class MaxRequestsExceeded(ThrottlingException):
+    pass
+
+
+class ThrottledBaseClient(BaseClient):
+    """
+    Throttled base client allows for two different types of Throttling. Note,
+    this is 'polite' client side throttling, to avoid well intentioned users
+    from mistakenly harming the funcX service, this does not prevent DOS
+    attacks.
+
+    Request Flood Throttling: Restricts the number of requests that can be made
+    in a given time period, and raises an exception when that has been exceeded
+
+    Request Size Throttling: Restricts the size of the payload that can be
+    sent to the FuncX web service.
+
+    Both of these raise exceptions when the values have been exceeded. Both can
+    be caught with ThrottlingException. Throttling can also be turned off with:
+
+    cli.throttling_enabled = False
+
+    """
+    # Max requests per second, in a 5 second period
+    DEFAULT_MAX_REQUESTS = 1
+    # Max size is 2Mb
+    DEFAULT_MAX_REQUEST_SIZE = 2 * 2 ** 20
+
+    def __init__(self, *args, **kwargs):
+        self.max_request_size = self.DEFAULT_MAX_REQUEST_SIZE
+        self.max_requests = self.DEFAULT_MAX_REQUESTS
+
+        self.throttling_enabled = True
+
+        self.timer = time.time()
+        self.period = 5
+        self.requests = 0
+        super().__init__(*args, **kwargs)
+
+    def throttle_max_requests(self):
+        # Check the period, and reset it if we have moved past the period
+        if self.timer + self.period < time.time():
+            self.timer = time.time()
+            self.requests = 0
+
+        self.requests += 1
+
+        if self.requests > self.max_requests * self.period:
+            raise MaxRequestsExceeded()
+
+    def throttle_request_size(self, *request_args, **request_kwargs):
+        rtype, path = request_args
+        if request_kwargs.get('json_body'):
+            size = len(json.dumps(request_kwargs['json_body']))
+        elif request_kwargs.get('text_body'):
+            size = len(request_kwargs['text_body'])
+        else:
+            return
+        if rtype == 'POST' and size > self.max_request_size:
+            raise MaxRequestSizeExceeded(
+                f'Size of {rtype} at {path} was {size} bytes, exceeded '
+                f'limit of {self.max_request_size}.')
+
+
+    def _request(self, *args, **kwargs):
+        if self.throttling_enabled is True:
+            self.throttle_request_size(*args, **kwargs)
+            self.throttle_max_requests()
+        return super()._request(*args, **kwargs)

--- a/funcx/sdk/utils/throttling.py
+++ b/funcx/sdk/utils/throttling.py
@@ -57,7 +57,6 @@ class ThrottledBaseClient(globus_sdk.base.BaseClient):
 
         self.requests += 1
 
-        print((self.requests, self.max_requests))
         if self.requests > self.max_requests:
             raise MaxRequestsExceeded()
 

--- a/funcx/sdk/utils/throttling.py
+++ b/funcx/sdk/utils/throttling.py
@@ -35,7 +35,7 @@ class ThrottledBaseClient(BaseClient):
 
     """
     # Max requests per second, in a 5 second period
-    DEFAULT_MAX_REQUESTS = 1
+    DEFAULT_MAX_REQUESTS = 5
     # Max size is 2Mb
     DEFAULT_MAX_REQUEST_SIZE = 2 * 2 ** 20
 
@@ -58,7 +58,8 @@ class ThrottledBaseClient(BaseClient):
 
         self.requests += 1
 
-        if self.requests > self.max_requests * self.period:
+        print((self.requests, self.max_requests))
+        if self.requests > self.max_requests:
             raise MaxRequestsExceeded()
 
     def throttle_request_size(self, *request_args, **request_kwargs):

--- a/funcx/tests/test_throttling.py
+++ b/funcx/tests/test_throttling.py
@@ -1,0 +1,58 @@
+"""
+Requires pytest
+
+pip install pytest
+
+pytest test_throttling.py
+"""
+
+import pytest
+import globus_sdk
+from unittest.mock import Mock
+
+from funcx.sdk.utils.throttling import (ThrottledBaseClient,
+                                        MaxRequestSizeExceeded,
+                                        MaxRequestsExceeded)
+
+@pytest.fixture
+def mock_globus_sdk(monkeypatch):
+    monkeypatch.setattr(globus_sdk.base.BaseClient, '__init__', Mock())
+
+
+def test_size_throttling_on_small_requests(mock_globus_sdk):
+    cli = ThrottledBaseClient()
+
+    # Should not raise
+    jb = {'not': 'big enough'}
+    cli.throttle_request_size('POST', '/my_rest_endpoint', json_body=jb)
+
+    # Should not raise for these methods
+    cli.throttle_request_size('GET', '/my_rest_endpoint')
+    cli.throttle_request_size('PUT', '/my_rest_endpoint')
+    cli.throttle_request_size('DELETE', '/my_rest_endpoint')
+
+
+def test_size_throttle_on_large_request(mock_globus_sdk):
+    cli = ThrottledBaseClient()
+    # Test with ~2mb sized POST
+    jb = {'is': 'l' + 'o' * 2 * 2 ** 20 + 'ng'}
+    with pytest.raises(MaxRequestSizeExceeded):
+        cli.throttle_request_size('POST', '/my_rest_endpoint', json_body=jb)
+
+    # Test on text request
+    data = 'B' + 'i' * 2 * 2 ** 20 + 'gly'
+    with pytest.raises(MaxRequestSizeExceeded):
+        cli.throttle_request_size('POST', '/my_rest_endpoint', text_body=data)
+
+
+def test_low_threshold_requests_does_not_raise(mock_globus_sdk):
+    cli = ThrottledBaseClient()
+    for _ in range(4):
+        cli.throttle_max_requests()
+
+
+def test_max_requests_raises_exception(mock_globus_sdk):
+    cli = ThrottledBaseClient()
+    with pytest.raises(MaxRequestsExceeded):
+        for _ in range(10):
+            cli.throttle_max_requests()


### PR DESCRIPTION
@ryanchard Let me know how well this matches up to what you 
envisioned! It seemed the most straight forward to hook into the
`_request` call in the BaseClient. 

These changes restrict the number of requests a user can make to
1/second in a 5 second period, and the size of a given request
body for a POST request to 2MB (Both of these restrictions are
hard to reach). It's also easy to disable both of these if they
somehow interfer and a user really wants to disable them:

funcx_cli.throttling_enabled = False