### PR TITLE
Retry Endpoint Registration

### DIFF
--- a/funcx_endpoint/funcx_endpoint/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/__init__.py
@@ -2,4 +2,3 @@ from funcx_endpoint.endpoint.version import VERSION
 
 __author__ = "The funcX team"
 __version__ = VERSION
-

--- a/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
@@ -46,7 +46,7 @@ class KubeSimpleStrategy(BaseStrategy):
 
     def _strategize(self, *args, **kwargs):
         task_breakdown = self.interchange.get_outstanding_breakdown()
-        logger.info(f"Task breakdown {task_breakdown}")
+        logger.debug(f"Task breakdown {task_breakdown}")
 
         min_blocks = self.interchange.config.provider.min_blocks
         max_blocks = self.interchange.config.provider.max_blocks

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -11,3 +11,4 @@ fair_research_login
 dill>=0.3
 typer>=0.3.0
 funcx>=0.0.3
+retry


### PR DESCRIPTION
# Problem
There is a race condition within the Helm deployment where the endpoint attempts to connect to the web service. If that service is not yet up, the endpoint will silently fail.
Fixes #280 

# Approach
Added a retry around the `register_endpoint` function

Also, debugging this was difficult with the noisy _Task breakdown_ messages. Demoted this log message to _debug_