### PR TITLE
Better exceptions when task sent to bad endpoint

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -13,7 +13,7 @@ from funcx.serialize import FuncXSerializer
 # from funcx.sdk.utils.futures import FuncXFuture
 from funcx.sdk.utils import throttling
 from funcx.sdk.utils.batch import Batch
-from funcx.utils.errors import MalformedResponse, VersionMismatch, SerializationError, HTTPError
+from funcx.utils.errors import FailureResponse, VersionMismatch, SerializationError, HTTPError
 
 try:
     from funcx_endpoint.version import VERSION as ENDPOINT_VERSION
@@ -342,7 +342,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         if r.http_status != 200:
             raise HTTPError(r)
         if r.get("status", "Failed") == "Failed":
-            raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
+            raise FailureResponse(r.get("reason", "Unknown reason for failure"))
         return r['task_uuids']
 
     def map_run(self, *args, endpoint_id=None, function_id=None, asynchronous=False, **kwargs):
@@ -388,7 +388,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
             raise Exception(r)
 
         if r.get("status", "Failed") == "Failed":
-            raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
+            raise FailureResponse(r.get("reason", "Unknown reason for failure"))
         return r['task_uuids']
 
     def register_endpoint(self, name, endpoint_uuid, metadata=None, endpoint_version=None):

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -341,7 +341,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         r = self.post(servable_path, json_body=data)
         if r.http_status != 200:
             raise HTTPError(r)
-        if r.get("status", "Failure") == "Failure":
+        if r.get("status", "Failed") == "Failed":
             raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
         return r['task_uuids']
 
@@ -387,7 +387,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         if r.http_status != 200:
             raise Exception(r)
 
-        if r.get("status", "Failure") == "Failure":
+        if r.get("status", "Failed") == "Failed":
             raise MalformedResponse("FuncX Request failed: {}".format(r.get("reason", "Unknown")))
         return r['task_uuids']
 

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -36,7 +36,18 @@ class MalformedResponse(FuncxError):
         self.response = response
 
     def __repr__(self):
-        return "FuncX remote service responded with Malformed Response {}".format(self.response)
+        return "FuncX remote service responded with Malformed Response: {}".format(self.response)
+
+
+class FailureResponse(FuncxError):
+    """ FuncX remote service responded with a failure
+    """
+
+    def __init__(self, response):
+        self.response = response
+
+    def __repr__(self):
+        return "FuncX remote service failed to fulfill request: {}".format(self.response)
 
 
 class VersionMismatch(FuncxError):


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcX/issues/329

It looks like there was a fix on `main` that just didn't get put on this branch, although the message from just this is still a bit misleading (I think `MalformedResponse` was meant to imply that the user's request was malformed, but its confusing and seems more like it is implying the response from the service was malformed):
![malformed-1](https://user-images.githubusercontent.com/22580625/106085921-bcba4280-60e6-11eb-88cc-325b666a372e.png)

I think a new error class would be more fitting and informative. Here is with my added changes:

![malformed-2](https://user-images.githubusercontent.com/22580625/106086910-9a292900-60e8-11eb-9b37-62d2fce54227.png)

Edit: If we want more specific error names for these cases like `InvalidEndpoint`, we would need more specific error messages from the service that contain some sort of error code, which I think would be overkill for now at least
