### PR TITLE
fix get_batch_result naming

### DIFF
--- a/funcx_endpoint/tests/integration/test_per_func_batch.py
+++ b/funcx_endpoint/tests/integration/test_per_func_batch.py
@@ -38,7 +38,7 @@ print("Time to launch {} tasks: {:8.3f} s".format(task_count * len(func_ids), de
 print("Got {} tasks_ids ".format(len(task_ids)))
 
 for i in range(10):
-    x = fx.get_batch_status(task_ids)
+    x = fx.get_batch_result(task_ids)
     complete_count = sum([1 for t in task_ids if t in x and x[t].get('pending', False)])
     print("Batch status : {}/{} complete".format(complete_count, len(task_ids)))
     if complete_count == len(task_ids):

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -235,7 +235,7 @@ class FuncXClient(FuncXErrorHandlingClient):
                 logger.warning("We have an exception : {}".format(task['exception']))
                 task['exception'].reraise()
 
-    def get_batch_status(self, task_id_list):
+    def get_batch_result(self, task_id_list):
         """ Request status for a batch of task_ids
         """
         assert isinstance(task_id_list, list), "get_batch_result expects a list of task ids"


### PR DESCRIPTION
It looks like the `get_batch_result` method unintentionally got swapped with another name. Unless we wanted `get_batch_status` instead?