### PR TITLE
remove some extra characters (typos) from a previous PR on interchange task dispatching

### DIFF
--- a/funcx/executors/high_throughput/interchange_task_dispatch.py
+++ b/funcx/executors/high_throughput/interchange_task_dispatch.py
@@ -73,8 +73,8 @@ def dispatch(interesting_managers,
                     logger.debug("[MAIN] The tasks on manager {} is {}".format(manager, ready_manager_queue[manager]['tasks']))
                     ready_manager_queue[manager]['total_tasks'] += len(tasks)
                     if manager not in task_dispatch:
-+                        task_dispatch[manager] = []
-+                    task_dispatch[manager] += tasks
+                        task_dispatch[manager] = []
+                    task_dispatch[manager] += tasks
                     dispatched_tasks += len(tasks)
                     logger.debug("[MAIN] Assigned tasks {} to manager {}".format(tids, manager))
                 if ready_manager_queue[manager]['free_capacity']['total_workers'] > 0:


### PR DESCRIPTION
PR #190 mistakenly introduced some extra characters. This PR removes those characters.