### PR TITLE
Modify http status code error handling

### DIFF
--- a/funcx_sdk/funcx/sdk/error_handling_client.py
+++ b/funcx_sdk/funcx/sdk/error_handling_client.py
@@ -20,7 +20,9 @@ class FuncXErrorHandlingClient(ThrottledBaseClient):
             # is a fallback in case there is no raw_json property
             raise e
 
-        if r.http_status != 200:
+        # the Globus API should catch this situation already, so this is
+        # just here as a fallback (should allow 200 and 207 through)
+        if r.http_status >= 400:
             raise HTTPError(r)
 
         return r
@@ -32,7 +34,7 @@ class FuncXErrorHandlingClient(ThrottledBaseClient):
             handle_response_errors(e.raw_json)
             raise e
 
-        if r.http_status != 200:
+        if r.http_status >= 400:
             raise HTTPError(r)
 
         return r
@@ -44,7 +46,7 @@ class FuncXErrorHandlingClient(ThrottledBaseClient):
             handle_response_errors(e.raw_json)
             raise e
 
-        if r.http_status != 200:
+        if r.http_status >= 400:
             raise HTTPError(r)
 
         return r

--- a/funcx_sdk/funcx/utils/response_errors.py
+++ b/funcx_sdk/funcx/utils/response_errors.py
@@ -68,7 +68,8 @@ class FuncxResponseError(Exception, ABC):
         return {'status': 'Failed',
                 'code': int(self.code),
                 'error_args': self.error_args,
-                'reason': self.reason}
+                'reason': self.reason,
+                'http_status_code': int(self.http_status_code)}
 
     @classmethod
     def unpack(cls, res_data):


### PR DESCRIPTION
I would like the `http_status_code` in the packed json error, and also we need to be more lenient on what status code is allowed through in order to accept 207.