### PR TITLE
Add asynchronous interface to funcX client

### DIFF
--- a/examples/AsynchFuncX Example.ipynb
+++ b/examples/AsynchFuncX Example.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Asynchronous FuncX Example\n",
+    "This example creates an asynchronous FuncX Client and shows up to receive results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df' # Public tutorial endpoint\n",
+    "\n",
+    "from funcx.sdk.client import FuncXClient\n",
+    "fxc = FuncXClient(asynchronous=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'915c017a-3db3-44f8-bb79-46b4503db216'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def sum1(nums):\n",
+    "    import time\n",
+    "    time.sleep(10)\n",
+    "    return sum(nums)\n",
+    "\n",
+    "func_id = fxc.register_function(sum1)\n",
+    "func_id\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Task pending coro=<FuncXTask.get_result() running at /Users/bengal1/dev/funcx/funcX/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py:21>>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "task = fxc.run([1,2,3,45, 66], function_id=func_id, endpoint_id=tutorial_endpoint)\n",
+    "task\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "117\n"
+     ]
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "await task\n",
+    "print(task.result())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/AsynchFuncX Example.ipynb
+++ b/examples/AsynchFuncX Example.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "logging.getLogger('funcx.sdk.asynchronous.polling_task').setLevel(logging.DEBUG)\n",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -10,11 +22,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df' # Public tutorial endpoint\n",
+    "\n",
     "\n",
     "from funcx.sdk.client import FuncXClient\n",
     "fxc = FuncXClient(asynchronous=True)\n"
@@ -22,20 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'915c017a-3db3-44f8-bb79-46b4503db216'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def sum1(nums):\n",
     "    import time\n",
@@ -48,20 +50,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Task pending coro=<FuncXTask.get_result() running at /Users/bengal1/dev/funcx/funcX/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py:21>>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "task = fxc.run([1,2,3,45, 66], function_id=func_id, endpoint_id=tutorial_endpoint)\n",
     "task\n"
@@ -69,21 +60,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "117\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import asyncio\n",
     "await task\n",
     "print(task.result())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def boom(l):\n",
+    "    return l/0\n",
+    "\n",
+    "func_id2 = fxc.register_function(boom)\n",
+    "func_id2\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task2 = fxc.run([1,2,3,45, 66], function_id=func_id2, endpoint_id=tutorial_endpoint)\n",
+    "await task2\n",
+    "print(task2.result())\n",
+    "\n",
+    "\n"
    ]
   },
   {

--- a/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
@@ -1,0 +1,28 @@
+import asyncio
+
+
+class FuncXTask:
+    """
+    Represents a submitted funcX task with an asychio wrapper
+    """
+    def __init__(self, task_id):
+        """
+        Parameters
+        ----------
+        task_id : uuid str
+            The uuid of the funcX task this instance is shadowing
+        """
+        self.future = asyncio.Future()
+        self.task_id = task_id
+
+    def __str__(self):
+        return "FuncX Task ID " + self.task_id
+
+    async def get_result(self):
+        """
+        Coroutine to wait on the funcX task to complete and then return the result
+        :return:
+            result : Any
+        """
+        await self.future
+        return self.future.result()

--- a/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
@@ -1,7 +1,7 @@
 import asyncio
 
 
-class FuncXTask:
+class FuncXTask(asyncio.Future):
     """
     Represents a submitted funcX task with an asychio wrapper
     """
@@ -12,7 +12,7 @@ class FuncXTask:
         task_id : uuid str
             The uuid of the funcX task this instance is shadowing
         """
-        self.future = asyncio.Future()
+        super(FuncXTask, self).__init__()
         self.task_id = task_id
 
     def __str__(self):
@@ -24,5 +24,5 @@ class FuncXTask:
         :return:
             result : Any
         """
-        await self.future
-        return self.future.result()
+        await self
+        return self.result()

--- a/funcx_sdk/funcx/sdk/asynchronous/polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/polling_task.py
@@ -1,0 +1,83 @@
+import asyncio
+from asyncio import AbstractEventLoop
+import time
+from funcx.sdk.asynchronous.funcx_task import FuncXTask
+
+
+class PollingTask:
+    """
+    Launches an asycnhio task for polling unresolved funcX tasks. Uses a work queue to
+    record unresolved funcX Tasks. Pulls one off and attempts to retrieve the result.
+    If this attempt fails, put the value back on the queue for later attempt.
+    Use a throttle to insure we DDOS the web service
+    """
+    async def poll_funcx(self, queue: asyncio.Queue):
+        while True:
+            t = await queue.get()
+            try:
+                result = self.fxc.get_result(t.task_id)
+                t.future.set_result(result)
+            except Exception as eek:
+                print(eek)
+                await self.throttle()
+                await queue.put(t)
+
+    def __init__(self, fxc, loop: AbstractEventLoop, period: float,
+                 max_calls_per_period: int, cooldown: float):
+        """
+
+        :param fxc: FuncXClient
+            Client instance for requesting results
+        :param loop: AbstractEventLoop
+            Asynchio event loop to manage asynchronous calls
+        :param period: float
+            Number of seconds over which the throttle is observing number of calls
+        :param max_calls_per_period: int
+            Maximum number of calls to be allowed during a period
+        :param cooldown: float
+            Number of seconds to sleep if we hit the max number of calls during the
+            period
+        """
+        self.fxc = fxc
+        self.loop = loop
+        self.running_tasks = asyncio.Queue()
+        self.poll_task = self.loop.create_task(self.poll_funcx(self.running_tasks))
+
+        if hasattr(time, 'monotonic'):
+            self._now = time.monotonic
+        else:
+            self._now = time.time
+
+        self.last_reset = self._now()
+        self.num_calls = 0
+        self.max_calls_per_period = max_calls_per_period
+        self.cooldown = cooldown
+        self.period = period
+
+    async def throttle(self):
+        """
+        Apply a throttle to calls made to the funcX web service. Don't allow more than
+        max_calls_period during a specific period. If this threshold is breached we
+        sleep for cooldown seconds
+        :return:
+        """
+        elapsed = self._now() - self.last_reset
+        period_remaining = self.period - elapsed
+
+        if period_remaining <= 0:
+            self.num_calls = 0
+            self.last_reset = self._now()
+
+        self.num_calls += 1
+
+        if self.num_calls > self.max_calls_per_period:
+            print("Cool rown")
+            await asyncio.sleep(self.cooldown)
+
+    def put(self, task: FuncXTask):
+        """
+        Add a funcX task to the poller
+        :param task: FuncXTask
+            Task to be added
+        """
+        self.running_tasks.put_nowait(task)

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import logging
@@ -7,6 +8,8 @@ from globus_sdk import AuthClient
 
 from fair_research_login import NativeClient, JSONTokenStorage
 
+from funcx.sdk.asynchronous.funcx_task import FuncXTask
+from funcx.sdk.asynchronous.polling_task import PollingTask
 from funcx.sdk.search import SearchHelper, FunctionSearchResults
 
 from funcx.serialize import FuncXSerializer
@@ -47,6 +50,8 @@ class FuncXClient(FuncXErrorHandlingClient):
                  force_login=False, fx_authorizer=None, search_authorizer=None,
                  openid_authorizer=None,
                  funcx_service_address='https://api.funcx.org/v1',
+                 asynchronous=False,
+                 loop=None,
                  **kwargs):
         """ Initialize the client
 
@@ -74,6 +79,16 @@ class FuncXClient(FuncXErrorHandlingClient):
         funcx_service_address: str
         The address of the funcX web service to communicate with.
         Default: https://api.funcx.org/v1
+
+        asynchronous: bool
+        Should the API use asynchronous interactions with the web service? Currently
+        only impacts the run method
+        Default: False
+
+        loop: AbstractEventLoop
+        If asynchronous mode is requested, then you can provide an optional event loop
+        instance. If None, then we will access asyncio.get_event_loop()
+        Default: None
 
         Keyword arguments are the same as for BaseClient.
         """
