### PR TITLE
Replace checks for "failure" with checks for "Failed"

### DIFF
--- a/funcx_endpoint/funcx_endpoint/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/__init__.py
@@ -2,4 +2,3 @@ from funcx_endpoint.endpoint.version import VERSION
 
 __author__ = "The funcX team"
 __version__ = VERSION
-

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -340,7 +340,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         r = self.post(servable_path, json_body=data)
         if r.http_status != 200:
             raise HTTPError(r)
-        if r.get("status", "Failure") == "Failure":
+        if r.get("status", "Failed") == "Failed":
             raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
         return r['task_uuids']
 
@@ -386,7 +386,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         if r.http_status != 200:
             raise Exception(r)
 
-        if r.get("status", "Failure") == "Failure":
+        if r.get("status", "Failed") == "Failed":
             raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
         return r['task_uuids']
 


### PR DESCRIPTION
We (this is my fault, oops.) were checking for various globus failures by doing the following:
```
if r.get("status", "Failure") == "Failure":
            raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
```
Globus actually returns the status code "Failed".