### PR TITLE
Dill prioritized over pickle for code serialization.

### DIFF
--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -45,9 +45,29 @@ class pickle_base64(fxPicker_shared):
         return data
 
 
-class code_pickle(fxPicker_shared):
+class code_dill(fxPicker_shared):
+    """ We use dill to serialize the function object
+    """
 
     _identifier = '02\n'
+    _for_code = True
+
+    def __init__(self):
+        super().__init__()
+
+    def serialize(self, data):
+        x = codecs.encode(dill.dumps(data), 'base64').decode()
+        return self.identifier + x
+
+    def deserialize(self, payload):
+        chomped = self.chomp(payload)
+        function = dill.loads(codecs.decode(chomped.encode(), 'base64'))
+        return function
+
+
+class code_pickle(fxPicker_shared):
+
+    _identifier = '03\n'
     _for_code = True
 
     def __init__(self):
@@ -61,31 +81,6 @@ class code_pickle(fxPicker_shared):
         chomped = self.chomp(payload)
         data = pickle.loads(codecs.decode(chomped.encode(), 'base64'))
         return data
-
-
-class code_text_dill(fxPicker_shared):
-    """ We use dill to get the source code out of the function object
-    and then exec the function body to load it in. The function object
-    is then returned by name.
-    """
-
-    _identifier = '03\n'
-    _for_code = True
-
-    def __init__(self):
-        super().__init__()
-
-    def serialize(self, data):
-        name = data.__name__
-        body = dill.source.getsource(data)
-        x = codecs.encode(pickle.dumps((name, body)), 'base64').decode()
-        return self.identifier + x
-
-    def deserialize(self, payload):
-        chomped = self.chomp(payload)
-        name, body = pickle.loads(codecs.decode(chomped.encode(), 'base64'))
-        exec(body)
-        return locals()[name]
 
 
 class code_text_inspect(fxPicker_shared):


### PR DESCRIPTION
Serializing methods in the main context is done by reference in pickle
which doesn't work in a remote context. This fault is difficult to detect
without having a clean process to attempt deserialization.