### PR TITLE
Updating funcx-service-address to https://api2.funcx.org/v2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -76,7 +76,7 @@ New Functionality
                ),
            )],
            detach_endpoint=True,
-           funcx_service_address='https://api.funcx.org/v2'
+           funcx_service_address='https://api2.funcx.org/v2'
        )
 
 * The endpoint will now log to `~/.funcx/<ENDPOINT_NAME>/EndpointInterchange.log`.

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -5,7 +5,7 @@ An endpoint is a persistent service launched by the user on their compute system
 and executing functions to their compute system. This could be their laptop, the login node of a campus cluster,
 grid, or supercomputing facility.
 
-The endpoint can be configured to connect to the funcX API web service at `funcx.org <https://api.funcx.org/v2>`_.
+The endpoint can be configured to connect to the funcX API web service at `funcx.org <https://api2.funcx.org/v2>`_.
 Once the endpoint is registered you can invoke functions to be executed on it.
 
 To install the funcX endpoint agent software::

--- a/funcx_endpoint/funcx_endpoint/endpoint/default_config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/default_config.py
@@ -10,7 +10,7 @@ config = Config(
             max_blocks=1,
         ),
     )],
-    funcx_service_address='https://api.funcx.org/v2'
+    funcx_service_address='https://api2.funcx.org/v2'
 )
 
 # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -72,7 +72,7 @@ class Config(RepresentationMixin):
                  # Connection info
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
-                 funcx_service_address='https://api.funcx.org/v2',
+                 funcx_service_address='https://api2.funcx.org/v2',
 
                  # Tuning info
                  worker_mode='no_container',

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -47,7 +47,7 @@ class FuncXClient(FuncXErrorHandlingClient):
     def __init__(self, http_timeout=None, funcx_home=os.path.join('~', '.funcx'),
                  force_login=False, fx_authorizer=None, search_authorizer=None,
                  openid_authorizer=None,
-                 funcx_service_address='https://api.funcx.org/v2',
+                 funcx_service_address='https://api2.funcx.org/v2',
                  **kwargs):
         """
         Initialize the client


### PR DESCRIPTION
Only address fixes.