### PR TITLE
Updates routes to send tuples, not lists.

### DIFF
--- a/funcx/sdk/client.py
+++ b/funcx/sdk/client.py
@@ -278,9 +278,9 @@ class FuncXClient(throttling.ThrottledBaseClient):
         -------
         task_ids : a list of UUID strings that identify the tasks
         """
-        servable_path = 'batch_run'
-        assert isinstance(batch, Batch), "Expect a Batch object as input"
-        assert len(batch.tasks) > 0, "Expect a non-empty batch"
+        servable_path = 'submit'
+        assert isinstance(batch, Batch), "Requires a Batch object as input"
+        assert len(batch.tasks) > 0, "Requires a non-empty batch"
 
         data = batch.prepare()
 

--- a/funcx/sdk/utils/batch.py
+++ b/funcx/sdk/utils/batch.py
@@ -50,14 +50,11 @@ class Batch:
         payloads in dictionary, Dict[str, list]
         """
         data = {
-            'endpoints': [],
-            'functions': [],
-            'payloads': [],
+            'tasks': []
         }
 
         for task in self.tasks:
-            data['endpoints'].append(task['endpoint'])
-            data['functions'].append(task['function'])
-            data['payloads'].append(task['payload'])
+            new_task = (task['function'], task['endpoint'], task['payload'])
+            data['tasks'].append(new_task)
 
         return data


### PR DESCRIPTION
Uses tuples rather than lists and works with /submit instead of /batch_run.