@@ -117,6 +132,17 @@ class FuncXClient(FuncXErrorHandlingClient):
         user_info = authclient.oauth2_userinfo()
         self.searcher = SearchHelper(authorizer=search_authorizer, owner_uuid=user_info['sub'])
         self.funcx_service_address = funcx_service_address
+
+        self.asynchronous = asynchronous
+        if asynchronous:
+            self.loop = loop if loop else asyncio.get_event_loop()
+
+            # Start up an asynchronous polling loop in the background
+            # Throttle to ten calls per second
+            self.polling_task = PollingTask(self, self.loop, period=1.0,
+                                            max_calls_per_period=10, cooldown=5.0)
+        else:
+            self.loop = None
 
     def version_check(self):
         """Check this client version meets the service's minimum supported version.
@@ -283,7 +309,11 @@ class FuncXClient(FuncXErrorHandlingClient):
         Returns
         -------
         task_id : str
-        UUID string that identifies the task
+        UUID string that identifies the task if asynchronous is False
+
+        funcX Task: asyncio.Task
+        A future that will eventually resolve into the function's result if
+        asynchronous is True
         """
         assert endpoint_id is not None, "endpoint_id key-word argument must be set"
         assert function_id is not None, "function_id key-word argument must be set"
@@ -292,18 +322,17 @@ class FuncXClient(FuncXErrorHandlingClient):
         batch.add(*args, endpoint_id=endpoint_id, function_id=function_id, **kwargs)
         r = self.batch_run(batch)
 
-        """
-        Create a future to deal with the result
-        funcx_future = FuncXFuture(self, task_id, async_poll)
+        # If we are presenting the asynch interface then return a asynchio task
+        # that will eventually resolve to the result
+        if self.asynchronous:
+            funcx_task = FuncXTask(r[0])
+            asyncio_task = self.loop.create_task(funcx_task.get_result())
 
-        if not asynchronous:
-            return funcx_future.result()
-
-        # Return the result
-        return funcx_future
-        """
-
-        return r[0]
+            # Add it to the list of tasks to be polled
+            self.polling_task.put(funcx_task)
+            return asyncio_task
+        else:
+            return r[0]
 
     def create_batch(self):
         """

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -139,8 +139,7 @@ class FuncXClient(FuncXErrorHandlingClient):
 
             # Start up an asynchronous polling loop in the background
             # Throttle to ten calls per second
-            self.polling_task = PollingTask(self, self.loop, period=1.0,
-                                            max_calls_per_period=10, cooldown=5.0)
+            self.polling_task = PollingTask(self, self.loop)
         else:
             self.loop = None
 

--- a/funcx_sdk/requirements.txt
+++ b/funcx_sdk/requirements.txt
@@ -8,3 +8,4 @@ dill>=0.3
 typer>=0.3.0
 pyzmq>=19.0.0,<20.0.0
 parsl>=1.1.0a0
+retry


### PR DESCRIPTION
# Problem
The funcX `get_result` method requires polling to wait for results to show up. This results in more boilerplate code than desirable and extra work to function in an asynchronous application.

# Approach
Add a new constructor argument, `asynchronous` which starts up an Asyncio based polling task. 

The `run` method in this mode adds the funcX task UUID to a queue and returns a Asyncio task to the caller. The polling task will ask for results for items in the queue and resolve the funcX task's future when the results are available.

# How to test
Created a notebook that demonstrates the api. It takes advantage of the Asyncio event loop already present in Jupyter notebook.