### PR TITLE
Updating version requirement to match funcx sdk

### DIFF
--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.0.6a5
+funcx>=0.2.2
 pyzmq>=22.0.0
 retry


### PR DESCRIPTION
Updating `funcx-endpoint` to require `funcx>=0.2.2` 