### PR TITLE
add improvements to pidfile check

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -307,6 +307,9 @@ def start_endpoint(
 
     pid_path = os.path.join(endpoint_dir, 'daemon.pid')
 
+    # if the pidfile exists, we should return early because we don't
+    # want to attempt to create a new daemon when one is already
+    # potentially running with the existing pidfile
     if check_pidfile(pid_path, endpoint_name=name, log=True)['exists']:
         return
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -68,10 +68,10 @@ def check_pidfile(filepath, match_name='funcx-endpoint', endpoint_name='', log=F
 
     match_name : str
        Name of the process to check for if pidfile exists
-    
+
     endpoint_name : str
         endpoint name for debugging purposes
-    
+
     log : bool
         whether or not to log instructions for user if pidfile exists
 
@@ -89,7 +89,7 @@ def check_pidfile(filepath, match_name='funcx-endpoint', endpoint_name='', log=F
         proc = psutil.Process(older_pid)
         if proc.name() == match_name:
             # this is the only case where the endpoint is active.
-            # Ff the process name does not match or no process exists,
+            # If the process name does not match or no process exists,
             # it means the endpoint has been terminated without proper cleanup
             proc_found = True
 
@@ -109,7 +109,7 @@ def check_pidfile(filepath, match_name='funcx-endpoint', endpoint_name='', log=F
             "exists": 1,
             "active": 1,
         }
-    
+
     return {
         "exists": 1,
         "active": 0,


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcX/issues/327

I've improved the check_pidfile function such that it can serve many purposes and indicate whether the pidfile `exists`, then whether the associated process is `active`.

This PR also prevents running another `funcx-endpoint start ...` from messing with an existing daemon, because it stops this function call from overwriting stdout and stderr files of an endpoint that is already running