### PR TITLE
Updating to 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.20.0
-jsonschema==2.6.0
+jsonschema==3.2.0
 sphinx_rtd_theme
 nbsphinx
 parsl


### PR DESCRIPTION
Updates to 3.2.0. Endpoints still work in testing and this meets DLHub requirements.