### PR TITLE
mac fix for htex

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -15,10 +15,7 @@ import threading
 import json
 import daemon
 import collections
-if platform.system() == 'Darwin':
-    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
-else:
-    from multiprocessing import Queue as mpQueue
+from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 
 from parsl.executors.errors import ScalingFailed
 from parsl.version import VERSION as PARSL_VERSION

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -15,7 +15,10 @@ import threading
 import json
 import daemon
 import collections
-import multiprocessing
+if platform.system() == 'Darwin':
+    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
+else:
+    from multiprocessing import Queue as mpQueue
 
 from parsl.executors.errors import ScalingFailed
 from parsl.version import VERSION as PARSL_VERSION
@@ -201,7 +204,7 @@ class EndpointInterchange(object):
         """
         logger.info("Loading endpoint local config")
 
-        self.results_passthrough = multiprocessing.Queue()
+        self.results_passthrough = mpQueue()
         self.executors = {}
         for executor in self.config.executors:
             logger.info(f"Initializing executor: {executor.label}")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -13,12 +13,8 @@ import queue
 import pickle
 import daemon
 import uuid
-import platform
 from multiprocessing import Process
-if platform.system() == 'Darwin':
-    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
-else:
-    from multiprocessing import Queue as mpQueue
+from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 
 from funcx_endpoint.executors.high_throughput.messages import HeartbeatReq, EPStatusReport, Heartbeat
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, Task

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -13,7 +13,12 @@ import queue
 import pickle
 import daemon
 import uuid
-from multiprocessing import Process, Queue
+import platform
+from multiprocessing import Process
+if platform.system() == 'Darwin':
+    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
+else:
+    from multiprocessing import Queue as mpQueue
 
 from funcx_endpoint.executors.high_throughput.messages import HeartbeatReq, EPStatusReport, Heartbeat
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, Task
@@ -367,7 +372,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         Starts the interchange process locally and uses an internal command queue to
         get the worker task and result ports that the interchange has bound to.
         """
-        comm_q = Queue(maxsize=10)
+        comm_q = mpQueue(maxsize=10)
         print(f"Starting local interchange with endpoint id: {self.endpoint_id}")
         self.queue_proc = Process(target=interchange.starter,
                                   args=(comm_q,),

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -23,6 +23,10 @@ from funcx_endpoint.executors.high_throughput.worker_map import WorkerMap
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.serialize import FuncXSerializer
+if platform.system() == 'Darwin':
+    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
+else:
+    from multiprocessing import Queue as mpQueue
 
 from parsl.version import VERSION as PARSL_VERSION
 
@@ -171,7 +175,7 @@ class Manager(object):
         self.outstanding_task_count = {}
         self.task_type_mapping = {}
 
-        self.pending_result_queue = multiprocessing.Queue()
+        self.pending_result_queue = mpQueue()
 
         self.max_queue_size = max_queue_size + self.max_worker_count
         self.tasks_per_round = 1

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -23,10 +23,7 @@ from funcx_endpoint.executors.high_throughput.worker_map import WorkerMap
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.serialize import FuncXSerializer
-if platform.system() == 'Darwin':
-    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
-else:
-    from multiprocessing import Queue as mpQueue
+from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 
 from parsl.version import VERSION as PARSL_VERSION
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
@@ -1,0 +1,5 @@
+import platform
+if platform.system() == 'Darwin':
+    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
+else:
+    from multiprocessing import Queue as mpQueue

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -34,7 +34,7 @@ class TestStart:
         mock_client = mocker.patch("funcx_endpoint.endpoint.interchange.FuncXClient")
         mock_client.return_value = None
 
-        mock_queue = mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing.Queue")
+        mock_queue = mocker.patch("funcx_endpoint.endpoint.interchange.mpQueue")
         mock_queue.return_value = None
 
         manager = EndpointManager(funcx_dir=os.getcwd())


### PR DESCRIPTION
Tested successfully with the following procedure
1. `funcx-endpoint start` on mac, which generated a uuid
2. Executed a function from a laptop with the uuid

We noticed with `conda 4.10.0` it works for `python=3.7`. But for `conda=4.10.0,python=3.8` and `conda=4.10.0,python=3.9`, `funcx-endpoint start pytest` would give error message
```
$ /Users/willr/miniconda3/envs/funcx-mac38/lib/python3.8/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 6 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```