### PR TITLE
Update workerInit to pull in the new split out endpoint library

### DIFF
--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 workerImage: python:3.6-buster
-workerInit: pip install parsl==0.9.0;pip install --force-reinstall funcx>=0.0.2a0
+workerInit: pip install parsl==0.9.0;pip install --force-reinstall funcx>=0.0.2a0 funcx-endpoint>=0.0.3
 workerNamespace: default
 workingDir: /tmp/worker_logs
 


### PR DESCRIPTION
# Problem
The workerInit in the endpoint values.yaml installs the wrong library so the endpoint code is not available

# Approach
Change the workerInit to pip install funcx-endpoint>=0.0.3