### PR TITLE
Refactor service response errors

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -22,7 +22,6 @@ import zmq
 
 import funcx_endpoint
 from funcx.utils.errors import *
-from funcx.utils.handle_service_response import handle_response_errors
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.executors.high_throughput import global_config as funcx_default_config
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
@@ -237,10 +236,6 @@ class EndpointManager:
         reg_info = funcx_client.register_endpoint(self.name,
                                                   endpoint_uuid,
                                                   endpoint_version=funcx_endpoint.__version__)
-
-        # the service will send back a message with a 'status'='error'
-        # property if something went wrong
-        handle_response_errors(reg_info)
 
         # this is a backup error handler in case an endpoint ID is not sent back
         # from the service or a bad ID is sent back

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -22,6 +22,7 @@ import zmq
 
 import funcx_endpoint
 from funcx.utils.errors import *
+from funcx.utils.handle_service_response import handle_response_errors
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.executors.high_throughput import global_config as funcx_default_config
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
@@ -239,11 +240,7 @@ class EndpointManager:
 
         # the service will send back a message with a 'status'='error'
         # property if something went wrong
-        if 'status' in reg_info and reg_info['status'] == 'error':
-            msg = "Endpoint registration failed."
-            if 'reason' in reg_info:
-                msg = "Endpoint registration failed. Service fail reason provided: {}".format(reg_info['reason'])
-            raise Exception(msg)
+        handle_response_errors(reg_info)
 
         # this is a backup error handler in case an endpoint ID is not sent back
         # from the service or a bad ID is sent back

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -192,19 +192,6 @@ class TestStart:
                                             keys_dir='mock_keys_dir',
                                             **mock_optionals)
 
-    def test_register_endpoint_status_error(self, mocker):
-        mock_client = mocker.patch("funcx_endpoint.endpoint.endpoint_manager.FuncXClient")
-        mock_client.return_value.register_endpoint.return_value = {'status': 'error',
-                                                                   'reason': 'unknown'}
-
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
-        config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
-
-        manager.configure_endpoint("mock_endpoint", None)
-        with pytest.raises(Exception, match='Endpoint registration failed. Service fail reason provided: unknown'):
-            manager.register_endpoint(mock_client(), 'mock_endpoint_uuid', config_dir)
-
     def test_register_endpoint_no_endpoint_id(self, mocker):
         mock_client = mocker.patch("funcx_endpoint.endpoint.endpoint_manager.FuncXClient")
         mock_client.return_value.register_endpoint.return_value = {'status': 'okay'}

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -236,7 +236,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
                 logger.warning("We have an exception : {}".format(task['exception']))
                 task['exception'].reraise()
 
-    def get_batch_result(self, task_id_list):
+    def get_batch_status(self, task_id_list):
         """ Request status for a batch of task_ids
         """
         assert isinstance(task_id_list, list), "get_batch_status expects a list of task ids"

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -408,7 +408,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
         Returns
         -------
         A dict
