### PR TITLE
Updating the version number to 0.2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Documentation: https://funcx.readthedocs.io/en/latest/
 Quickstart
 ==========
 
-funcX is in a beta state with version `0.2.0` currently available on PyPI.
+funcX is in a beta state with version `0.2.2` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 **funcX** is currently in Alpha and early testing releases are available on `PyPI <https://pypi.org/project/funcx/>`_.
 
-The latest version available on PyPI is ``v0.2.0``.
+The latest version available on PyPI is ``v0.2.2``.
 
 You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/funcx/master?filepath=examples%2FTutorial.ipynb>`_
 
@@ -32,7 +32,7 @@ To check if you have network access, run ::
 
   >>> curl https://api2.funcx.org/v2/version
 
-This should return a version string, for example: ``"0.2.0"``
+This should return a version string, for example: ``"0.2.2"``
 
 .. note:: The funcx client is supported on MacOS, Linux, and Windows. The funcx-endpoint
    is only supported on Linux.

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
Updates the version numbers for funcx, funcx-endpoint and the docs.

We still need to update the changelog with info on recent fixes.