### PR TITLE
Updating pyzmq version string to >= 22.0.0

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.6a4"
+__version__ = "0.0.6a5"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.0.6a1
+funcx>=0.0.6a5
 pyzmq>=22.0.0
 retry

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -8,5 +8,5 @@ fair_research_login
 dill>=0.3
 typer>=0.3.0
 funcx>=0.0.6a1
-pyzmq>=19.0.0,<20.0.0
+pyzmq>=22.0.0
 retry

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.6a2"
+__version__ = "0.0.6a5"
 VERSION = __version__
 
 # app name to send as part of SDK requests

--- a/funcx_sdk/requirements.txt
+++ b/funcx_sdk/requirements.txt
@@ -6,5 +6,5 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-pyzmq>=19.0.0,<20.0.0
+pyzmq>=22.0.0
 parsl>=1.1.0a0


### PR DESCRIPTION
Fixes issue described in #393. This PR also updates the version strings for funcx and funcx-endpoint to `0.0.6a5`.