### PR TITLE
Add RotateFileHandler for interchange.log and manager.log to limit the log size

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -68,7 +68,7 @@ class Config(RepresentationMixin):
                  heartbeat_threshold=120,
                  poll_period=10,
                  # Logging info
-                 log_max_bytes=256*1024*1024,  # in bytes
+                 log_max_bytes=256 * 1024 * 1024,  # in bytes
                  log_backup_count=1,
                  working_dir=None,
                  worker_debug=False):

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -68,6 +68,8 @@ class Config(RepresentationMixin):
                  heartbeat_threshold=120,
                  poll_period=10,
                  # Logging info
+                 log_max_bytes=256*1024*1024,  # in bytes
+                 log_backup_count=1,
                  working_dir=None,
                  worker_debug=False):
         # Scaling mechanics
@@ -96,5 +98,7 @@ class Config(RepresentationMixin):
         self.poll_period = poll_period
 
         # Logging info
+        self.log_max_bytes = log_max_bytes
+        self.log_backup_count = log_backup_count
         self.working_dir = working_dir
         self.worker_debug = worker_debug

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -544,7 +544,7 @@ def cli_run():
                               "(hard, soft"))
     parser.add_argument("-r", "--result_url", required=True,
                         help="REQUIRED: ZMQ url for posting results")
-    parser.add_argument("--log_max_bytes", default=256*1024*1024,
+    parser.add_argument("--log_max_bytes", default=256 * 1024 * 1024,
                         help="The maximum bytes per logger file in bytes")
     parser.add_argument("--log_backup_count", default=1,
                         help="The number of backup (must be non-zero) per logger file")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -544,6 +544,10 @@ def cli_run():
                               "(hard, soft"))
     parser.add_argument("-r", "--result_url", required=True,
                         help="REQUIRED: ZMQ url for posting results")
+    parser.add_argument("--log_max_bytes", default=256*1024*1024,
+                        help="The maximum bytes per logger file in bytes")
+    parser.add_argument("--log_backup_count", default=1,
+                        help="The number of backup (must be non-zero) per logger file")
 
     args = parser.parse_args()
 
@@ -556,7 +560,9 @@ def cli_run():
         global logger
         logger = set_file_logger('{}/{}/manager.log'.format(args.logdir, args.uid),
                                  name='funcx_endpoint',
-                                 level=logging.DEBUG if args.debug is True else logging.INFO)
+                                 level=logging.DEBUG if args.debug is True else logging.INFO,
+                                 max_bytes=float(args.log_max_bytes),
+                                 backup_count=int(args.log_backup_count))
 
         logger.info("Python version: {}".format(sys.version))
         logger.info("Debug logging: {}".format(args.debug))
@@ -573,6 +579,8 @@ def cli_run():
         logger.info("worker_mode: {}".format(args.worker_mode))
         logger.info("scheduler_mode: {}".format(args.scheduler_mode))
         logger.info("worker_type: {}".format(args.worker_type))
+        logger.info("log_max_bytes: {}".format(args.log_max_bytes))
+        logger.info("log_backup_count: {}".format(args.log_backup_count))
 
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -882,7 +882,7 @@ def start_file_logger(filename,
                       name="interchange",
                       level=logging.DEBUG,
                       format_string=None,
-                      max_bytes=256*1024*1024,
+                      max_bytes=256 * 1024 * 1024,
                       backup_count=1):
     """Add a stream log handler.
 

--- a/funcx_sdk/funcx/utils/loggers.py
+++ b/funcx_sdk/funcx/utils/loggers.py
@@ -1,7 +1,13 @@
 import logging
+from logging.handlers import RotatingFileHandler
 
 
-def set_file_logger(filename, name='funcx', level=logging.DEBUG, format_string=None):
+def set_file_logger(filename,
+                    name='funcx',
+                    level=logging.DEBUG,
+                    format_string=None,
+                    max_bytes=100*1024*1024,
+                    backup_count=1):
     """Add a stream log handler.
 
     Args:
@@ -9,6 +15,8 @@ def set_file_logger(filename, name='funcx', level=logging.DEBUG, format_string=N
         - name (string): Logger name
         - level (logging.LEVEL): Set the logging level.
         - format_string (string): Set the format string
+        - maxBytes: The maximum bytes per logger file, default: 100MB
+        - backupCount: The number of backup (must be non-zero) per logger file, default: 1
 
     Returns:
        -  None
@@ -18,7 +26,7 @@ def set_file_logger(filename, name='funcx', level=logging.DEBUG, format_string=N
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
-    handler = logging.FileHandler(filename)
+    handler = RotatingFileHandler(filename, maxBytes=max_bytes, backupCount=backup_count)
     handler.setLevel(level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)

--- a/funcx_sdk/funcx/utils/loggers.py
+++ b/funcx_sdk/funcx/utils/loggers.py
@@ -6,7 +6,7 @@ def set_file_logger(filename,
                     name='funcx',
                     level=logging.DEBUG,
                     format_string=None,
-                    max_bytes=100*1024*1024,
+                    max_bytes=100 * 1024 * 1024,
                     backup_count=1):
     """Add a stream log handler.
 


### PR DESCRIPTION
This PR adds new options for users to limit the log size for interchange.log and manager.log. Fixes #271 