### PR TITLE
Helm Chart for Kubernetes Endpoint

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.3"
+__version__ = "0.0.2a0"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -91,11 +91,15 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                  group_id: Optional[str] = None,
                  run_as_non_root: bool = False,
                  secret: Optional[str] = None,
+                 incluster_config: Optional[bool] = True,
                  persistent_volumes: List[Tuple[str, str]] = []) -> None:
         if not _kubernetes_enabled:
             raise OptionalModuleMissing(['kubernetes'],
                                         "Kubernetes provider requires kubernetes module and config.")
-        config.load_incluster_config()
+        if incluster_config:
+            config.load_incluster_config()
+        else:
+            config.load_kube_config()
 
         self.namespace = namespace
         self.image = image
@@ -110,6 +114,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.parallelism = parallelism
         self.worker_init = worker_init
         self.secret = secret
+        self.incluster_config = incluster_config
         self.pod_name = pod_name
         self.user_id = user_id
         self.group_id = group_id

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -123,7 +123,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Dictionary that keeps track of jobs, keyed on task_type
         self.resources_by_task_type = {}
 
-    def submit(self, cmd_string, tasks_per_node, task_type, job_name="FuncX"):
+    def submit(self, cmd_string, tasks_per_node, task_type, job_name="funcx"):
         """ Submit a job
         Args:
              - cmd_string  :(String) - Name of the container to initiate

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -95,7 +95,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         if not _kubernetes_enabled:
             raise OptionalModuleMissing(['kubernetes'],
                                         "Kubernetes provider requires kubernetes module and config.")
-        config.load_kube_config()
+        config.load_incluster_config()
 
         self.namespace = namespace
         self.image = image

--- a/helm/README.md
+++ b/helm/README.md
@@ -69,3 +69,5 @@ The deployment is configured via values.yaml file.
 | initCPU | Initial CPUs to allocate to worker pod | 1 |  
 | maxCPU | Maximum CPUs to allocate to worker pod | 2 |
 | maxBlocks | Maximum number of worker pods to spawn | 100 |
+| maxWorkersPerPod | How many workers will be scheduled in each pod | 1 |
+

--- a/helm/README.md
+++ b/helm/README.md
@@ -5,6 +5,51 @@ will launch workers with a specified container image into a namespace.
 It uses Role Based Access Control to create a service account and assign it
 permissions to create the worker pod.
 
+## How to Use
+First you need to install valid funcX credentials into the cluster's 
+namespace. Launch a local version of the endpoint to get it to populate your
+`~/.funcx/credentials/funcx_sdk_tokens.json` with
+```
+funcx-endpoint start 
+```
+
+It will prompt you with an authentication URL to visit and ask you to paste the
+resulting token. After it completes you can stop your endpoint with 
+```
+funcx-endpoint stop 
+```
+
+cd to your `~/.funcx/credentials` directory and install the keys file as a
+kubernetes secret.
+
+```shell script
+kubectl create secret generic funcx-sdk-tokens --from-file=funcx_sdk_tokens.json
+```
+
+### Install the helm chart
+You need to add the funcx helm chart repo to your helm
+
+```shell script
+repo add funcx http://funcx.org/funcx-helm-charts/
+repo update
+```
+
+Create a local values.yaml file to set any specific values you wish to
+override.
+
+Then invoke the chart installation with:
+
+```shell script
+helm install -f covid19-mesa-values.yaml funcx funcx/funcx_endpoint
+```
+
+Once the pods start you can view your endpoint UID with 
+
+
+The notes that are printed with the installation will tell you how to access the
+logs for the endpoint to see the UID.
+
+
 ## Values
 The deployment is configured via values.yaml file.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,26 @@
+# Kubernetes Endpoint Helm Chart
+This chart will deploy a functioning Kubernetes endpoint into your cluster. It
+will launch workers with a specified container image into a namespace.
+
+It uses Role Based Access Control to create a service account and assign it
+permissions to create the worker pod.
+
+## Values
+The deployment is configured via values.yaml file.
+
+| Value | Description | Default |
+|-------| ----------- | ------- |
+| funcXServiceAddress | URL for the FuncX Webservice. | https://api.funcx.org |
+| image.repository | Docker image repository |  funcx/kube-endpoint |
+| image.tag | Tag name for the endpoint image | endpoint_helm |
+| image.pullPolicy | Pod pull policy for the endpoint image |  Always |
+| workerImage | Docker image to run in the worker pods |  python:3.6-buster |
+| workerInit | Command to execute on worker before strating uip | pip install parsl==0.9.0;pip install --force-reinstall funcx>=0.0.2a0 |
+| workerNamespace | Kubernetes namespace to launch worker pods into | default |
+| workingDir | Directory inside the container where log files are to be stored | /tmp/worker_logs |
+| rbacEnabled | Create service account and roles? | true |
+| initMem | Initial memory for worker pod | 2000Mi |
+| maxMem| Maximum allowed memory for worker pod | 16000Mi |
+| initCPU | Initial CPUs to allocate to worker pod | 1 |  
+| maxCPU | Maximum CPUs to allocate to worker pod | 2 |
+| maxBlocks | Maximum number of worker pods to spawn | 100 |

--- a/helm/funcx_endpoint/.helmignore
+++ b/helm/funcx_endpoint/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/funcx_endpoint/Chart.yaml
+++ b/helm/funcx_endpoint/Chart.yaml
@@ -1,15 +1,7 @@
 apiVersion: v2
 name: funcx_endpoint
-description: A Helm chart for Kubernetes
+description: Deploy a funcX endpoint into a cluster
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
@@ -18,4 +10,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.16.0
+appVersion: 0.0.3

--- a/helm/funcx_endpoint/Chart.yaml
+++ b/helm/funcx_endpoint/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: funcx_endpoint
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/helm/funcx_endpoint/templates/NOTES.txt
+++ b/helm/funcx_endpoint/templates/NOTES.txt
@@ -1,1 +1,5 @@
 Ready to use your new endpoint
+
+To find your Endpoint UID
+export EP_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=funcx-endpoint" -o jsonpath="{.items[0].metadata.name}")
+kubectl logs $EP_POD_NAME

--- a/helm/funcx_endpoint/templates/NOTES.txt
+++ b/helm/funcx_endpoint/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Ready to use your new endpoint

--- a/helm/funcx_endpoint/templates/_helpers.tpl
+++ b/helm/funcx_endpoint/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "funcx_endpoint.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "funcx_endpoint.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "funcx_endpoint.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "funcx_endpoint.labels" -}}
+helm.sh/chart: {{ include "funcx_endpoint.chart" . }}
+{{ include "funcx_endpoint.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "funcx_endpoint.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "funcx_endpoint.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "funcx_endpoint.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "funcx_endpoint.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/funcx_endpoint/templates/endpoint-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-endpoint-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name }}
+data:
+  config.py: |
+    import getpass
+    from parsl.addresses import address_by_interface
+
+    global_options = {
+        'username': getpass.getuser(),
+        'email': 'USER@USERDOMAIN.COM',
+        'broker_address': '127.0.0.1',
+        'broker_port': 8088,
+        'endpoint_address': address_by_interface('eth0'),
+    }
+

--- a/helm/funcx_endpoint/templates/endpoint-deployment.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-endpoint
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-endpoint
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-endpoint
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-endpoint
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        command: [ "/bin/bash", "-c", "--" ]
+        args: [ "mkdir ~/.funcx; mkdir ~/.funcx/{{ .Release.Name }}; mkdir ~/.funcx/credentials; cp /funcx/config/config.py ~/.funcx; cp /funcx/{{ .Release.Name }}/* ~/.funcx/{{ .Release.Name }}; cp /funcx/credentials/* ~/.funcx/credentials; funcx-endpoint start {{ .Release.Name }}; sleep infinity"]
+        tty: true
+        stdin: true
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
+
+        volumeMounts:
+          - mountPath: "/mnt"
+            name: funcxmnt
+          - name: funcx-sdk-tokens
+            mountPath: /funcx/credentials
+            readOnly: true
+          - name: endpoint-config
+            mountPath: /funcx/config
+          - name: endpoint-instance-config
+            mountPath: /funcx/{{ .Release.Name }}
+
+
+        ports:
+          - containerPort: 5000
+
+      volumes:
+        - name: funcxmnt
+          emptyDir: {}
+        - name: funcx-sdk-tokens
+          secret:
+            secretName: funcx-sdk-tokens
+        - name: endpoint-config
+          configMap:
+            name: {{ .Release.Name }}-endpoint-config
+        - name: endpoint-instance-config
+          configMap:
+            name: {{ .Release.Name }}-endpoint-instance-config

--- a/helm/funcx_endpoint/templates/endpoint-deployment.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-endpoint
     spec:
+      serviceAccountName: {{ template "funcx_endpoint.fullname" . }}
       containers:
       - name: {{ .Release.Name }}-endpoint
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -28,6 +28,7 @@ data:
             namespace='{{ .Values.workerNamespace }}'
         ),
         strategy=KubeSimpleStrategy(max_idletime=3600),
+        max_workers_per_node={{ .Values.maxWorkersPerPod }},
         scheduler_mode='hard',
         heartbeat_period=15,
         heartbeat_threshold=200,

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -27,6 +27,7 @@ data:
         heartbeat_period=15,
         heartbeat_threshold=200,
         max_workers_per_node=1,
+        working_dir='/tmp/worker_logs',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v1"
     )
 

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -16,9 +16,13 @@ data:
     config = Config(
         scaling_enabled=True,
         provider=KubernetesProvider(
-            init_blocks=0,
-            min_blocks=1,
-            max_blocks=1,
+            init_blocks={{ .Values.initBlocks }},
+            min_blocks={{ .Values.minBlocks }},
+            max_blocks={{ .Values.maxBlocks }},
+            init_cpu= {{ .Values.initCPU }},
+            max_cpu={{ .Values.maxCPU }},
+            init_mem="{{ .Values.initMem }}",
+            max_mem="{{ .Values.maxMem }}",
             image="{{ .Values.workerImage }}",
             worker_init='{{ .Values.workerInit }}',
             namespace='{{ .Values.workerNamespace }}'
@@ -27,8 +31,7 @@ data:
         scheduler_mode='hard',
         heartbeat_period=15,
         heartbeat_threshold=200,
-        max_workers_per_node=1,
-        working_dir='/tmp/worker_logs',
+        working_dir='{{ .Values.workingDir }}',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v1"
     )
 

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -20,7 +20,8 @@ data:
             min_blocks=1,
             max_blocks=1,
             image="{{ .Values.workerImage }}",
-            worker_init='{{ .Values.workerInit }}'
+            worker_init='{{ .Values.workerInit }}',
+            namespace='{{ .Values.workerNamespace }}'
         ),
         strategy=KubeSimpleStrategy(max_idletime=3600),
         scheduler_mode='hard',

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-endpoint-instance-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name }}
+data:
+  config.py: |
+    from funcx_endpoint.endpoint.utils.config import Config
+    from funcx_endpoint.providers.kubernetes.kube import KubernetesProvider
+    from funcx_endpoint.strategies import KubeSimpleStrategy
+
+    config = Config(
+        scaling_enabled=True,
+        provider=KubernetesProvider(
+            init_blocks=0,
+            min_blocks=1,
+            max_blocks=1,
+            image="{{ .Values.workerImage }}",
+            worker_init='{{ .Values.workerInit }}'
+        ),
+        strategy=KubeSimpleStrategy(max_idletime=3600),
+        scheduler_mode='hard',
+        heartbeat_period=15,
+        heartbeat_threshold=200,
+        max_workers_per_node=1,
+        funcx_service_address="{{ .Values.funcXServiceAddress }}/v1"
+    )
+
+    # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:
+    # urn:globus:auth:identity:{user_uuid}
+    # urn:globus:groups:id:{group_uuid}
+    meta = {
+    "name": "default",
+    "description": "",
+    "organization": "",
+    "department": "",
+    "public": True,
+    "visible_to": []
+    }

--- a/helm/funcx_endpoint/templates/role.yaml
+++ b/helm/funcx_endpoint/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbacEnabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "funcx_endpoint.fullname" . }}-worker-manager
+  labels:
+    app: {{ template "funcx_endpoint.name" . }}
+    chart: {{ template "funcx_endpoint.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}

--- a/helm/funcx_endpoint/templates/rolebinding.yaml
+++ b/helm/funcx_endpoint/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbacEnabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "funcx_endpoint.fullname" . }}-worker-manager
+  labels:
+    app: {{ template "funcx_endpoint.name" . }}
+    chart: {{ template "funcx_endpoint.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "funcx_endpoint.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "funcx_endpoint.fullname" . }}-worker-manager
+
+{{- end }}

--- a/helm/funcx_endpoint/templates/service_account.yaml
+++ b/helm/funcx_endpoint/templates/service_account.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "funcx_endpoint.fullname" . }}
+  labels:
+    app: {{ template "funcx_endpoint.name" . }}
+    chart: {{ template "funcx_endpoint.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -1,0 +1,13 @@
+# Default values for funcx_endpoint.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+funcXServiceAddress: https://api.funcx.org
+image:
+  repository: funcx/kube-endpoint
+  tag: 236_incluster_config
+  pullPolicy: IfNotPresent
+
+workerImage: covid19-mesa:dev
+workerInit: pip freeze

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -6,12 +6,23 @@ replicaCount: 1
 funcXServiceAddress: https://api.funcx.org
 image:
   repository: funcx/kube-endpoint
-  tag: 236_incluster_kube_config
+  tag: endpoint_helm
   pullPolicy: Always
 
-workerImage: covid19-mesa:dev
-workerInit: pip freeze
-workerNamespace: servicex
+workerImage: python:3.6-buster
+workerInit: pip install parsl==0.9.0;pip install --force-reinstall funcx>=0.0.2a0
+workerNamespace: default
+workingDir: /tmp/worker_logs
 
 rbacEnabled: true
 nameOverride: funcx-endpoint
+
+initMem: 2000Mi
+maxMem: 16000Mi
+initCPU: 1
+maxCPU: 2
+
+initBlocks: 0
+minBlocks: 1
+maxBlocks: 100
+

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 funcXServiceAddress: https://api.funcx.org
 image:
   repository: funcx/kube-endpoint
-  tag: endpoint_helm
-  pullPolicy: Always
+  tag: dev
+  pullPolicy: IfNotPresent
 
 workerImage: python:3.6-buster
 workerInit: pip install parsl==0.9.0;pip install --force-reinstall funcx>=0.0.2a0
@@ -25,4 +25,4 @@ maxCPU: 2
 initBlocks: 0
 minBlocks: 1
 maxBlocks: 100
-
+maxWorkersPerPod: 1

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -6,8 +6,12 @@ replicaCount: 1
 funcXServiceAddress: https://api.funcx.org
 image:
   repository: funcx/kube-endpoint
-  tag: 236_incluster_config
-  pullPolicy: IfNotPresent
+  tag: 236_incluster_kube_config
+  pullPolicy: Always
 
 workerImage: covid19-mesa:dev
 workerInit: pip freeze
+workerNamespace: servicex
+
+rbacEnabled: true
+nameOverride: funcx-endpoint


### PR DESCRIPTION
# Problem
Want to be able to deploy a configurable and workable kubernetes endpoint on any cluster

# Approach
Create a helm chart that deploys:
1. Endpoint Kubernetes deployment
2. A global config
3. An endpoint config
4. Service Account with role bindings to create pods

Added a parameter to the KubernetesProvider to obtain Kubernetes config from in-cluster. This is the default
now for this provider, but they can optionally be picked up from a mounted .kube file.

# Testing
The default values for the chart try to put the launched worker pods in the `default` namespace. This may not work
with your kubernetes account, so minimally, you will need a `values.yaml` file that sets:
```
workerNamespace: servicex
``` 