### PR TITLE
remove funcx from test-requirements in forwarder_rearch_1 branch

### DIFF
--- a/funcx_sdk/test-requirements.txt
+++ b/funcx_sdk/test-requirements.txt
@@ -1,4 +1,3 @@
-funcx
 bottle
 cherrypy
 nbsphinx


### PR DESCRIPTION
Not sure why there is a `funcx` requirement in `funcx_sdk/test-requirements.txt`. Removing that.

Note this PR is merging to `forwarder_rearch_1` branch, rather than `main`