### PR TITLE
Test serializers across versions

### DIFF
--- a/funcx_sdk/funcx/serialize/create_serials.py
+++ b/funcx_sdk/funcx/serialize/create_serials.py
@@ -1,0 +1,90 @@
+import dill
+import sys
+import filecmp
+import math
+import numpy
+import pandas as pd
+import os
+
+from funcx.serialize.concretes import (pickle_base64,
+                                       code_pickle, code_text_dill,
+                                       code_text_inspect)
+
+if not os.path.exists('serials'):
+    os.makedirs('serials')
+    os.makedirs('serials/3.6')
+    os.makedirs('serials/3.7')
+    os.makedirs('serials/3.8')
+
+def func0(x, y={'a': 3}):
+    return math.floor(math.log(x)) * y['a']
+
+def func1(x):
+    return numpy.linalg.det(x)
+
+def func2(self):
+    return self.product(0).iloc[0]
+
+def func3(arr, low, high, x):
+    if high >= low:
+        mid = (high + low) // 2
+        if arr[mid] == x:
+            return mid
+        elif arr[mid] > x:
+            return func3(arr, low, mid - 1, x)
+        else:
+            return func3(arr, mid + 1, high, x)
+    else:
+        return -1
+
+def func4(word_list):
+    return sorted(word_list)
+
+def func5(word):
+    return word[::-2]
+
+def func6(x):
+    if (x > 10):
+        raise Exception('input is too large')
+
+test_functions = [func0, func1, func2, func3, func4, func5, func6]
+
+arr1 = numpy.array([[1, 2], [3, 4]])
+data = {'B':[15, 21, 59, 92, 35],
+        'A':['A', 'B', 'C', 'D', 'E']}
+df = pd.DataFrame(data)
+arr2 = [-1,0,3,5,9,12]
+word_list = ["Hello", "this", "Is", "an", "Example"]
+some_string = "asdfghjkl;"
+
+func_args = [10042, arr1, df, (arr2, 0, 6, 9), word_list, some_string]
+
+s02 = code_pickle()
+s03 = code_text_dill()
+s04 = code_text_inspect()
+
+serializers = [s02, s03, s04]
+
+expected_outputs = []
+
+for i, func in enumerate(test_functions):
+    if i == len(test_functions) - 1:
+        expected_outputs.append(0)
+    elif type(func_args[i]) is tuple:
+        expected_outputs.append(func(*func_args[i]))
+    else:
+        expected_outputs.append(func(func_args[i]))
+
+# write function serials to files
+if __name__ == "__main__":
+    version = str(sys.version_info[0]) + "." + str(sys.version_info[1])
+    print("Current version:", version)
+    for i in range(len(serializers)):
+        for j in range(len(test_functions)):
+            payload = serializers[i].serialize(test_functions[j])
+            f_name = "serials/" + version + "/func" + \
+                      str(j) + "_0" + str(i+2) + ".txt"
+            fp = open(f_name, "w")
+            fp.write(payload)
+            fp.close()
+    print("Wrote serials to serials/" + version)

--- a/funcx_sdk/funcx/serialize/test.py
+++ b/funcx_sdk/funcx/serialize/test.py
@@ -13,9 +13,6 @@ import numpy
 from create_serials import (serializers, test_functions, func_args,
                             expected_outputs)
 
-def func0(x, y={'a': 3}):
-    return math.floor(math.log(x)) * y['a']
-
 def func1(x):
     return numpy.linalg.det(x)
 
@@ -60,6 +57,8 @@ print("\n")
 
 class testSerializers(unittest.TestCase):
 
+    # tests deserialization of all functions across different versions using
+    # serializer 02
     def test_serializer02(self):
         for j in range(len(test_functions)):
             for i in range(6, 9):
@@ -84,6 +83,9 @@ class testSerializers(unittest.TestCase):
                                                        expected_outputs[j])
                 fp.close()
 
+
+    # Testing for func0, func1, func4 fail for serializers 03/04 since they
+    # rely on external modules or are recursive
     """
     def test_serializer03(self):
         for j in range(len(test_functions)):

--- a/funcx_sdk/funcx/serialize/test.py
+++ b/funcx_sdk/funcx/serialize/test.py
@@ -13,6 +13,9 @@ import numpy
 from create_serials import (serializers, test_functions, func_args,
                             expected_outputs)
 
+def func0(x, y={'a': 3}):
+    return math.floor(math.log(x)) * y['a']
+
 def func1(x):
     return numpy.linalg.det(x)
 
@@ -44,9 +47,9 @@ def func6(x):
 # Compare serials of different versions
 for i in range(len(serializers)):
     for j in range(len(test_functions)):
-        f_name36 = "serials/3.6/func" + str(j) + "_0" + str(i) + ".txt"
-        f_name37 = "serials/3.7/func" + str(j) + "_0" + str(i) + ".txt"
-        f_name38 = "serials/3.8/func" + str(j) + "_0" + str(i) + ".txt"
+        f_name36 = "serials/3.6/func" + str(j) + "_0" + str(i+2) + ".txt"
+        f_name37 = "serials/3.7/func" + str(j) + "_0" + str(i+2) + ".txt"
+        f_name38 = "serials/3.8/func" + str(j) + "_0" + str(i+2) + ".txt"
         compare3637 = filecmp.cmp(f_name36, f_name37, shallow = False)
         compare3638 = filecmp.cmp(f_name36, f_name38, shallow = False)
         print("3.6/3.7 comparison(serializer:", str(i+1),
@@ -59,6 +62,7 @@ class testSerializers(unittest.TestCase):
 
     # tests deserialization of all functions across different versions using
     # serializer 02
+
     def test_serializer02(self):
         for j in range(len(test_functions)):
             for i in range(6, 9):
@@ -135,6 +139,8 @@ class testSerializers(unittest.TestCase):
                                                        expected_outputs[j])
                 fp.close()
     """
