### PR TITLE
Kubernetes Helm Chart with In-Cluster config Load

### DIFF
--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -124,7 +124,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Dictionary that keeps track of jobs, keyed on task_type
         self.resources_by_task_type = {}
 
-    def submit(self, cmd_string, tasks_per_node, task_type, job_name="FuncX"):
+    def submit(self, cmd_string, tasks_per_node, task_type, job_name="funcx"):
         """ Submit a job
         Args:
              - cmd_string  :(String) - Name of the container to initiate

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -57,9 +57,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         the opposite situation in which as few resources as possible (i.e., min_blocks) are used.
     worker_init : str
         Command to be run first for the workers, such as `python start.py`.
-    in_cluster_config: bool
-        Should we load the kubernetes config as running inside the cluster, or attempt
-        to find a .kube file to read from? Default is True
     secret : str
         Docker secret to use to pull images
     pod_name : str
@@ -89,7 +86,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                  init_mem: str = "250Mi",
                  parallelism: float = 1,
                  worker_init: str = "",
-                 in_cluster_config=True,
                  pod_name: Optional[str] = None,
                  user_id: Optional[str] = None,
                  group_id: Optional[str] = None,
@@ -100,10 +96,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
             raise OptionalModuleMissing(['kubernetes'],
                                         "Kubernetes provider requires kubernetes module and config.")
 
-        if in_cluster_config:
-            config.load_incluster_config()
-        else:
-            config.load_kube_config()
+        config.load_incluster_config()
 
         self.namespace = namespace
         self.image = image

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -57,6 +57,9 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         the opposite situation in which as few resources as possible (i.e., min_blocks) are used.
     worker_init : str
         Command to be run first for the workers, such as `python start.py`.
+    in_cluster_config: bool
+        Should we load the kubernetes config as running inside the cluster, or attempt
+        to find a .kube file to read from? Default is True
     secret : str
         Docker secret to use to pull images
     pod_name : str
@@ -86,6 +89,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                  init_mem: str = "250Mi",
                  parallelism: float = 1,
                  worker_init: str = "",
+                 in_cluster_config=True,
                  pod_name: Optional[str] = None,
                  user_id: Optional[str] = None,
                  group_id: Optional[str] = None,
@@ -95,7 +99,11 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         if not _kubernetes_enabled:
             raise OptionalModuleMissing(['kubernetes'],
                                         "Kubernetes provider requires kubernetes module and config.")
-        config.load_kube_config()
+
+        if in_cluster_config:
+            config.load_incluster_config()
+        else:
+            config.load_kube_config()
 
         self.namespace = namespace
         self.image = image


### PR DESCRIPTION
# Problem 
The Kubernetes endpoint needs configuration settings to interact with the Kubernetes API. When running inside the cluster its much cleaner and more secure to access the internal pod configuration than to attempt to mount parameters as a volume and load them as user mode.

Solves #236 

# Approach
Added a new option to the Kubernetes provider constructor to allow the provider to load config from in cluster or keep the old way.
