### PR TITLE
Add exception checks for invalid endpoint/function tests

### DIFF
--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
@@ -6,10 +6,12 @@ def hello_world() -> str:
     return 'Hello World'
 
 
-@pytest.mark.skip('Pending github funcx issue: #329')
 def test_invalid_endpoint(fxc, endpoint):
     fn_uuid = fxc.register_function(hello_world, endpoint, description='Hello')
 
-    # Assert here that an InvalidEndpoint exception is raised
-    fxc.run(endpoint_id='BAD-BAD-BAD-BAD',
-            function_id=fn_uuid)
+    # TODO: currently a generic Exception is raised when the service reports an error,
+    # but eventually the service should send an error code and the SDK should raise
+    # a corresponding Exception type, such as InvalidEndpoint
+    with pytest.raises(Exception, match="Endpoint BAD-BAD-BAD-BAD could not be resolved"):
+        fxc.run(endpoint_id='BAD-BAD-BAD-BAD',
+                function_id=fn_uuid)

--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
@@ -7,8 +7,10 @@ def hello_world() -> str:
     return 'Hello World'
 
 
-@pytest.mark.skip('Pending github funcx issue: #329')
 def test_invalid_function(fxc, endpoint):
-    # Assert here that an InvalidFunction exception is raised
-    fxc.run(endpoint_id=endpoint,
-            function_id='BAD-BAD-BAD-BAD')
+    # TODO: currently a generic Exception is raised when the service reports an error,
+    # but eventually the service should send an error code and the SDK should raise
+    # a corresponding Exception type, such as InvalidEndpoint
+    with pytest.raises(Exception, match="Function BAD-BAD-BAD-BAD could not be resolved"):
+        fxc.run(endpoint_id=endpoint,
+                function_id='BAD-BAD-BAD-BAD')


### PR DESCRIPTION
This will work with the error messages produced in the service by: https://github.com/funcx-faas/funcx-web-service/pull/201 (We should merge this service PR first)

For now we should just check that a useful error message is produced. Later we can ensure that the correct Exception type is being raised as well.