### PR TITLE
Updating to funcx==0.0.6a2 and funcx-endpoint==0.0.6a4

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.6a3"
+__version__ = "0.0.6a4"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.6a1"
+__version__ = "0.0.6a2"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
This PR contains only the version bump. 