### PR TITLE
Fix ep status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ on existing infrastructure including clouds, clusters, and supercomputers.
 Quickstart
 ==========
 
-funcX is in alpha state with version `0.0.2` currently available on PyPI.
+funcX is in alpha state with version `0.0.2a0` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/funcx/executors/high_throughput/executor.py
+++ b/funcx/executors/high_throughput/executor.py
@@ -403,6 +403,13 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                     logger.debug("[MTHREAD] Received EPStatusReport")
                     if len(msgs.task_statuses):
                         self.task_status_queue.put(msgs.task_statuses)
+
+                    try:
+                        if self.endpoint_db:
+                            self.endpoint_db.put(self.endpoint_id, msgs.ep_status)
+                    except Exception as e:
+                        logger.error("Caught error while trying to push data into redis")
+
                 else:
                     for serialized_msg in msgs:
                         try:
@@ -417,13 +424,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
                         if tid == -2 and 'info' in msg:
                             logger.warning("Received info response : {}".format(msg['info']))
-                            try:
-                                if self.endpoint_db:
-                                    self.endpoint_db.put(self.endpoint_id, msg['info'])
-                            except Exception as e:
-                                logger.exception("Caught error while trying to push data into redis")
-                                pass
-                            continue
+
 
                         if tid == -1 and 'exception' in msg:
                             # TODO: This could be handled better we are essentially shutting down the

--- a/funcx/sdk/client.py
+++ b/funcx/sdk/client.py
@@ -37,7 +37,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
     CLIENT_ID = '4cf29807-cf21-49ec-9443-ff9a3fb9f81c'
 
     def __init__(self, http_timeout=None, funcx_home=os.path.join('~', '.funcx'),
-                 force_login=False, fx_authorizer=None, funcx_service_address='https://dev.api.funcx.org/v1',
+                 force_login=False, fx_authorizer=None, funcx_service_address='https://api.funcx.org/v1',
                  **kwargs):
         """ Initialize the client
 
@@ -54,9 +54,9 @@ class FuncXClient(throttling.ThrottledBaseClient):
         A custom authorizer instance to communicate with funcX.
         Default: ``None``, will be created.
 
-        service_address: str
+        funcx_service_address: str
         The address of the funcX web service to communicate with.
-        Default: https://dev.funcx.org/api/v1
+        Default: https://api.funcx.org/v1
 
         Keyword arguments are the same as for BaseClient.
         """


### PR DESCRIPTION
Endpoint status used to be sent in a specific message.  It's now bundled in with the task statuses.  Just moved the code for inserting into db to the place where the new message type is handled.