### PR TITLE
Fix endpoint registration logging

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -216,7 +216,7 @@ class EndpointManager:
             # the output of a NetworkError exception is huge and unhelpful, so
             # it seems better to just stringify it here and get a concise error
             self.logger.exception(f"Caught exception while attempting endpoint registration: {e}")
-            self.logger.critical("funcx-endpoint is unable to reach the funcX service due a NetworkError \n"
+            self.logger.critical("funcx-endpoint is unable to reach the funcX service due to a NetworkError \n"
                                  "Please make sure that the funcX service address you provided is reachable \n"
                                  "and then attempt restarting the endpoint")
             exit(-1)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -230,9 +230,9 @@ class EndpointManager:
             self.logger.critical("Launching endpoint daemon process with errors noted above")
 
         with context:
-            self.daemon_launch(funcx_client, reg_info, endpoint_uuid, endpoint_dir, keys_dir, endpoint_config)
+            self.daemon_launch(funcx_client, endpoint_uuid, endpoint_dir, keys_dir, endpoint_config, reg_info)
 
-    def daemon_launch(self, funcx_client, reg_info, endpoint_uuid, endpoint_dir, keys_dir, endpoint_config):
+    def daemon_launch(self, funcx_client, endpoint_uuid, endpoint_dir, keys_dir, endpoint_config, reg_info):
         if reg_info is None:
             # Register the endpoint
             self.logger.info("Retrying endpoint registration after initial registration attempt failed")

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -215,12 +215,11 @@ class EndpointManager:
         except NetworkError as e:
             # the output of a NetworkError exception is huge and unhelpful, so
             # it seems better to just stringify it here and get a concise error
-            self.logger.error(f"Caught exception while attempting endpoint registration: {e}")
-            self.logger.critical("Because this was a network error, endpoint registration will be "
-                                 "retried in the new endpoint daemon process. The endpoint will not "
-                                 "work until it is successfully registered. Please make sure that "
-                                 "the FuncX service address you provided is reachable for you, and "
-                                 "restart your endpoint if it is not.")
+            self.logger.exception(f"Caught exception while attempting endpoint registration: {e}")
+            self.logger.critical("funcx-endpoint is unable to reach the funcX service due a NetworkError \n"
+                                 "Please make sure that the funcX service address you provided is reachable \n"
+                                 "and then attempt restarting the endpoint")
+            exit(-1)
         except Exception:
             raise
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -656,6 +656,16 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         # Submit task to queue
         return self.outgoing_q.put(packed_task)
 
+    def _get_block_and_job_ids(self):
+        # Not using self.blocks.keys() and self.blocks.values() simultaneously
+        # The dictionary may be changed during invoking this function
+        # As scale_in and scale_out are invoked in multiple threads
+        block_ids = list(self.blocks.keys())
+        job_ids = []  # types: List[Any]
+        for bid in block_ids:
+            job_ids.append(self.blocks[bid])
+        return block_ids, job_ids
+
     @property
     def connection_info(self):
         """ All connection info necessary for the endpoint to connect back

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -46,9 +46,10 @@ class TestStart:
 
     def test_start(self, mocker):
         mock_client = mocker.patch("funcx_endpoint.endpoint.endpoint_manager.FuncXClient")
-        mock_client.return_value.register_endpoint.return_value = {'endpoint_id': 'abcde12345',
-                                                                   'address': 'localhost',
-                                                                   'client_ports': '8080'}
+        reg_info = {'endpoint_id': 'abcde12345',
+                    'address': 'localhost',
+                    'client_ports': '8080'}
+        mock_client.return_value.register_endpoint.return_value = reg_info
 
         mock_zmq_create = mocker.patch("zmq.auth.create_certificates",
                                        return_value=("public/key/file", None))
@@ -84,7 +85,7 @@ class TestStart:
         mock_zmq_create.assert_called_with(os.path.join(config_dir, "certificates"), "endpoint")
         mock_zmq_load.assert_called_with("public/key/file")
 
-        mock_daemon.assert_called_with(mock_client(), '123456', config_dir, os.path.join(config_dir, "certificates"), endpoint_config)
+        mock_daemon.assert_called_with(mock_client(), '123456', config_dir, os.path.join(config_dir, "certificates"), endpoint_config, reg_info)
 
         mock_context.assert_called_with(working_directory=config_dir,
                                         umask=0o002,
@@ -145,7 +146,7 @@ class TestStart:
         manager.configure_endpoint("mock_endpoint", None)
         endpoint_config = SourceFileLoader('config',
                                            os.path.join(config_dir, 'config.py')).load_module()
-        manager.daemon_launch(mock_client(), 'mock_endpoint_uuid', config_dir, 'mock_keys_dir', endpoint_config)
+        manager.daemon_launch(mock_client(), 'mock_endpoint_uuid', config_dir, 'mock_keys_dir', endpoint_config, None)
 
         mock_register_endpoint.assert_called_with(mock_client(), 'mock_endpoint_uuid', config_dir)
 
@@ -185,7 +186,7 @@ class TestStart:
         manager.configure_endpoint("mock_endpoint", None)
         endpoint_config = SourceFileLoader('config',
                                            os.path.join(config_dir, 'config.py')).load_module()
-        manager.daemon_launch(mock_client(), 'mock_endpoint_uuid', config_dir, 'mock_keys_dir', endpoint_config)
+        manager.daemon_launch(mock_client(), 'mock_endpoint_uuid', config_dir, 'mock_keys_dir', endpoint_config, None)
 
         mock_interchange.assert_called_with(endpoint_config.config,
                                             endpoint_id='mock_endpoint_uuid',


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcX/issues/383

Moved endpoint registration logging outside of the daemon process. I'm not exactly sure what purpose it serves to keep retrying endpoint registration, especially without first informing the user.

There used to be a `while True` loop around the daemon code, meaning if the interchange were to terminate, endpoint registration would happen again and the interchange would start again. However, this loop has since been removed. I believe this is because `EndpointInterchange.start` is designed to never terminate, and this would also mean endpoint registration would only ever happen when the daemon starts up. Does this sound correct?