### PR TITLE
Fixed endpoint_id consistency in interchange.log and endpoint.json

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -210,6 +210,11 @@ class EndpointInterchange(object):
         self.executors = {}
         for executor in self.config.executors:
             logger.info(f"Initializing executor: {executor.label}")
+            if not executor.endpoint_id:
+                executor.endpoint_id = self.endpoint_id
+            else:
+                if not executor.endpoint_id == self.endpoint_id:
+                    raise Exception('InconsistentEndpointId')
             self.executors[executor.label] = executor
             if hasattr(executor, 'passthrough') and executor.passthrough is True:
                 executor.start(results_passthrough=self.results_passthrough)

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -249,7 +249,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.managed = managed
         self.blocks = []
         self.cores_per_worker = cores_per_worker
-        self.endpoint_id = endpoint_id if endpoint_id else str(uuid.uuid4())
+        self.endpoint_id = endpoint_id
         self._task_counter = 0
         self.address = address
         self.worker_ports = worker_ports

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -1,0 +1,61 @@
+from funcx_endpoint.endpoint.endpoint_manager import EndpointManager
+from funcx_endpoint.endpoint.interchange import EndpointInterchange
+from importlib.machinery import SourceFileLoader
+import os
+import logging
+import sys
+import shutil
+import pytest
+import json
+from pytest import fixture
+from unittest.mock import ANY
+
+logger = logging.getLogger('mock_funcx')
+
+
+class TestStart:
+
+    @pytest.fixture(autouse=True)
+    def test_setup_teardown(self):
+        # Code that will run before your test, for example:
+
+        funcx_dir = f'{os.getcwd()}'
+        config_dir = os.path.join(funcx_dir, "mock_endpoint")
+        assert not os.path.exists(config_dir)
+        # A test function will be run at this point
+        yield
+        # Code that will run after your test, for example:
+        shutil.rmtree(config_dir)
+
+    def test_endpoint_id(self, mocker):
+        mock_taskqueue = mocker.patch('funcx_endpoint.endpoint.interchange.TaskQueue')
+        mock_taskqueue.return_value.put.return_value = None
+
+        mock_client = mocker.patch("funcx_endpoint.endpoint.interchange.FuncXClient")
+
+        mock_queue = mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing.Queue")
+
+        manager = EndpointManager(logger)
+        manager.funcx_dir = f'{os.getcwd()}'
+        config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
+        keys_dir = os.path.join(config_dir, 'certificates')
+
+        optionals = {}
+        optionals['client_address'] = '127.0.0.1'
+        optionals['client_ports'] = (8080, 8081, 8082)
+        optionals['logdir'] = './mock_endpoint'
+
+        manager.configure_endpoint("mock_endpoint", None)
+        endpoint_config = SourceFileLoader('config',
+                                           os.path.join(config_dir, 'config.py')).load_module()
+
+        for executor in endpoint_config.config.executors:
+            executor.passthrough = False
+
+        ic = EndpointInterchange(endpoint_config.config,
+                                 endpoint_id='mock_endpoint_id',
+                                 keys_dir=keys_dir,
+                                 **optionals)
+
+        for executor in ic.executors.values():
+            assert executor.endpoint_id == 'mock_endpoint_id'

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -32,8 +32,10 @@ class TestStart:
         mock_taskqueue.return_value.put.return_value = None
 
         mock_client = mocker.patch("funcx_endpoint.endpoint.interchange.FuncXClient")
+        mock_client.return_value = None
 
         mock_queue = mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing.Queue")
+        mock_queue.return_value = None
 
         manager = EndpointManager(logger)
         manager.funcx_dir = f'{os.getcwd()}'


### PR DESCRIPTION
The issue was reported as Issue #369: after starting an endpoint, the `endpoint_id` in `endpoint.json` and the `Endpoint id` in `HighThroughputExecutor/interchange.log` are different. This is due to the fact that when an executor is constructed, if the variable `endpoint_id` is not given, a random string will be assigned to executor's member variable.

To fix the issue, when an executor are constructed in `interchange.py`, we assign the interchange's `endpoint_id`, which is also the endpoint's `endpoint_id`, to the executor.

To test the fix, we created a new unit test, and checked after an interchange's construction, if its `endpoint_id` is consistent with its executors' `endpoint_id`.