### PR TITLE
fix funcx-manager logger name after separating to funcx_endpoint and funcx repos

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -555,6 +555,7 @@ def cli_run():
     try:
         global logger
         logger = set_file_logger('{}/{}/manager.log'.format(args.logdir, args.uid),
+                                 name='funcx_endpoint',
                                  level=logging.DEBUG if args.debug is True else logging.INFO)
 
         logger.info("Python version: {}".format(sys.version))


### PR DESCRIPTION
Currently some modules for funcx-manager do not log to `manager.log` because of the rearch. This fixes the issue.