### PR TITLE
373 remove tornado

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -48,7 +48,6 @@ BUFFER_THRESHOLD = 1024 * 1024
 ITEM_THRESHOLD = 1024
 
 
-#class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
     """Executor designed for cluster-scale
 

--- a/funcx_endpoint/test-requirements.txt
+++ b/funcx_endpoint/test-requirements.txt
@@ -1,7 +1,5 @@
-bottle
-cherrypy
-nbsphinx
-Flask>=1.0.2
-sphinx_rtd_theme
-redis
-flake8==3.8.0
+pytest>=5.2
+coverage>=5.2
+codecov==2.1.8
+pytest-mock==3.2.0
+flake8>=3.8

--- a/funcx_sdk/funcx/sdk/search.py
+++ b/funcx_sdk/funcx/sdk/search.py
@@ -237,9 +237,5 @@ class FunctionSearchResults(list):
 
         # if we also saved the source code of the function, we could interactively
         # generate a cell to edit the searched function
-        #ipython = get_ipython()
-        #if ipython:
-        #    ipython.set_next_input(func_source)
-        #else:
         # TODO: Strip the ipython bits and remove entirely
         print(func_source)

--- a/funcx_sdk/test-requirements.txt
+++ b/funcx_sdk/test-requirements.txt
@@ -1,9 +1,3 @@
-bottle
-cherrypy
-nbsphinx
-Flask>=1.0.2
-sphinx_rtd_theme
-redis
 flake8==3.8.0
 numpy
 pytest


### PR DESCRIPTION
Fixes #373  by clearing out unused dependencies in the test-requirements files
Also fixed the flake8 errors that are preventing a clean build