### PR TITLE
Made worker_logs appeared at correct location within .funcx dir

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -218,6 +218,8 @@ class EndpointInterchange(object):
                 if not executor.endpoint_id == self.endpoint_id:
                     raise Exception('InconsistentEndpointId')
             self.executors[executor.label] = executor
+            if executor.run_dir is None:
+                executor.run_dir = self.logdir
             if hasattr(executor, 'passthrough') and executor.passthrough is True:
                 executor.start(results_passthrough=self.results_passthrough)
                 # executor._start_remote_interchange_process()

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -217,6 +217,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  poll_period=10,
                  container_image=None,
                  suppress_failure=False,
+                 run_dir=None,
                  endpoint_id=None,
                  managed=True,
                  interchange_local=True,
@@ -259,7 +260,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.heartbeat_period = heartbeat_period
         self.poll_period = poll_period
         self.suppress_failure = suppress_failure
-        self.run_dir = '.'
+        self.run_dir = run_dir
         self.queue_proc = None
         self.interchange_local = interchange_local
         self.passthrough = passthrough


### PR DESCRIPTION
Currently, if we execute `funcx-endpoint start endpoint_name` from a directory, a new directory `HighThroughputExecutor` would be created in the present directory, which includes `worker_logs`, i.e, `HighThroughputExecutor/worker_logs/...`. The behavior is automatic, and the user cannot change it.

After the change, user can use `run_dir` in the config to specify the directory of worker log. If the `run_dir` does not appear in the config file, the logs will be automatically put within the `~/.funcx` under proper endpoint name directory. i.e.,
- If the user has `run_dir='/tmp'` in the config, the log would appear at `/tmp/HighThroughputExecutor/worker_logs`
- If the user does not have `run_dir` in the config, the log would appear at `~/.funcx/endpoint_name/HighThroughputExecutor/worker_logs`

```
config = Config(
    executors=[HighThroughputExecutor(
        provider=LocalProvider(
            init_blocks=1,
            min_blocks=0,
            max_blocks=1,
        ),
        run_dir = '/tmp'
    )],
    funcx_service_address='https://api2.funcx.org/v2'
)
```