### PR TITLE
Fix container routing from manager to worker

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -329,16 +329,13 @@ class Manager(object):
 
                 else:
                     logger.warning("YADU: RAW Tasks {}".format(message))
-                    tasks = [Message.unpack(rt) for rt in message]
+                    tasks = [(rt['local_container'], Message.unpack(rt['raw_buffer'])) for rt in message]
 
                     task_recv_counter += len(tasks)
                     logger.debug("[TASK_PULL_THREAD] Got tasks: {} of {}".format([t.task_id for t in tasks],
                                                                                  task_recv_counter))
 
-                    for task in tasks:
-                        # Set default type to raw
-                        task_type = task.container_id
-
+                    for task_type, task in tasks:
                         logger.debug("[TASK DEBUG] Task is of type: {}".format(task_type))
 
                         if task_type not in self.task_queues:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -332,7 +332,7 @@ class Manager(object):
                     tasks = [(rt['local_container'], Message.unpack(rt['raw_buffer'])) for rt in message]
 
                     task_recv_counter += len(tasks)
-                    logger.debug("[TASK_PULL_THREAD] Got tasks: {} of {}".format([t.task_id for t in tasks],
+                    logger.debug("[TASK_PULL_THREAD] Got tasks: {} of {}".format([t[1].task_id for t in tasks],
                                                                                  task_recv_counter))
 
                     for task_type, task in tasks:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -422,6 +422,7 @@ class Interchange(object):
                 # We pass the raw message along
                 self.pending_task_queue[local_container].put({'task_id': msg.task_id,
                                                               'container_id': msg.container_id,
+                                                              'local_container': local_container, 
                                                               'raw_buffer': raw_msg})
                 self.total_pending_task_count += 1
                 self.task_status_deltas[msg.task_id] = TaskStatusCode.WAITING_FOR_NODES
@@ -706,7 +707,7 @@ class Interchange(object):
                 tasks = task_dispatch[manager]
                 if tasks:
                     logger.info("[MAIN] Sending task message {} to manager {}".format(tasks, manager))
-                    serializd_raw_tasks_buffer = pickle.dumps([t['raw_buffer'] for t in tasks])
+                    serializd_raw_tasks_buffer = pickle.dumps(tasks)
                     # self.task_outgoing.send_multipart([manager, b'', pickle.dumps(tasks)])
                     self.task_outgoing.send_multipart([manager, b'', serializd_raw_tasks_buffer])
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -422,7 +422,7 @@ class Interchange(object):
                 # We pass the raw message along
                 self.pending_task_queue[local_container].put({'task_id': msg.task_id,
                                                               'container_id': msg.container_id,
-                                                              'local_container': local_container, 
+                                                              'local_container': local_container,
                                                               'raw_buffer': raw_msg})
                 self.total_pending_task_count += 1
                 self.task_status_deltas[msg.task_id] = TaskStatusCode.WAITING_FOR_NODES


### PR DESCRIPTION
When a task is associated with a container, the current main is routed based on `container_id`, which does not work. A task should be routed based on `local_container` instead.

This PR fixes this error.

