### PR TITLE
Better exceptions at endpoint when registering

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -393,10 +393,11 @@ def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
         raise Exception(msg)
 
     # this is a backup error handler in case an endpoint ID is not sent back
-    # from the service
+    # from the service or a bad ID is sent back
     if 'endpoint_id' not in reg_info:
-        msg = "Endpoint ID was not included in the service's registration response."
-        raise Exception(msg)
+        raise Exception("Endpoint ID was not included in the service's registration response.")
+    elif not isinstance(reg_info['endpoint_id'], str):
+        raise Exception("Endpoint ID sent by the service was not a string.")
 
     with open(os.path.join(endpoint_dir, 'endpoint.json'), 'w+') as fp:
         json.dump(reg_info, fp)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -384,10 +384,19 @@ def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
                                               endpoint_uuid,
                                               endpoint_version=ENDPOINT_VERSION)
 
+    # the service will send back a message with a 'status'='error'
+    # property if something went wrong
     if 'status' in reg_info and reg_info['status'] == 'error':
         msg = "Endpoint registration failed."
         if 'reason' in reg_info:
             msg = "Endpoint registration failed. Service fail reason provided: {}".format(reg_info['reason'])
+        logger.critical(msg)
+        raise Exception(msg)
+
+    # this is a backup error handler in case an endpoint ID is not sent back
+    # from the service
+    if not 'endpoint_id' in reg_info:
+        msg = "Endpoint ID was not included in the service's registration response."
         logger.critical(msg)
         raise Exception(msg)
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -18,7 +18,6 @@ import psutil
 import requests
 import texttable as tt
 import typer
-from retry import retry
 
 import funcx
 from funcx.utils.errors import *
@@ -250,7 +249,7 @@ def start_endpoint(
 
     funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address)
 
-    # If pervious registration info exists, use that
+    # If previous registration info exists, use that
     if os.path.exists(endpoint_json):
         with open(endpoint_json, 'r') as fp:
             logger.debug("Connection info loaded from prior registration record")
@@ -260,6 +259,14 @@ def start_endpoint(
         endpoint_uuid = str(uuid.uuid4())
 
     logger.info(f"Starting endpoint with uuid: {endpoint_uuid}")
+
+    # attempt the first registration before the daemon is started
+    try:
+        reg_info = handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir)
+    except Exception as e:
+        # the registration handler already logs this as a critical error, so
+        # no additional logging is needed here
+        return
 
     # Create a daemon context
     # If we are running a full detached daemon then we will send the output to
@@ -295,18 +302,10 @@ def start_endpoint(
 
     with context:
         while True:
-            # Register the endpoint
-            logger.info("Registering endpoint")
-            if State.FUNCX_CONFIG.get('broker_test', False) is True:
-                logger.warning("**************** BROKER State.DEBUG MODE *******************")
-                reg_info = register_with_hub(endpoint_uuid,
-                                             endpoint_dir,
-                                             State.FUNCX_CONFIG['broker_address'],
-                                             State.FUNCX_CONFIG['redis_host'])
-            else:
-                reg_info = register_endpoint(funcx_client, name, endpoint_uuid, endpoint_dir)
-
-            logger.info("Endpoint registered with UUID: {}".format(reg_info['endpoint_id']))
+            if reg_info is None:
+                # this registration will continue retrying every 5s until the
+                # endpoint is successfully registered with the service
+                reg_info = handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir, True)
 
             # Configure the parameters for the interchange
             optionals = {}
@@ -326,10 +325,39 @@ def start_endpoint(
 
             logger.critical("Interchange terminated.")
             time.sleep(10)
+            # clear reg_info so that registration will happen again in the next loop iteration
+            reg_info = None
+
+
+def handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir, retry=False):
+    # Register the endpoint
+    logger.info("Registering endpoint")
+    if State.FUNCX_CONFIG.get('broker_test', False) is True:
+        logger.warning("**************** BROKER State.DEBUG MODE *******************")
+        reg_info = register_with_hub(endpoint_uuid,
+                                        endpoint_dir,
+                                        State.FUNCX_CONFIG['broker_address'],
+                                        State.FUNCX_CONFIG['redis_host'])
+    elif retry:
+
+        # this will retry the registration process every 5s until it succeeds
+        while True:
+            try:
+                reg_info = register_endpoint(funcx_client, name, endpoint_uuid, endpoint_dir)
+                break
+            except Exception as e:
+                logger.warning("Retrying registration in 5s")
+                time.sleep(5)
+                continue
+    else:
+        reg_info = register_endpoint(funcx_client, name, endpoint_uuid, endpoint_dir)
+
+    logger.info("Endpoint registered with UUID: {}".format(reg_info['endpoint_id']))
+
+    return reg_info
 
 
 # Avoid a race condition when starting the endpoint alongside the web service
