### PR TITLE
Use new Task object consistently on funcx-manager and fix batch tests after merging to main

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -420,9 +420,9 @@ class Manager(object):
                             to_send = [worker_id, pickle.dumps(task.task_id), pickle.dumps(task.container_id), task.pack()]
                             self.funcx_task_socket.send_multipart(to_send)
                             self.worker_map.update_worker_idle(task_type)
-                            if task['task_id'] != pickle.dumps(b"KILL"):
-                                logger.debug(f"Set task {task['task_id']} to RUNNING")
-                                self.task_status_deltas[task['task_id']] = TaskStatusCode.RUNNING
+                            if task.task_id != pickle.dumps(b"KILL"):
+                                logger.debug(f"Set task {task.task_id} to RUNNING")
+                                self.task_status_deltas[task.task_id] = TaskStatusCode.RUNNING
                             logger.debug("Sending complete!")
 
     def _status_report_loop(self, kill_event):

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -238,7 +238,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
     def get_batch_result(self, task_id_list):
         """ Request status for a batch of task_ids
         """
-        assert isinstance(task_id_list, list), "get_batch_status expects a list of task ids"
+        assert isinstance(task_id_list, list), "get_batch_result expects a list of task ids"
 
         pending_task_ids = [t for t in task_id_list if t not in self.func_table]
 
@@ -260,7 +260,7 @@ class FuncXClient(throttling.ThrottledBaseClient):
                 except KeyError:
                     logger.debug("Task {} info was not available in the batch status")
                 except Exception:
-                    logger.exception("Failure while unpacking results fom get_batch_status")
+                    logger.exception("Failure while unpacking results fom get_batch_result")
             else:
                 results[task_id] = self.func_table[task_id]
 

--- a/funcx_sdk/funcx/tests/test_batch.py
+++ b/funcx_sdk/funcx/tests/test_batch.py
@@ -36,7 +36,7 @@ def test_batch(fxc, endpoint):
     print("Got {} tasks_ids ".format(len(task_ids)))
 
     for i in range(10):
-        x = fxc.get_batch_status(task_ids)
+        x = fxc.get_batch_result(task_ids)
         complete_count = sum([1 for t in task_ids if t in x and not x[t].get('pending', False)])
         print("Batch status : {}/{} complete".format(complete_count, len(task_ids)))
         if complete_count == len(task_ids):

--- a/funcx_sdk/funcx/tests/test_performance/test_performance.py
+++ b/funcx_sdk/funcx/tests/test_performance/test_performance.py
@@ -25,8 +25,8 @@ def test_performance(fxc, endpoint, task_count):
     print(f"Time to create batch: {t_batch_create}s")
     print(f"Time to submit batch: {t_batch_submit}s")
     for i in range(10):
-        x = fxc.get_batch_status(task_ids)
-        complete_count = sum([1 for t in task_ids if t in x and x[t].get('pending', False)])
+        x = fxc.get_batch_result(task_ids)
+        complete_count = sum([1 for t in task_ids if t in x and not x[t].get('pending', False)])
         print("Batch status : {}/{} complete".format(complete_count, len(task_ids)))
         if complete_count == len(task_ids):
             print(x)


### PR DESCRIPTION
Current `main` and some funcx tests are broken because:

1. The new `Task` object format is not used consistently on funcx-manager. See issue #377 
2. The API `get_batch_status` is renamed to `get_batch_result` on sdk.

This PR fixes the issues by using `Task` in the correct way and correcting the naming of `get_batch_status` API in tests.
Fixes #377 