### PR TITLE
Configurable service address

### DIFF
--- a/funcx/config.py
+++ b/funcx/config.py
@@ -49,6 +49,7 @@ class Config(RepresentationMixin):
                  provider=LocalProvider(),
                  scaling_enabled=True,
                  # Connection info
+                 funcx_service_address='https://funcx.org/api/v1',
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
                  # Scaling info
@@ -74,6 +75,7 @@ class Config(RepresentationMixin):
         self.scaling_enabled = scaling_enabled
 
         # Connection info
+        self.funcx_service_address = funcx_service_address
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
 

--- a/funcx/config.py
+++ b/funcx/config.py
@@ -49,7 +49,7 @@ class Config(RepresentationMixin):
                  provider=LocalProvider(),
                  scaling_enabled=True,
                  # Connection info
-                 funcx_service_address='https://funcx.org/api/v1',
+                 funcx_service_address='https://api.funcx.org/v1',
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
                  # Scaling info

--- a/funcx/endpoint/endpoint.py
+++ b/funcx/endpoint/endpoint.py
@@ -219,11 +219,18 @@ def start_endpoint(
     name : str
     endpoint_uuid : str
     """
-
-    funcx_client = FuncXClient()
-
     endpoint_dir = os.path.join(State.FUNCX_DIR, name)
     endpoint_json = os.path.join(endpoint_dir, 'endpoint.json')
+
+    # TODO : we need to load the config ? maybe not. This needs testing
+    endpoint_config = SourceFileLoader(
+        'config',
+        os.path.join(endpoint_dir, FUNCX_CONFIG_FILE_NAME)
+    ).load_module()
+
+    funcx_client = FuncXClient(
+        funcx_service_address=endpoint_config.config.funcx_service_address
+    )
 
     if not os.path.exists(endpoint_dir):
         print('''Endpoint {0} is not configured!
@@ -263,10 +270,7 @@ def start_endpoint(
 
     check_pidfile(context.pidfile.path, "funcx-endpoint", name)
 
-    # TODO : we need to load the config ? maybe not. This needs testing
-    endpoint_config = SourceFileLoader(
-        'config',
-        os.path.join(endpoint_dir, FUNCX_CONFIG_FILE_NAME)).load_module()
+
 
     with context:
         while True:

--- a/funcx/executors/high_throughput/default_config.py
+++ b/funcx/executors/high_throughput/default_config.py
@@ -9,5 +9,5 @@ config = Config(
         max_blocks=1,
     ),
     max_workers_per_node=2,
-    funcx_service_address='https://funcx.org/api/v1'
+    funcx_service_address='https://api.funcx.org/v1'
 )

--- a/funcx/executors/high_throughput/default_config.py
+++ b/funcx/executors/high_throughput/default_config.py
@@ -9,4 +9,5 @@ config = Config(
         max_blocks=1,
     ),
     max_workers_per_node=2,
+    funcx_service_address='https://funcx.org/api/v1'
 )


### PR DESCRIPTION
In response to https://github.com/funcx-faas/funcX/issues/170.  Places a field in the default endpoint config for `funcx_service_address`.  This is then passed to the FuncXClient when starting the endpoint.