-@retry(delay=5, logger=logging.getLogger('funcx'))
 def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
     """Register the endpoint and return the registration info.
 
@@ -355,6 +383,13 @@ def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
     reg_info = funcx_client.register_endpoint(endpoint_name,
                                               endpoint_uuid,
                                               endpoint_version=ENDPOINT_VERSION)
+
+    if 'status' in reg_info and reg_info['status'] == 'error':
+        msg = "Endpoint registration failed."
+        if 'reason' in reg_info:
+            msg = "Endpoint registration failed. Service fail reason provided: {}".format(reg_info['reason'])
+        logger.critical(msg)
+        raise Exception(msg)
 
     with open(os.path.join(endpoint_dir, 'endpoint.json'), 'w+') as fp:
         json.dump(reg_info, fp)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -264,8 +264,7 @@ def start_endpoint(
     try:
         reg_info = handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir)
     except Exception as e:
-        # the registration handler already logs this as a critical error, so
-        # no additional logging is needed here
+        logger.critical(e)
         return
 
     # Create a daemon context
@@ -291,7 +290,7 @@ def start_endpoint(
                                        )
     except Exception as e:
         logger.critical("Caught exception while trying to setup endpoint context dirs")
-        logger.critical("Exception : ", e)
+        logger.critical("Exception: ", e)
 
     check_pidfile(context.pidfile.path, "funcx-endpoint", name)
 
@@ -335,9 +334,9 @@ def handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir, r
     if State.FUNCX_CONFIG.get('broker_test', False) is True:
         logger.warning("**************** BROKER State.DEBUG MODE *******************")
         reg_info = register_with_hub(endpoint_uuid,
-                                        endpoint_dir,
-                                        State.FUNCX_CONFIG['broker_address'],
-                                        State.FUNCX_CONFIG['redis_host'])
+                                     endpoint_dir,
+                                     State.FUNCX_CONFIG['broker_address'],
+                                     State.FUNCX_CONFIG['redis_host'])
     elif retry:
 
         # this will retry the registration process every 5s until it succeeds
@@ -346,6 +345,7 @@ def handle_start_registration(funcx_client, name, endpoint_uuid, endpoint_dir, r
                 reg_info = register_endpoint(funcx_client, name, endpoint_uuid, endpoint_dir)
                 break
             except Exception as e:
+                logger.critical(e)
                 logger.warning("Retrying registration in 5s")
                 time.sleep(5)
                 continue
@@ -390,14 +390,12 @@ def register_endpoint(funcx_client, endpoint_name, endpoint_uuid, endpoint_dir):
         msg = "Endpoint registration failed."
         if 'reason' in reg_info:
             msg = "Endpoint registration failed. Service fail reason provided: {}".format(reg_info['reason'])
-        logger.critical(msg)
         raise Exception(msg)
 
     # this is a backup error handler in case an endpoint ID is not sent back
     # from the service
-    if not 'endpoint_id' in reg_info:
+    if 'endpoint_id' not in reg_info:
         msg = "Endpoint ID was not included in the service's registration response."
-        logger.critical(msg)
         raise Exception(msg)
 
     with open(os.path.join(endpoint_dir, 'endpoint.json'), 'w+') as fp:


### PR DESCRIPTION
This is meant to fix: https://github.com/funcx-faas/funcX/issues/251

My idea here is that there should be an initial endpoint registration attempt before the daemon is started. If this initial registration fails, the `funcx-endpoint start` fails, and no daemon is started. This is also useful because rather than having the stdout and stderr of this registration vanishing to the daemon's output files, it gets printed for the user when running the `start` command.

So, for example, trying this:
```
funcx-endpoint start --endpoint-uuid abc test
```
would result in:
![endpoint-start-fail](https://user-images.githubusercontent.com/22580625/104827179-d0c98e80-5820-11eb-8aa4-945f0be6d263.png)

A couple things I'm still thinking about:
- I got rid of the previous use of `retry`, because I think it is better to manually run a retry loop in the case where the daemon is running on its own. In this case, it is obviously better to constantly retry registration since there is nothing else to be done otherwise.
- Previously, registration would be done again if the interchange fails, from my understanding. Is this actually necessary, or can a new interchange be started using the original registration?
- It seems if I do `funcx-endpoint stop test1` then I need to do `funcx-endpoint start test1` twice in order for it to be reachable from the SDK. I still need to investigate whether or not I introduced that issue in this PR
