### PR TITLE
Add service address CLI arg and an example

### DIFF
--- a/funcx_sdk/funcx/tests/README.rst
+++ b/funcx_sdk/funcx/tests/README.rst
@@ -18,3 +18,10 @@ How to run the tests
 
    >>> pytest . --endpoint='<ENDPOINT_UUID>'
 
+   set the funcX service address with:
+
+   >>> pytest . --service-address='<FUNCX_SERVICE_ADDRESS>'
+
+   Example:
+
+   >>> pytest . --endpoint='4b116d3c-1703-4f8f-9f6f-39921e5864df' --service-address='https://api.funcx.org/v1'

--- a/funcx_sdk/funcx/tests/conftest.py
+++ b/funcx_sdk/funcx/tests/conftest.py
@@ -32,10 +32,19 @@ def pytest_addoption(parser):
         help="Specify an active endpoint UUID"
     )
 
+    parser.addoption(
+        '--service-address',
+        action='store',
+        metavar='service-address',
+        nargs=1,
+        default=[config['funcx_service_address']],
+        help="Specify a funcX service address"
+    )
+
 
 @pytest.fixture
-def fxc():
-    fxc = FuncXClient(funcx_service_address=config['funcx_service_address'])
+def fxc(pytestconfig):
+    fxc = FuncXClient(funcx_service_address=pytestconfig.getoption('--service-address')[0])
     return fxc
 
 


### PR DESCRIPTION
Making the pytest suite a little more useable with a `--service-address` arg.