-            {'endopoint_id' : <>,
+            {'endpoint_id' : <>,
              'address' : <>,
              'client_ports': <>}
         """

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -14,6 +14,7 @@ from funcx.serialize import FuncXSerializer
 from funcx.sdk.utils import throttling
 from funcx.sdk.utils.batch import Batch
 from funcx.utils.errors import FailureResponse, VersionMismatch, SerializationError, HTTPError
+from funcx.utils.handle_service_response import handle_response_errors
 
 try:
     from funcx_endpoint.version import VERSION as ENDPOINT_VERSION
@@ -342,7 +343,10 @@ class FuncXClient(throttling.ThrottledBaseClient):
         if r.http_status != 200:
             raise HTTPError(r)
         if r.get("status", "Failed") == "Failed":
-            raise FailureResponse(r.get("reason", "Unknown reason for failure"))
+            if 'data' in r:
+                handle_response_errors(r.data)
+            else:
+                raise FailureResponse(r.get("reason", "Unknown reason for failure"))
         return r['task_uuids']
 
     def map_run(self, *args, endpoint_id=None, function_id=None, asynchronous=False, **kwargs):
@@ -388,7 +392,10 @@ class FuncXClient(throttling.ThrottledBaseClient):
             raise Exception(r)
 
         if r.get("status", "Failed") == "Failed":
-            raise FailureResponse(r.get("reason", "Unknown reason for failure"))
+            if 'data' in r:
+                handle_response_errors(r.data)
+            else:
+                raise FailureResponse(r.get("reason", "Unknown reason for failure"))
         return r['task_uuids']
 
     def register_endpoint(self, name, endpoint_uuid, metadata=None, endpoint_version=None):

--- a/funcx_sdk/funcx/sdk/error_handling_client.py
+++ b/funcx_sdk/funcx/sdk/error_handling_client.py
@@ -1,0 +1,50 @@
+from globus_sdk import GlobusAPIError
+
+from funcx.sdk.utils.throttling import ThrottledBaseClient
+from funcx.utils.handle_service_response import handle_response_errors
+from funcx.utils.errors import HTTPError
+
+
+class FuncXErrorHandlingClient(ThrottledBaseClient):
+    """Class which handles errors from GET, POST, and DELETE requests before proceeding
+    """
+
+    def get(self, path, **kwargs):
+        try:
+            r = ThrottledBaseClient.get(self, path, **kwargs)
+        except GlobusAPIError as e:
+            # this error has a raw_json property which we can use to create our
+            # own custom error
+            handle_response_errors(e.raw_json)
+            # the above error handler should raise an error, but the GlobusAPIError
+            # is a fallback in case there is no raw_json property
+            raise e
+
+        if r.http_status != 200:
+            raise HTTPError(r)
+
+        return r
+
+    def post(self, path, **kwargs):
+        try:
+            r = ThrottledBaseClient.post(self, path, **kwargs)
+        except GlobusAPIError as e:
+            handle_response_errors(e.raw_json)
+            raise e
+
+        if r.http_status != 200:
+            raise HTTPError(r)
+
+        return r
+
+    def delete(self, path, **kwargs):
+        try:
+            r = ThrottledBaseClient.delete(self, path, **kwargs)
+        except GlobusAPIError as e:
+            handle_response_errors(e.raw_json)
+            raise e
+
+        if r.http_status != 200:
+            raise HTTPError(r)
+
+        return r

--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
@@ -1,4 +1,5 @@
 from funcx.sdk.client import FuncXClient
+from funcx.utils.response_errors import EndpointNotFound
 import pytest
 
 
@@ -6,10 +7,9 @@ def hello_world() -> str:
     return 'Hello World'
 
 
-@pytest.mark.skip('Pending github funcx issue: #329')
 def test_invalid_endpoint(fxc, endpoint):
     fn_uuid = fxc.register_function(hello_world, endpoint, description='Hello')
 
-    # Assert here that an InvalidEndpoint exception is raised
-    fxc.run(endpoint_id='BAD-BAD-BAD-BAD',
-            function_id=fn_uuid)
+    with pytest.raises(EndpointNotFound, match="Endpoint BAD-BAD-BAD-BAD could not be resolved"):
+        fxc.run(endpoint_id='BAD-BAD-BAD-BAD',
+                function_id=fn_uuid)

--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
@@ -1,14 +1,10 @@
 from funcx.sdk.client import FuncXClient
+from funcx.utils.response_errors import FunctionNotFound
 import pytest
 import time
 
 
-def hello_world() -> str:
-    return 'Hello World'
-
-
-@pytest.mark.skip('Pending github funcx issue: #329')
 def test_invalid_function(fxc, endpoint):
-    # Assert here that an InvalidFunction exception is raised
-    fxc.run(endpoint_id=endpoint,
-            function_id='BAD-BAD-BAD-BAD')
+    with pytest.raises(FunctionNotFound, match="Function BAD-BAD-BAD-BAD could not be resolved"):
+        fxc.run(endpoint_id=endpoint,
+                function_id='BAD-BAD-BAD-BAD')

--- a/funcx_sdk/funcx/utils/handle_service_response.py
+++ b/funcx_sdk/funcx/utils/handle_service_response.py
@@ -1,19 +1,8 @@
-import inspect
-import funcx.utils.response_errors as response_errors
+from funcx.utils.response_errors import FuncxResponseError
 
 def handle_response_errors(res_data):
-    if 'status' in res_data and res_data['status'] == 'Failed':
-        if 'code' in res_data and res_data['code'] != 0 and 'error_args' in res_data:
-            res_error_code = res_data['code']
-            error_types = inspect.getmembers(response_errors, inspect.isclass)
-            for error_type in error_types:
-                error_class = error_type[1]
-                if issubclass(error_class, response_errors.FuncxResponseError) and res_error_code == error_class.code:
-                    raise error_class(*res_data['error_args'])
-        
-        if 'reason' in res_data:
-            raise Exception(f"The web service responded with a failure - {res_data['reason']}")
-        else:
-            raise Exception("The web service failed for an unknown reason")
+    error = FuncxResponseError.unpack(res_data)
+    if error is not None:
+        raise error
 
     return

--- a/funcx_sdk/funcx/utils/handle_service_response.py
+++ b/funcx_sdk/funcx/utils/handle_service_response.py
@@ -1,0 +1,19 @@
+import inspect
+import funcx.utils.response_errors as response_errors
+
+def handle_response_errors(res_data):
+    if 'status' in res_data and res_data['status'] == 'Failed':
+        if 'code' in res_data and res_data['code'] != 0 and 'error_args' in res_data:
+            res_error_code = res_data['code']
+            error_types = inspect.getmembers(response_errors, inspect.isclass)
+            for error_type in error_types:
+                error_class = error_type[1]
+                if issubclass(error_class, response_errors.FuncxResponseError) and res_error_code == error_class.code:
+                    raise error_class(*res_data['error_args'])
+        
+        if 'reason' in res_data:
+            raise Exception(f"The web service responded with a failure - {res_data['reason']}")
+        else:
+            raise Exception("The web service failed for an unknown reason")
+
+    return

--- a/funcx_sdk/funcx/utils/handle_service_response.py
+++ b/funcx_sdk/funcx/utils/handle_service_response.py
@@ -2,6 +2,16 @@ from funcx.utils.response_errors import FuncxResponseError
 
 
 def handle_response_errors(res_data):
+    """Handle a JSON service response and raise the proper exception if the service
+    responded with an error. This helper does nothing if the service did not respond
+    with an error, but raises the corresponding FuncxResponseError if the service did
+    send back a particular error.
+
+    Parameters
+    ----------
+    res_data : dict
+        The JSON data sent from the service
+    """
     error = FuncxResponseError.unpack(res_data)
     if error is not None:
         raise error

--- a/funcx_sdk/funcx/utils/handle_service_response.py
+++ b/funcx_sdk/funcx/utils/handle_service_response.py
@@ -1,5 +1,6 @@
 from funcx.utils.response_errors import FuncxResponseError
 
+
 def handle_response_errors(res_data):
     error = FuncxResponseError.unpack(res_data)
     if error is not None:

--- a/funcx_sdk/funcx/utils/response_errors.py
+++ b/funcx_sdk/funcx/utils/response_errors.py
@@ -1,0 +1,78 @@
+class FuncxResponseError(Exception):
+    """ Base class for all web service response exceptions
+    """
+    code = 0
+
+    def __init__(self, reason):
+        self.error_args = [reason]
+        self.reason = reason
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return self.reason
+
+
+class UserNotFound(FuncxResponseError):
+    """ User not found exception
+    """
+    code = 1
+
+    def __init__(self, reason):
+        self.error_args = [reason]
+        self.reason = reason
+
+
+class FunctionNotFound(FuncxResponseError):
+    """ Function could not be resolved from the database
+    """
+    code = 2
+
+    def __init__(self, uuid):
+        self.error_args = [uuid]
+        self.reason = "Function {} could not be resolved".format(uuid)
+        self.uuid = uuid
+
+
+class EndpointNotFound(FuncxResponseError):
+    """ Endpoint could not be resolved from the database
+    """
+    code = 3
+
+    def __init__(self, uuid):
+        self.error_args = [uuid]
+        self.reason = "Endpoint {} could not be resolved".format(uuid)
+        self.uuid = uuid
+
+
+class FunctionNotPermitted(FuncxResponseError):
+    """ Function not permitted on endpoint
+    """
+    code = 4
+
+    def __init__(self, function_uuid, endpoint_uuid):
+        self.error_args = [function_uuid, endpoint_uuid]
+        self.reason = "Function {} not permitted on endpoint {}".format(function_uuid, endpoint_uuid)
+        self.function_uuid = function_uuid
+        self.endpoint_uuid = endpoint_uuid
+
+
+class ForwarderRegistrationError(FuncxResponseError):
+    """ Registering the endpoint with the forwarder has failed
+    """
+    code = 5
+
+    def __init__(self, forwarder_reason):
+        self.error_args = [forwarder_reason]
+        self.reason = "Endpoint registration with forwarder failed - {}".format(forwarder_reason)
+
+
+class RequestKeyError(FuncxResponseError):
+    """ User request JSON KeyError exception
+    """
+    code = 6
+
+    def __init__(self, key_error_reason):
+        self.error_args = [key_error_reason]
+        self.reason = "Missing key in JSON request - {}".format(key_error_reason)

--- a/funcx_sdk/funcx/utils/response_errors.py
+++ b/funcx_sdk/funcx/utils/response_errors.py
@@ -15,14 +15,15 @@ class ResponseErrorCode(int, Enum):
     FUNCTION_ACCESS_FORBIDDEN = 8
     ENDPOINT_ACCESS_FORBIDDEN = 9
     FUNCTION_NOT_PERMITTED = 10
-    FORWARDER_REGISTRATION_ERROR = 11
-    FORWARDER_CONTACT_ERROR = 12
-    ENDPOINT_STATS_ERROR = 13
-    LIVENESS_STATS_ERROR = 14
-    REQUEST_KEY_ERROR = 15
-    REQUEST_MALFORMED = 16
-    INTERNAL_ERROR = 17
-    ENDPOINT_OUTDATED = 18
+    ENDPOINT_ALREADY_REGISTERED = 11
+    FORWARDER_REGISTRATION_ERROR = 12
+    FORWARDER_CONTACT_ERROR = 13
+    ENDPOINT_STATS_ERROR = 14
+    LIVENESS_STATS_ERROR = 15
+    REQUEST_KEY_ERROR = 16
+    REQUEST_MALFORMED = 17
+    INTERNAL_ERROR = 18
+    ENDPOINT_OUTDATED = 19
 
 
 # a collection of the HTTP status error codes that the service would make use of
@@ -84,6 +85,8 @@ class FuncxResponseError(Exception, ABC):
                         error_class = UserNotFound
                     elif res_error_code is ResponseErrorCode.FUNCTION_NOT_FOUND:
                         error_class = FunctionNotFound
+                    elif res_error_code is ResponseErrorCode.ENDPOINT_ALREADY_REGISTERED:
+                        error_class = EndpointAlreadyRegistered
                     elif res_error_code is ResponseErrorCode.ENDPOINT_NOT_FOUND:
                         error_class = EndpointNotFound
                     elif res_error_code is ResponseErrorCode.CONTAINER_NOT_FOUND:
@@ -256,6 +259,18 @@ class FunctionNotPermitted(FuncxResponseError):
         self.reason = f"Function {function_uuid} not permitted on endpoint {endpoint_uuid}"
         self.function_uuid = function_uuid
         self.endpoint_uuid = endpoint_uuid
+
+
+class EndpointAlreadyRegistered(FuncxResponseError):
+    """ Endpoint with specified uuid already registered by a different user
+    """
+    code = ResponseErrorCode.ENDPOINT_ALREADY_REGISTERED
+    http_status_code = HTTPStatusCode.BAD_REQUEST
+
+    def __init__(self, uuid):
+        self.error_args = [uuid]
+        self.reason = f"Endpoint {uuid} was already registered by a different user"
+        self.uuid = uuid
 
 
 class ForwarderRegistrationError(FuncxResponseError):

--- a/funcx_sdk/funcx/utils/response_errors.py
+++ b/funcx_sdk/funcx/utils/response_errors.py
@@ -1,7 +1,24 @@
-class FuncxResponseError(Exception):
+from abc import ABC
+from enum import Enum
+
+# IMPORTANT: new error codes can be added, but existing error codes must not be changed once published.
+# changing existing error codes will cause problems with users that have older SDK versions
+class ResponseErrorCode(int, Enum):
+    UNKNOWN_ERROR = 0
+    USER_NOT_FOUND = 1
+    FUNCTION_NOT_FOUND = 2
+    ENDPOINT_NOT_FOUND = 3
+    FUNCTION_NOT_PERMITTED = 4
+    FORWARDER_REGISTRATION_ERROR = 5
+    REQUEST_KEY_ERROR = 6
+
+
+class FuncxResponseError(Exception, ABC):
     """ Base class for all web service response exceptions
     """
-    code = 0
+    @property
+    def code(self):
+        raise NotImplementedError()
 
     def __init__(self, reason):
         self.error_args = [reason]
@@ -12,12 +29,56 @@ class FuncxResponseError(Exception):
 
     def __repr__(self):
         return self.reason
+    
+    def pack(self):
+        return {'status': 'Failed',
+                'code': int(self.code),
+                'error_args': self.error_args,
+                'reason': self.reason}
+    
+    @classmethod
+    def unpack(cls, res_data):
+        if 'status' in res_data and res_data['status'] == 'Failed':
+            if 'code' in res_data and res_data['code'] != 0 and 'error_args' in res_data:
+                try:
+                    # if the response error code is not recognized here because the
+                    # user is not using the latest SDK version, an exception will occur here
+                    # which we will pass in order to give the user a generic exception below
+                    res_error_code = ResponseErrorCode(res_data['code'])
+                    error_class = None
+                    if res_error_code is ResponseErrorCode.USER_NOT_FOUND:
+                        error_class = UserNotFound
+                    elif res_error_code is ResponseErrorCode.FUNCTION_NOT_FOUND:
+                        error_class = FunctionNotFound
+                    elif res_error_code is ResponseErrorCode.ENDPOINT_NOT_FOUND:
+                        error_class = EndpointNotFound
+                    elif res_error_code is ResponseErrorCode.FUNCTION_NOT_PERMITTED:
+                        error_class = FunctionNotPermitted
+                    elif res_error_code is ResponseErrorCode.FORWARDER_REGISTRATION_ERROR:
+                        error_class = ForwarderRegistrationError
+                    elif res_error_code is ResponseErrorCode.REQUEST_KEY_ERROR:
+                        error_class = RequestKeyError
+
+                    if error_class is not None:
+                        return error_class(*res_data['error_args'])
+                except Exception:
+                    pass
+            
+            # this is useful for older SDK versions to be compatible with a newer web
+            # service: if the SDK does not recognize an error code, it creates a generic
+            # exception with the human-readable error reason that was sent
+            if 'reason' in res_data:
+                return Exception(f"The web service responded with a failure - {res_data['reason']}")
+            
+            return Exception("The web service failed for an unknown reason")
+        
+        return None
 
 
 class UserNotFound(FuncxResponseError):
     """ User not found exception
     """
-    code = 1
+    code = ResponseErrorCode.USER_NOT_FOUND
 
     def __init__(self, reason):
         self.error_args = [reason]
@@ -27,7 +88,7 @@ class UserNotFound(FuncxResponseError):
 class FunctionNotFound(FuncxResponseError):
     """ Function could not be resolved from the database
     """
-    code = 2
+    code = ResponseErrorCode.FUNCTION_NOT_FOUND
 
     def __init__(self, uuid):
         self.error_args = [uuid]
@@ -38,7 +99,7 @@ class FunctionNotFound(FuncxResponseError):
 class EndpointNotFound(FuncxResponseError):
     """ Endpoint could not be resolved from the database
     """
-    code = 3
+    code = ResponseErrorCode.ENDPOINT_NOT_FOUND
 
     def __init__(self, uuid):
         self.error_args = [uuid]
@@ -49,7 +110,7 @@ class EndpointNotFound(FuncxResponseError):
 class FunctionNotPermitted(FuncxResponseError):
     """ Function not permitted on endpoint
     """
-    code = 4
+    code = ResponseErrorCode.FUNCTION_NOT_PERMITTED
 
     def __init__(self, function_uuid, endpoint_uuid):
         self.error_args = [function_uuid, endpoint_uuid]
@@ -61,7 +122,7 @@ class FunctionNotPermitted(FuncxResponseError):
 class ForwarderRegistrationError(FuncxResponseError):
     """ Registering the endpoint with the forwarder has failed
     """
-    code = 5
+    code = ResponseErrorCode.FORWARDER_REGISTRATION_ERROR
 
     def __init__(self, forwarder_reason):
         self.error_args = [forwarder_reason]
@@ -71,7 +132,7 @@ class ForwarderRegistrationError(FuncxResponseError):
 class RequestKeyError(FuncxResponseError):
     """ User request JSON KeyError exception
     """
-    code = 6
+    code = ResponseErrorCode.REQUEST_KEY_ERROR
 
     def __init__(self, key_error_reason):
         self.error_args = [key_error_reason]

--- a/funcx_sdk/funcx/utils/response_errors.py
+++ b/funcx_sdk/funcx/utils/response_errors.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from enum import Enum
 
+
 # IMPORTANT: new error codes can be added, but existing error codes must not be changed once published.
 # changing existing error codes will cause problems with users that have older SDK versions
 class ResponseErrorCode(int, Enum):
@@ -48,7 +49,7 @@ class FuncxResponseError(Exception, ABC):
     @property
     def code(self):
         raise NotImplementedError()
-    
+
     @property
     def http_status_code(self):
         raise NotImplementedError()
@@ -62,13 +63,13 @@ class FuncxResponseError(Exception, ABC):
 
     def __repr__(self):
         return self.reason
-    
+
     def pack(self):
         return {'status': 'Failed',
                 'code': int(self.code),
                 'error_args': self.error_args,
                 'reason': self.reason}
-    
+
     @classmethod
     def unpack(cls, res_data):
         if 'status' in res_data and res_data['status'] == 'Failed':
@@ -95,10 +96,10 @@ class FuncxResponseError(Exception, ABC):
                         error_class = TaskNotFound
                     elif res_error_code is ResponseErrorCode.AUTH_GROUP_NOT_FOUND:
                         error_class = AuthGroupNotFound
-                    elif res_error_code is ResponseErrorCode.UNAUTHORIZED_FUNCTION_ACCESS:
-                        error_class = UnauthorizedFunctionAccess
-                    elif res_error_code is ResponseErrorCode.UNAUTHORIZED_ENDPOINT_ACCESS:
-                        error_class = UnauthorizedEndpointAccess
+                    elif res_error_code is ResponseErrorCode.FUNCTION_ACCESS_FORBIDDEN:
+                        error_class = FunctionAccessForbidden
+                    elif res_error_code is ResponseErrorCode.ENDPOINT_ACCESS_FORBIDDEN:
+                        error_class = EndpointAccessForbidden
                     elif res_error_code is ResponseErrorCode.FUNCTION_NOT_PERMITTED:
                         error_class = FunctionNotPermitted
                     elif res_error_code is ResponseErrorCode.FORWARDER_REGISTRATION_ERROR:
@@ -122,15 +123,15 @@ class FuncxResponseError(Exception, ABC):
                         return error_class(*res_data['error_args'])
                 except Exception:
                     pass
-            
+
             # this is useful for older SDK versions to be compatible with a newer web
             # service: if the SDK does not recognize an error code, it creates a generic
             # exception with the human-readable error reason that was sent
             if 'reason' in res_data:
                 return Exception(f"The web service responded with a failure - {res_data['reason']}")
-            
+
             return Exception("The web service failed for an unknown reason")
-        
+
         return None
 
 


### PR DESCRIPTION
This PR goes along with: https://github.com/funcx-faas/funcx-web-service/pull/204

The idea here is that all response-related errors that the web service might have can live on the funcx sdk side. Each error type will have:
- A unique identifier `code`
- An error reason string `reason`
- An `error_args` value that is an array of args passed into the exception

When a request to the funcx web service comes back with an error message such as this:

```python
{'status': 'Failed',
 'code': 2,
 'error_args': ["uuid-1234"],
 'reason': 'Function uuid-1234 could not be resolved'}
```

the error handler will know to throw the error with code 2 (`FunctionNotFound` for example), and it will know which arguments to pass into the exception, because the service provided them.

If for some reason an error code is not recognized or some data is not provided, there are fallbacks of just doing normal Exceptions rather than the custom error type.

So far I've only implemented an example of how this could work for `register_endpoint`.