### PR TITLE
Allow interchange logger to report to pod log

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -89,7 +89,8 @@ class Config(RepresentationMixin):
                  worker_debug=False,
                  stdout="./interchange.stdout",
                  stderr="./interchange.stderr",
-                 detach_endpoint=True):
+                 detach_endpoint=True,
+                 interchange_file_logger=True):
         # Scaling mechanics
         self.provider = provider
         self.scaling_enabled = scaling_enabled
@@ -122,6 +123,7 @@ class Config(RepresentationMixin):
         self.worker_debug = worker_debug
         self.stdout = stdout
         self.stderr = stderr
+        self.interchange_file_logger = interchange_file_logger
 
         # Endpoint behavior
         self.detach_endpoint = detach_endpoint

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -34,7 +34,8 @@ data:
         heartbeat_threshold=200,
         working_dir='{{ .Values.workingDir }}',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v1",
-        detach_endpoint=False
+        detach_endpoint=False,
+        interchange_file_logger=False
     )
 
     # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:


### PR DESCRIPTION
# Problem
The interchange always logs to a file. This means that for Kubernetes endpoints, the output doesn't show up in the Kubectl logs. There is also far too many info log messages to see what is going on.
Solution to #289  

# Approach
1. Added a new option to the config: `interchange_file_logger` - the default is True which keeps the file logging behavior
2. The helm chart will set this to False to have logging sent to the pod's log
3. Based on this setting, `start_file_logger` will create a `RotatingFileHandler` or a `StreamHandler`
4. Changed some of the interchange log statements to _debug_ instead of _info_
5. Supressed the Heartbeat messages, the "Sending status report to forwarder", and zero items in batch messages

# Merge Notes
This PR depends on code submitted to #285 

# Testing
Deploy an endpoint using this helm chart. 
View the logs in the endpoint pod and you should see interchange logging
