### PR TITLE
Added notification message and exception for starting a non-configured endpoint

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -90,6 +90,16 @@ def start_endpoint(
     endpoint_uuid : str
     """
     endpoint_dir = os.path.join(manager.funcx_dir, name)
+
+    if not os.path.exists(endpoint_dir):
+        msg = (f'\nEndpoint {name} is not configured!\n'
+               '1. Please create a configuration template with:\n'
+               f'\tfuncx-endpoint configure {name}\n'
+               '2. Update the configuration\n'
+               '3. Start the endpoint\n')
+        print(msg)
+        return
+
     endpoint_config = SourceFileLoader('config',
                                        os.path.join(endpoint_dir, manager.funcx_config_file_name)).load_module()
     manager.start_endpoint(name, endpoint_uuid, endpoint_config)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -136,14 +136,6 @@ class EndpointManager:
         endpoint_dir = os.path.join(self.funcx_dir, self.name)
         endpoint_json = os.path.join(endpoint_dir, 'endpoint.json')
 
-        if not os.path.exists(endpoint_dir):
-            print(f'Endpoint {self.name} is not configured!')
-            print('1. Please create a configuration template with:')
-            print(f'    funcx-endpoint configure {self.name}')
-            print('2. Update configuration')
-            print('3. Start the endpoint.')
-            return
-
         # These certs need to be recreated for every registration
         keys_dir = os.path.join(endpoint_dir, 'certificates')
         os.makedirs(keys_dir, exist_ok=True)


### PR DESCRIPTION
For Issue #432
After the fix, when we try to start a non-configured endpoint `test-ep`:
```
$ funcx-endpoint start test-ep

Endpoint test-ep is not configured!
1. Please create a configuration template with:
	funcx-endpoint configure test-ep
2. Update the configuration
3. Start the endpoint

```