### PR TITLE
fix a losing task problem in soft scheduling mode

### DIFF
--- a/funcx/executors/high_throughput/interchange_task_dispatch.py
+++ b/funcx/executors/high_throughput/interchange_task_dispatch.py
@@ -72,7 +72,9 @@ def dispatch(interesting_managers,
                         ready_manager_queue[manager]['tasks'][task_type].update(tids[task_type])
                     logger.debug("[MAIN] The tasks on manager {} is {}".format(manager, ready_manager_queue[manager]['tasks']))
                     ready_manager_queue[manager]['total_tasks'] += len(tasks)
-                    task_dispatch[manager] = tasks
+                    if manager not in task_dispatch:
++                        task_dispatch[manager] = []
++                    task_dispatch[manager] += tasks
                     dispatched_tasks += len(tasks)
                     logger.debug("[MAIN] Assigned tasks {} to manager {}".format(tids, manager))
                 if ready_manager_queue[manager]['free_capacity']['total_workers'] > 0:


### PR DESCRIPTION
The soft scheduling mode has two loops when deciding the tasks to send to a manager. Prior to this PR, a task from the first loop is not appended to the second loop, causing the task lost during soft scheduling.