+
+    # Tests for individual functions on serializers 03/04
 
     def test_serializer03_func2(self):
         for i in range(6, 9):

--- a/funcx_sdk/funcx/serialize/test.py
+++ b/funcx_sdk/funcx/serialize/test.py
@@ -1,0 +1,234 @@
+import codecs
+import json
+import dill
+import pickle
+import inspect
+import logging
+import sys
+import filecmp
+import math
+import unittest
+import numpy
+
+from create_serials import (serializers, test_functions, func_args,
+                            expected_outputs)
+
+def func0(x, y={'a': 3}):
+    return math.floor(math.log(x)) * y['a']
+
+def func1(x):
+    return numpy.linalg.det(x)
+
+def func2(self):
+    return self.product(0).iloc[0]
+
+def func3(arr, low, high, x):
+    if high >= low:
+        mid = (high + low) // 2
+        if arr[mid] == x:
+            return mid
+        elif arr[mid] > x:
+            return func3(arr, low, mid - 1, x)
+        else:
+            return func3(arr, mid + 1, high, x)
+    else:
+        return -1
+
+def func4(word_list):
+    return sorted(word_list)
+
+def func5(word):
+    return word[::-2]
+
+def func6(x):
+    if (x > 10):
+        raise Exception('input is too large')
+
+# Compare serials of different versions
+for i in range(len(serializers)):
+    for j in range(len(test_functions)):
+        f_name36 = "serials/3.6/func" + str(j) + "_0" + str(i) + ".txt"
+        f_name37 = "serials/3.7/func" + str(j) + "_0" + str(i) + ".txt"
+        f_name38 = "serials/3.8/func" + str(j) + "_0" + str(i) + ".txt"
+        compare3637 = filecmp.cmp(f_name36, f_name37, shallow = False)
+        compare3638 = filecmp.cmp(f_name36, f_name38, shallow = False)
+        print("3.6/3.7 comparison(serializer:", str(i+1),
+            "func:", str(j) + ")", compare3637)
+        print("3.6/3.8 comparison(serializer:", str(i+1),
+            "func:", str(j) + ")", compare3638)
+print("\n")
+
+class testSerializers(unittest.TestCase):
+    
+    def test_serializer02(self):
+        for j in range(len(test_functions)):
+            for i in range(6, 9):
+                print("func: " + str(j))
+                f_name = "serials/3." + str(i) + "/func" + str(j) + "_02.txt"
+                fp = open(f_name, "r")
+                deserialized_func = serializers[0].deserialize(fp.read())
+                print("After deserialization (serialized on 3."
+                 + str(i) + "): ")
+                if (j == len(test_functions) - 1):
+                    with self.assertRaises(Exception) as context:
+                        deserialized_func(15)
+                    self.assertTrue('input is too large' in \
+                    str(context.exception))
+                elif type(func_args[j]) is tuple:
+                    print("FN(): ", deserialized_func(*func_args[j]))
+                    self.assertEqual(deserialized_func(*func_args[j]),
+                                                       expected_outputs[j])
+                else:
+                    print("FN(): ", deserialized_func(func_args[j]))
+                    self.assertEqual(deserialized_func(func_args[j]),
+                                                       expected_outputs[j])
+                fp.close()
+
+    """
+    def test_serializer03(self):
+        for j in range(len(test_functions)):
+            for i in range(6, 9):
+                print("func: " + str(j))
+                f_name = "serials/3." + str(i) + "/func" + str(j) + "_02.txt"
+                fp = open(f_name, "r")
+                deserialized_func = serializers[2].deserialize(fp.read())
+                print("After deserialization (serialized on 3." + str(i) +
+                      "): ")
+                if (j == len(test_functions) - 1):
+                    with self.assertRaises(Exception) as context:
+                        deserialized_func(15)
+                    self.assertTrue('input is too large' in \
+                    str(context.exception))
+                elif type(func_args[j]) is tuple:
+                    print("FN(): ", deserialized_func(*func_args[j]))
+                    self.assertEqual(deserialized_func(*func_args[j]),
+                                                       expected_outputs[j])
+                else:
+                    print("FN(): ", deserialized_func(func_args[j]))
+                    self.assertEqual(deserialized_func(func_args[j]),
+                                                       expected_outputs[j])
+                fp.close()
+
+    def test_serializer04(self):
+        for j in range(len(test_functions)):
+            for i in range(6, 9):
+                print("func: " + str(j))
+                f_name = "serials/3." + str(i) + "/func" + str(j) + "_03.txt"
+                fp = open(f_name, "r")
+                deserialized_func = serializers[3].deserialize(fp.read())
+                print("After deserialization (serialized on 3." + str(i) +
+                      "): ")
+                if (j == len(test_functions) - 1):
+                    with self.assertRaises(Exception) as context:
+                        deserialized_func(15)
+                    self.assertTrue('input is too large' in \
+                    str(context.exception))
+                elif type(func_args[j]) is tuple:
+                    print("FN(): ", deserialized_func(*func_args[j]))
+                    self.assertEqual(deserialized_func(*func_args[j]),
+                                                       expected_outputs[j])
+                else:
+                    print("FN(): ", deserialized_func(func_args[j]))
+                    self.assertEqual(deserialized_func(func_args[j]),
+                                                       expected_outputs[j])
+                fp.close()
+    """
+
+    def test_serializer03_func2(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func2" + "_03.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[1].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[2]))
+            self.assertEqual(deserialized_func(func_args[2]),
+                                               expected_outputs[2])
+            fp.close()
+
+    def test_serializer04_func2(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func2" + "_04.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[2].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[2]))
+            self.assertEqual(deserialized_func(func_args[2]),
+                                           expected_outputs[2])
+            fp.close()
+
+    def test_serializer03_func4(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func4" + "_03.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[1].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[4]))
+            self.assertEqual(deserialized_func(func_args[4]),
+                                               expected_outputs[4])
+            fp.close()
+
+    def test_serializer04_func4(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func4" + "_04.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[2].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[4]))
+            self.assertEqual(deserialized_func(func_args[4]),
+                                           expected_outputs[4])
+            fp.close()
+
+    def test_serializer03_func5(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func5" + "_03.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[1].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[5]))
+            self.assertEqual(deserialized_func(func_args[5]),
+                                               expected_outputs[5])
+            fp.close()
+
+    def test_serializer04_func5(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func5" + "_04.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[2].deserialize(fp.read())
+            print("After deserialization (serialized on 3." + str(i) +
+                  "): ")
+            print("FN(): ", deserialized_func(func_args[5]))
+            self.assertEqual(deserialized_func(func_args[5]),
+                                           expected_outputs[5])
+            fp.close()
+
+    def test_serializer03_func6(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func6" + "_03.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[1].deserialize(fp.read())
+            with self.assertRaises(Exception) as context:
+                deserialized_func(15)
+            self.assertTrue('input is too large' in \
+            str(context.exception))
+            fp.close()
+
+    def test_serializer04_func6(self):
+        for i in range(6, 9):
+            f_name = "serials/3." + str(i) + "/func6" + "_04.txt"
+            fp = open(f_name, "r")
+            deserialized_func = serializers[2].deserialize(fp.read())
+            with self.assertRaises(Exception) as context:
+                deserialized_func(15)
+            self.assertTrue('input is too large' in \
+            str(context.exception))
+            fp.close()
+
+    #def test_serializer03_func
+
+if __name__ == '__main__':
+    unittest.main()

--- a/funcx_sdk/funcx/serialize/test.py
+++ b/funcx_sdk/funcx/serialize/test.py
@@ -60,9 +60,8 @@ print("\n")
 
 class testSerializers(unittest.TestCase):
 
-    # tests deserialization of all functions across different versions using
+    # Tests deserialization of all functions across different versions using
     # serializer 02
-
     def test_serializer02(self):
         for j in range(len(test_functions)):
             for i in range(6, 9):
@@ -141,7 +140,6 @@ class testSerializers(unittest.TestCase):
     """
 
     # Tests for individual functions on serializers 03/04
-
     def test_serializer03_func2(self):
         for i in range(6, 9):
             f_name = "serials/3." + str(i) + "/func2" + "_03.txt"

--- a/funcx_sdk/funcx/serialize/test.py
+++ b/funcx_sdk/funcx/serialize/test.py
@@ -59,7 +59,7 @@ for i in range(len(serializers)):
 print("\n")
 
 class testSerializers(unittest.TestCase):
-    
+
     def test_serializer02(self):
         for j in range(len(test_functions)):
             for i in range(6, 9):
@@ -227,8 +227,6 @@ class testSerializers(unittest.TestCase):
             self.assertTrue('input is too large' in \
             str(context.exception))
             fp.close()
-
-    #def test_serializer03_func
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The protocol for pickling can be different for different versions of python, so I wrote two test files for checking the compatibility of serialization/deserialization across different versions. `create_serials.py` writes the serials for the functions to files under a directory serials/, so `create_serials.py` should be run on 3.6/3.7/3.8 separately first. `test.py` then reads the files and tests the deserialized functions. 

Google doc of findings: 
[(https://docs.google.com/document/d/1Mm1Nu_wA1xPE_H1eSF7-0CyWdNZic8sEvJHeY5X70lA/edit)]