### PR TITLE
Accept an existing endpoint UUID in helm chart

### DIFF
--- a/Dockerfile-endpoint
+++ b/Dockerfile-endpoint
@@ -15,4 +15,5 @@ RUN useradd -m funcx
 RUN mkdir -p /home/funcx/.kube
 USER funcx
 WORKDIR /home/funcx
+COPY helm/boot.sh .
 ENV HOME /home/funcx

--- a/Dockerfile-endpoint
+++ b/Dockerfile-endpoint
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 RUN mkdir /opt/funcx
 RUN pip install kubernetes
 RUN pip install --no-binary :all: --force-reinstall pyzmq

--- a/helm/README.md
+++ b/helm/README.md
@@ -71,4 +71,5 @@ The deployment is configured via values.yaml file.
 | maxBlocks | Maximum number of worker pods to spawn | 100 |
 | maxWorkersPerPod | How many workers will be scheduled in each pod | 1 |
 | detachEndpoint | Run the endpoint as a daemon inside the pod? | true | 
+| endpointUUID   | Specify an existing UUID to this endpoint. Leave blank to generate a new one | |
 

--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -11,4 +11,9 @@ else
   funcx-endpoint start $1 --endpoint-uuid $2
 fi
 
-sleep infinity
+while pgrep funcx-endpoint >/dev/null;
+    do
+        echo "funcx-endpoint process is still alive. Next check in 600s."
+        sleep 600;
+    done
+echo "funcx-endpoint process exited. Restarting endpoint"

--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+mkdir ~/.funcx
+mkdir ~/.funcx/$1
+mkdir ~/.funcx/credentials
+cp /funcx/config/config.py ~/.funcx
+cp /funcx/$1/* ~/.funcx/$1
+cp /funcx/credentials/* ~/.funcx/credentials
+if [ -z "$2" ]; then
+  funcx-endpoint start $1
+else
+  funcx-endpoint start $1 --endpoint-uuid $2
+fi
+
+sleep infinity

--- a/helm/funcx_endpoint/templates/endpoint-deployment.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-deployment.yaml
@@ -17,7 +17,11 @@ spec:
       - name: {{ .Release.Name }}-endpoint
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         command: [ "/bin/bash", "-c", "--" ]
-        args: [ "mkdir ~/.funcx; mkdir ~/.funcx/{{ .Release.Name }}; mkdir ~/.funcx/credentials; cp /funcx/config/config.py ~/.funcx; cp /funcx/{{ .Release.Name }}/* ~/.funcx/{{ .Release.Name }}; cp /funcx/credentials/* ~/.funcx/credentials; funcx-endpoint start {{ .Release.Name }}; sleep infinity"]
+        {{- if .Values.endpointUUID }}
+        args: [ "/home/funcx/boot.sh {{ .Release.Name }} {{ .Values.endpointUUID }}" ]
+        {{- else }}
+        args: [ "/home/funcx/boot.sh {{ .Release.Name }}" ]
+        {{- end }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -28,3 +28,5 @@ maxBlocks: 100
 maxWorkersPerPod: 1
 
 detachEndpoint: true
+
+endpointUUID:


### PR DESCRIPTION
# Problem
Redeploying a kubernetes endpoint causes the endpoint ID to be randomly generated, breaking existing code

Solution to #429 

# Approach
Move the extremely long and awkward command for starting the endpoint to a script, `boot.sh` - this script takes two arguments:
* The endpoint name
* An optional endpoint id

If endpointID is provided then the endpoint script is run with the `--endpoint-uuid` option.

Added a new value to the helm chart `endpointUUID` - if a value is provided, that is the uuid passed into the script. If the value is empty or omitted then the endpoint generates a new uuid