### PR TITLE
Sets address by hostname as the default

### DIFF
--- a/funcx/executors/high_throughput/global_config.py
+++ b/funcx/executors/high_throughput/global_config.py
@@ -1,8 +1,10 @@
 import getpass
+from parsl.addresses import address_by_hostname
 
 global_options = {
     'username': getpass.getuser(),
     'email': 'USER@USERDOMAIN.COM',
     'broker_address': '127.0.0.1',
     'broker_port': 8088,
+    'endpoint_address': address_by_hostname(),
 }


### PR DESCRIPTION
Updates the default ~/.funcx/config.py to use Parsl's address_by_hostname() as the default endpoint address. This replaces the current default "localhost", which does not work for managers that are deployed on a different machine than the endpoint.