### PR TITLE
Improve multiple log line descriptions and fix multiple small bugs and typos

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/container_sched.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/container_sched.py
@@ -47,7 +47,7 @@ def naive_scheduler(task_qs, outstanding_task_count, max_workers, old_worker_map
         if len(q_types) > 0:
             while difference > 0:
                 win_q = random.choice(q_types)
-                if q_sizes(win_q) > new_worker_map[win_q]:
+                if q_sizes[win_q] > new_worker_map[win_q]:
                     new_worker_map[win_q] += 1
                     difference -= 1
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -298,7 +298,7 @@ class Manager(object):
                         logger.debug(f"[WORKER_REMOVE] Worker processes: {self.worker_procs}")
 
                 except Exception as e:
-                    logger.warning("[TASK_PULL_THREAD] FUNCX : caught {}".format(e))
+                    logger.exception("[TASK_PULL_THREAD] FUNCX : caught {}".format(e))
 
             # Spin up any new workers according to the worker queue.
             # Returns the total number of containers that have spun up.

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -278,7 +278,7 @@ class Manager(object):
                         task_done_counter += 1
                         task_id = pickle.loads(message)['task_id']
                         task_type = self.task_type_mapping.pop(task_id)
-                        del self.task_status_deltas[task_id]
+                        self.task_status_deltas.pop(task_id, None)
                         logger.debug("Task type: {}".format(task_type))
                         self.outstanding_task_count[task_type] -= 1
                         logger.debug("Got result: Outstanding task counts: {}".format(self.outstanding_task_count))

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -604,8 +604,8 @@ def cli_run():
         logger.exception("Caught error: {}".format(e))
         raise
     else:
-        logger.info("process_worker_pool exiting")
-        print("PROCESS_WORKER_POOL exiting")
+        logger.info("process_worker_pool main event loop exiting normally")
+        print("PROCESS_WORKER_POOL main event loop exiting normally")
 
 
 if __name__ == "__main__":

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -414,8 +414,9 @@ class Manager(object):
                             to_send = [worker_id, pickle.dumps(task['task_id']), task['buffer']]
                             self.funcx_task_socket.send_multipart(to_send)
                             self.worker_map.update_worker_idle(task_type)
-                            logger.debug(f"Set task {task['task_id']} to RUNNING")
-                            self.task_status_deltas[task['task_id']] = TaskStatusCode.RUNNING
+                            if task['task_id'] != pickle.dumps(b"KILL"):
+                                logger.debug(f"Set task {task['task_id']} to RUNNING")
+                                self.task_status_deltas[task['task_id']] = TaskStatusCode.RUNNING
                             logger.debug("Sending complete!")
 
     def _status_report_loop(self, kill_event):

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -390,7 +390,7 @@ class Interchange(object):
             elif isinstance(msg, Heartbeat):
                 logger.debug("Got heartbeat")
             else:
-                logger.info("[TASK_PULL_THREAD] Received task:{}".format(msg))
+                logger.info("[TASK_PULL_THREAD] Received task:{}".format(msg['task_id']))
                 task_type = self.get_container(msg['task_id'].split(";")[1])
                 msg['container'] = task_type
                 if task_type not in self.pending_task_queue:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
@@ -159,7 +159,8 @@ class WorkerMap(object):
                 max_remove = max(0, self.total_worker_type_counts[worker_type] - 1)
                 num_remove = min(num_remove, max_remove)
 
-            logger.debug("[SPIN DOWN] Removing {} workers of type {}".format(num_remove, worker_type))
+            if num_remove > 0:
+                logger.debug("[SPIN DOWN] Removing {} workers of type {}".format(num_remove, worker_type))
             for i in range(num_remove):
                 spin_downs.append(worker_type)
         return spin_downs


### PR DESCRIPTION
This PR improves multiple logging lines and fixes a typo of the bracket. 

It also fixes multiple bugs relevant to `task_status_delta`.
1. `task_status_delta` could be empty after it is sent to the interchange---`del` may raise keyError in this case.
2. `task_status_delta` includes reports of killer tasks, which would also be reported to interchange. 