### PR TITLE
Add singularity support to start a worker in singularity container

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -67,15 +67,18 @@ class Config(RepresentationMixin):
 
                  # Scaling mechanics
                  scaling_enabled=True,
+
                  # Connection info
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
                  funcx_service_address='https://api2.funcx.org/v2',
 
-                 # Tuning info
+                 # Container info
                  worker_mode='no_container',
                  scheduler_mode='hard',
                  container_type=None,
+
+                 # Tuning info
                  prefetch_capacity=10,
                  heartbeat_period=30,
                  heartbeat_threshold=120,
@@ -100,10 +103,12 @@ class Config(RepresentationMixin):
         self.worker_port_range = worker_port_range
         self.funcx_service_address = funcx_service_address
 
-        # Tuning info
+        # Container info
         self.worker_mode = worker_mode
         self.scheduler_mode = scheduler_mode
         self.container_type = container_type
+
+        # Tuning info
         self.prefetch_capacity = prefetch_capacity
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -164,6 +164,10 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         Select the mode of operation from no_container, singularity_reuse, singularity_single_use
         Default: singularity_reuse
 
+    container_cmd_options: str
+        Container command strings to be added to associated container command.
+        For example, singularity exec {container_cmd_options}
+
     task_status_queue : queue.Queue
         Queue to pass updates to task statuses back to the forwarder.
 
@@ -200,6 +204,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  worker_mode='no_container',
                  scheduler_mode='hard',
                  container_type=None,
+                 container_cmd_options='',
+
                  # Tuning info
                  prefetch_capacity=10,
 
@@ -239,6 +245,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         # Container specific
         self.scheduler_mode = scheduler_mode
         self.container_type = container_type
+        self.container_cmd_options = container_cmd_options
         # Tuning info
         self.prefetch_capacity = prefetch_capacity
 
@@ -388,7 +395,9 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           # "log_max_bytes": self.log_max_bytes,
                                           # "log_backup_count": self.log_backup_count,
                                           "scheduler_mode": self.scheduler_mode,
+                                          "worker_mode": self.worker_mode,
                                           "container_type": self.container_type,
+                                          "container_cmd_options": self.container_cmd_options,
                                           "funcx_service_address": self.funcx_service_address,
                                           "interchange_address": self.address,
                                           "worker_ports": self.worker_ports,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -305,6 +305,7 @@ class Manager(object):
             # Spin up any new workers according to the worker queue.
             # Returns the total number of containers that have spun up.
             self.worker_procs.update(self.worker_map.spin_up_workers(self.next_worker_q,
+                                                                     mode=self.worker_mode,
                                                                      debug=self.debug,
                                                                      address=self.address,
                                                                      uid=self.uid,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -419,7 +419,7 @@ class Manager(object):
 
                             task = self.task_queues[task_type].get()
                             worker_id = self.worker_map.get_worker(task_type)
-                            logger.info("Sending task {}".format(task, task.__repr__))
+
                             logger.debug("Sending task {} to {}".format(task.task_id, worker_id))
                             # TODO: Some duplication of work could be avoided here
                             to_send = [worker_id, pickle.dumps(task.task_id), pickle.dumps(task.container_id), task.pack()]
@@ -553,7 +553,7 @@ def cli_run():
                         help=("Choose the mode of operation from "
                               "(no_container, singularity_reuse, singularity_single_use"))
     parser.add_argument("--container_cmd_options", default="",
-                                    help=("Container cmd options to add to container startup cmd"))
+                        help=("Container cmd options to add to container startup cmd"))
     parser.add_argument("--scheduler_mode", default="soft",
                         help=("Choose the mode of scheduler "
                               "(hard, soft"))

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -104,10 +104,13 @@ class Interchange(object):
                  max_workers_per_node=None,
                  mem_per_worker=None,
                  prefetch_capacity=None,
+
                  scheduler_mode=None,
                  container_type=None,
-                 funcx_service_address=None,
+                 container_cmd_options='',
                  worker_mode=None,
+
+                 funcx_service_address=None,
                  scaling_enabled=True,
                  #
                  client_address="127.0.0.1",
@@ -154,6 +157,10 @@ class Interchange(object):
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0. Default=1
 
+        container_cmd_options: str
+            Container command strings to be added to associated container command.
+            For example, singularity exec {container_cmd_options}
+
         worker_debug : Bool
              Enables worker debug logging.
 
@@ -187,14 +194,17 @@ class Interchange(object):
         self.mem_per_worker = mem_per_worker
         self.cores_per_worker = cores_per_worker
         self.prefetch_capacity = prefetch_capacity
+
         self.scheduler_mode = scheduler_mode
         self.container_type = container_type
+        self.container_cmd_options = container_cmd_options
+        self.worker_mode = worker_mode
+
         self.log_max_bytes = log_max_bytes
         self.log_backup_count = log_backup_count
         self.working_dir = working_dir
         self.provider = provider
         self.worker_debug = worker_debug
-        self.worker_mode = worker_mode
         self.scaling_enabled = scaling_enabled
         #
 
