### PR TITLE
remove assert min_pods == 0 in strategy for k8s provider

### DIFF
--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -105,11 +105,11 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.image = image
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
-        
+
         # Kubernetes provider doesn't really know which pods by container to initialize
         # so best to set init_blocks to 0
         assert init_blocks == 0
-        
+
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
         self.max_cpu = max_cpu

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -105,6 +105,11 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.image = image
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
+        
+        # Kubernetes provider doesn't really know which pods by container to scale
+        # so best to set init_blocks to 0
+        assert init_blocks == 0
+        
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
         self.max_cpu = max_cpu

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -106,7 +106,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
         
-        # Kubernetes provider doesn't really know which pods by container to scale
+        # Kubernetes provider doesn't really know which pods by container to initialize
         # so best to set init_blocks to 0
         assert init_blocks == 0
         

--- a/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
@@ -47,10 +47,6 @@ class KubeSimpleStrategy(BaseStrategy):
         max_pods = self.interchange.config.provider.max_blocks
         min_pods = self.interchange.config.provider.min_blocks
 
-        # Kubernetes provider doesn't really know how to keep track of pods by container
-        # so best to allow it to shut them all down when quiet
-        assert min_pods == 0
-
         # Kubernetes provider only supports one manager in a pod
         managers_per_pod = 1
 


### PR DESCRIPTION
The strategy should allow users to set `min_blocks` to greater than 0, so they can keep at least one container of each type during execution. The more reasonable assertion should be `init_blocks == 0`, because we don't know which pod/container to scale for initialization. 