### PR TITLE
Endpoint Logging for Kubernetes 

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -304,13 +304,7 @@ def start_endpoint(
                                              State.FUNCX_CONFIG['broker_address'],
                                              State.FUNCX_CONFIG['redis_host'])
             else:
-                metadata = None
-                try:
-                    metadata = endpoint_config.meta
-                except AttributeError:
-                    logger.info("Did not find associated endpoint metadata")
-
-                reg_info = register_endpoint(funcx_client, name, endpoint_uuid, metadata, endpoint_dir)
+                reg_info = register_endpoint(funcx_client, name, endpoint_uuid, endpoint_dir)
 
             logger.info("Endpoint registered with UUID: {}".format(reg_info['endpoint_id']))
 
@@ -333,15 +327,10 @@ def start_endpoint(
             logger.critical("Interchange terminated.")
             time.sleep(10)
 
-    stdout.close()
-    stderr.close()
-
-    logger.critical(f"Shutting down endpoint {endpoint_uuid}")
-
 
 # Avoid a race condition when starting the endpoint alongside the web service
 @retry(delay=5, logger=logging.getLogger('funcx'))
-def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, metadata, endpoint_dir):
+def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
     """Register the endpoint and return the registration info.
 
     Parameters

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -43,6 +43,21 @@ class Config(RepresentationMixin):
         Allow Interchange to manage resource provisioning. If set to False, interchange
         will not do any scaling.
         Default: True
+
+    stdout : str
+        Path where the endpoint's stdout should be written
+        Default: ./interchange.stdout
+
+    stderr : str
+        Path where the endpoint's stderr should be written
+        Default: ./interchange.stderr
+
+    detach_endpoint : Bool
+        Should the endpoint deamon be run as a detached process? This is good for
+        a real edge node, but an anti-pattern for kubernetes pods
+        Default: True
+
+
     """
 
     def __init__(self,
@@ -71,7 +86,10 @@ class Config(RepresentationMixin):
                  log_max_bytes=256 * 1024 * 1024,  # in bytes
                  log_backup_count=1,
                  working_dir=None,
-                 worker_debug=False):
+                 worker_debug=False,
+                 stdout="./interchange.stdout",
+                 stderr="./interchange.stderr",
+                 detach_endpoint=True):
         # Scaling mechanics
         self.provider = provider
         self.scaling_enabled = scaling_enabled
@@ -102,3 +120,8 @@ class Config(RepresentationMixin):
         self.log_backup_count = log_backup_count
         self.working_dir = working_dir
         self.worker_debug = worker_debug
+        self.stdout = stdout
+        self.stderr = stderr
+
+        # Endpoint behavior
+        self.detach_endpoint = detach_endpoint

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -143,9 +143,9 @@ class Interchange(object):
              When set to True, the interchange will attempt to suppress failures. Default: False
         """
 
+        self.logdir = logdir
         if config.interchange_file_logger:
             logpath = "{}/interchange.log".format(self.logdir)
-            self.logdir = logdir
             try:
                 os.makedirs(self.logdir)
             except FileExistsError:

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -33,7 +33,8 @@ data:
         heartbeat_period=15,
         heartbeat_threshold=200,
         working_dir='{{ .Values.workingDir }}',
-        funcx_service_address="{{ .Values.funcXServiceAddress }}/v1"
+        funcx_service_address="{{ .Values.funcXServiceAddress }}/v1",
+        detach_endpoint=False
     )
 
     # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:


### PR DESCRIPTION
# Problem
The Kubernetes endpoint writes the daemon's logs to files in the .funcx directory. This is inconvenient for Kubernetes admins since they don't show up in `Kubectl log` command output. You have to create a bash shell into the pod and tail the file.
Solution to Issue #285 

# Approach
The endpoint cli launches an endpoint as a daemon. In kubernetes it is considered an anti-pattern to have multiple detached processes running in a pod. This is why other attempts have failed.

There is an option to `daemon.DaemonContext` to tell it to not detach the daemon process. Added a new config setting to the endpoint to say whether this should be set to True or False. Updated the config created by the helm chart to set this to False.

During development of this it was clear that there needs to be more flexibility in where the log files are placed, so externalized this to the config settings. 

Also cleaned up some unreachable code and an unused parameter.

# How to Test
1. Create a development `values.yaml` for the endpoint helm chart
```
image:
  pullPolicy: IfNotPresent
  tag: 285_endpoint_logging

workerInit: pip freeze
workingDir: /tmp/worker_logs

initBlocks: 0
minBlocks: 1
maxBlocks: 100
```
2. Deploy the endpoint with the latest chart in helm directory
```
helm install -f my-values.yaml test funcx
```
3. Verify that all logging now shows up in kubectl log command 