### PR TITLE
Redoing theodore's changes in PR #177 into dev.

### DIFF
--- a/funcx_endpoint/funcx/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx/endpoint/endpoint.py
@@ -243,6 +243,12 @@ def start_endpoint(
         '''.format(name))
         return
 
+    endpoint_config = SourceFileLoader('config',
+                                       os.path.join(endpoint_dir, FUNCX_CONFIG_FILE_NAME)).load_module()
+
+    funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address)
+    print(funcx_client)
+
     # If pervious registration info exists, use that
     if os.path.exists(endpoint_json):
         with open(endpoint_json, 'r') as fp:

--- a/funcx_endpoint/funcx/executors/high_throughput/default_config.py
+++ b/funcx_endpoint/funcx/executors/high_throughput/default_config.py
@@ -9,6 +9,7 @@ config = Config(
         max_blocks=1,
     ),
     max_workers_per_node=2,
+    funcx_service_address='https://api.funcx.org/v1'
 )
 
 # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:

--- a/funcx_sdk/funcx/utils/config.py
+++ b/funcx_sdk/funcx/utils/config.py
@@ -52,6 +52,7 @@ class Config(RepresentationMixin):
                  # Connection info
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
+                 funcx_service_address='https://api.funcx.org/v1',
                  # Scaling info
                  strategy=SimpleStrategy(),
                  max_workers_per_node=float('inf'),
@@ -76,6 +77,7 @@ class Config(RepresentationMixin):
         # Connection info
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
+        self.funcx_service_address = funcx_service_address
 
         # Scaling info
         self.strategy = strategy


### PR DESCRIPTION
This is exactly the same set of changes made by Theodore in #177. 
This allows the user to set the service address via updating `~/.funcx/ENDPOINT_NAME/config.py`

TODO for later: 
`funcx/funcx_sdk/funcx/utils/config.py` needs to be moved to funcx_endpoint.