### PR TITLE
set parsl version to 0.9 for funcx for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests==2.20.0
 jsonschema==3.2.0
 sphinx_rtd_theme
 nbsphinx
-parsl>=0.9.0
+parsl==0.9.0
 configobj
 texttable
 psutil


### PR DESCRIPTION
funcx does not work gracefully with parsl 1.0. before we update, we should fix the requirement to `parsl==0.9.0`