@@ -281,6 +291,7 @@ class Interchange(object):
                                "--hb_period={heartbeat_period} "
                                "--hb_threshold={heartbeat_threshold} "
                                "--worker_mode={worker_mode} "
+                               "--container_cmd_options='{container_cmd_options}' "
                                "--scheduler_mode={scheduler_mode} "
                                "--log_max_bytes={log_max_bytes} "
                                "--log_backup_count={log_backup_count} "
@@ -339,6 +350,7 @@ class Interchange(object):
                                        heartbeat_threshold=self.heartbeat_threshold,
                                        poll_period=self.poll_period,
                                        worker_mode=self.worker_mode,
+                                       container_cmd_options=self.container_cmd_options,
                                        scheduler_mode=self.scheduler_mode,
                                        logdir=working_dir,
                                        log_max_bytes=self.log_max_bytes,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
@@ -26,6 +26,7 @@ def naive_interchange_task_dispatch(interesting_managers,
     elif scheduler_mode == 'soft':
         task_dispatch, dispatched_tasks = {}, 0
         for loop in ['first', 'second']:
+        # for loop in ['second']:
             task_dispatch, dispatched_tasks = dispatch(interesting_managers,
                                                        pending_task_queue,
                                                        ready_manager_queue,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
@@ -26,7 +26,6 @@ def naive_interchange_task_dispatch(interesting_managers,
     elif scheduler_mode == 'soft':
         task_dispatch, dispatched_tasks = {}, 0
         for loop in ['first', 'second']:
-        # for loop in ['second']:
             task_dispatch, dispatched_tasks = dispatch(interesting_managers,
                                                        pending_task_queue,
                                                        ready_manager_queue,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
@@ -3,8 +3,9 @@ import logging
 import random
 import subprocess
 import time
+import os
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("funcx_manager.worker_map")
 
 
 class WorkerMap(object):
@@ -64,7 +65,15 @@ class WorkerMap(object):
         self.total_worker_type_counts['unused'] += 1
         self.ready_worker_type_counts['unused'] += 1
 
-    def spin_up_workers(self, next_worker_q, mode='no_container', address=None, debug=None, uid=None, logdir=None, worker_port=None):
+    def spin_up_workers(self,
+                        next_worker_q,
+                        mode='no_container',
+                        container_cmd_options='',
+                        address=None,
+                        debug=None,
+                        uid=None,
+                        logdir=None,
+                        worker_port=None):
         """ Helper function to call 'remove' for appropriate workers in 'new_worker_map'.
 
         Parameters
@@ -104,6 +113,7 @@ class WorkerMap(object):
                 try:
                     proc = self.add_worker(worker_id=str(self.worker_id_counter),
                                            worker_type=next_worker_q.pop(0),
+                                           container_cmd_options=container_cmd_options,
                                            mode=mode,
                                            address=address, debug=debug,
                                            uid=uid,
@@ -169,6 +179,7 @@ class WorkerMap(object):
     def add_worker(self, worker_id=str(random.random()),
                    mode='no_container',
                    worker_type='RAW',
+                   container_cmd_options="",
                    walltime=1,
                    address=None,
                    debug=None,
@@ -207,15 +218,22 @@ class WorkerMap(object):
         logger.info("Command string :\n {}".format(cmd))
         logger.info("Mode: {}".format(mode))
         logger.info("Container uri: {}".format(container_uri))
+        logger.info("Container cmd options: {}".format(container_cmd_options))
         logger.info("Worker type: {}".format(worker_type))
 
         if mode == 'no_container':
             modded_cmd = cmd
         elif mode == 'singularity_reuse':
             if container_uri is None:
-                logger.error("Worker mode is singularity, but no container is specified for task")
-                raise NameError("No container is specified")
-            modded_cmd = f'singularity exec -H /home/ {container_uri} {cmd}'
+                logger.warning("No container is specified for singularity mode. "
+                               "Spawning a worker in a raw process instead.")
+                modded_cmd = cmd
+            elif not os.path.exists(container_uri):
+                logger.warning(f"Container uri {container_uri} is not found. "
+                               "Spawning a worker in a raw process instead.")
+                modded_cmd = cmd
+            else:
+                modded_cmd = f'singularity exec {container_cmd_options} {container_uri} {cmd}'
             logger.info("Command string with singularity:\n {}".format(modded_cmd))
         else:
             raise NameError("Invalid container launch mode.")


### PR DESCRIPTION
This PR adds the support of singularity worker to funcx. 

For usability, users can specify `container_cmd_options` in the config, which is added to the command of starting a singularity container. For example, `singularity exec {container_cmd_options} {container_uri} funcx-worker ...`

A typical local singularity config would be like this:

```
from funcx_endpoint.endpoint.utils.config import Config
from funcx_endpoint.executors import HighThroughputExecutor
from parsl.providers import LocalProvider

config = Config(
    executors=[HighThroughputExecutor(
        scheduler_mode='soft',
        worker_mode='singularity_reuse',
        container_type='singularity',
        container_cmd_options="-H /home/$USERS",
        provider=LocalProvider(
            init_blocks=1,
            min_blocks=0,
            max_blocks=1,
        ),
    )],
    funcx_service_address='https://api2.funcx.org/v2'
)

```