### PR TITLE
Cleanup obsolete config opts

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/config.py
@@ -52,7 +52,6 @@ def _get_parsl_config():
             HighThroughputExecutor(
                 label="htex_local",
                 worker_debug=False,
-                poll_period=1,
                 cores_per_worker=1,
                 max_workers=1,
                 provider=LocalProvider(

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -147,7 +147,6 @@ class EndpointInterchange(object):
         self.client_ports = client_ports
         self.suppress_failure = suppress_failure
 
-        self.poll_period = self.config.poll_period
         self.heartbeat_period = self.config.heartbeat_period
         self.heartbeat_threshold = self.config.heartbeat_threshold
         # initalize the last heartbeat time to start the loop
@@ -203,8 +202,8 @@ class EndpointInterchange(object):
         """
         logger.info("Loading endpoint local config")
 
-        working_dir = self.config.working_dir
-        if self.config.working_dir is None:
+        working_dir = self.config.log_dir
+        if self.config.log_dir is None:
             working_dir = "{}/{}".format(self.logdir, "worker_logs")
         logger.info("Setting working_dir: {}".format(working_dir))
 
@@ -369,17 +368,10 @@ class EndpointInterchange(object):
         self._task_puller_thread.join()
         self._command_thread.join()
 
-    def start(self, poll_period=None):
+    def start(self):
         """ Start the Interchange
-
-        Parameters:
-        ----------
-        poll_period : int
-           poll_period in milliseconds
         """
         logger.info("Starting EndpointInterchange")
-        if poll_period is None:
-            poll_period = self.poll_period
 
         start = time.time()
         count = 0
@@ -640,8 +632,6 @@ def cli_run():
                         help="Worker port range as a tuple")
     parser.add_argument("-l", "--logdir", default="./parsl_worker_logs",
                         help="Parsl worker log directory")
-    parser.add_argument("-p", "--poll_period",
-                        help="REQUIRED: poll period used for main thread")
     parser.add_argument("--worker_ports", default=None,
                         help="OPTIONAL, pair of workers ports to listen on, eg --worker_ports=50001,50005")
     parser.add_argument("--suppress_failure", action='store_true',

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -202,11 +202,6 @@ class EndpointInterchange(object):
         """
         logger.info("Loading endpoint local config")
 
-        working_dir = self.config.log_dir
-        if self.config.log_dir is None:
-            working_dir = "{}/{}".format(self.logdir, "worker_logs")
-        logger.info("Setting working_dir: {}".format(working_dir))
-
         self.results_passthrough = multiprocessing.Queue()
         self.executors = {}
         for executor in self.config.executors:

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -9,40 +9,23 @@ class Config(RepresentationMixin):
     Parameters
     ----------
 
-    max_workers_per_node : int
-        Maximum # of worker per node. Default: inf
+    executors : list of Executors
+        A list of executors which serve as the backend for function execution. As of 0.2.2,
+        this list should contain only one executor.
+        Default: [HighThroughtputExecutor()]
 
-    cores_per_worker : float
-        cores to be assigned to each worker. Oversubscription is possible
-        by setting cores_per_worker < 1.0. Default=1
+    funcx_service_address: str
+        URL address string of the funcX service to which the Endpoint should connect.
+        Default: 'https://api2.funcx.org/v2'
 
-    mem_per_worker : float
-        GB of memory required per worker. If this option is specified, the node manager
-        will check the available memory at startup and limit the number of workers such that
-        the there's sufficient memory for each worker. Default: None
+    heartbeat_period: int (seconds)
+        The interval at which heartbeat messages are sent from the endpoint to the funcx-web-service
+        Default: 30s
 
-    working_dir : str
-        Working dir to be used by the executor. Default to the endpoint directory if not specified
-
-    worker_debug : Bool
-        Enables worker debug logging.
-
-    worker_mode : str
-        Select the mode of operation from no_container, singularity_reuse, singularity_single_use
-        Default: no_container
-
-    scheduler_mode : str
-        Select the mode of how the container is managed from hard, soft
-        Default: hard
-
-    container_type : str
-        Select the type of container from Docker, Singularity, Shifter
-        Default: None
-
-    scaling_enabled : Bool
-        Allow Interchange to manage resource provisioning. If set to False, interchange
-        will not do any scaling.
-        Default: True
+    heartbeat_threshold: int (seconds)
+        Seconds since the last hearbeat message from the funcx-web-service after which the connection
+        is assumed to be disconnected.
+        Default: 120s
 
     stdout : str
         Path where the endpoint's stdout should be written
@@ -57,7 +40,9 @@ class Config(RepresentationMixin):
         a real edge node, but an anti-pattern for kubernetes pods
         Default: True
 
-
+    log_dir : str
+        Optional path string to the top-level directory where logs should be written to.
+        Default: None
     """
 
     def __init__(self,
@@ -65,55 +50,33 @@ class Config(RepresentationMixin):
                  # Execution backed
                  executors: list = [HighThroughputExecutor()],
 
-                 # Scaling mechanics
-                 scaling_enabled=True,
                  # Connection info
-                 worker_ports=None,
-                 worker_port_range=(54000, 55000),
                  funcx_service_address='https://api2.funcx.org/v2',
 
                  # Tuning info
-                 worker_mode='no_container',
-                 scheduler_mode='hard',
-                 container_type=None,
-                 prefetch_capacity=10,
                  heartbeat_period=30,
                  heartbeat_threshold=120,
                  poll_period=10,
                  detach_endpoint=True,
+
                  # Logging info
-                 log_max_bytes=256 * 1024 * 1024,  # in bytes
-                 log_backup_count=1,
-                 working_dir=None,
+                 log_dir=None,
                  stdout="./interchange.stdout",
-                 stderr="./interchange.stderr",
-                 worker_debug=False):
+                 stderr="./interchange.stderr"):
 
         # Execution backends
         self.executors = executors  # List of executors
 
-        # Scaling mechanics
-        self.scaling_enabled = scaling_enabled
-
         # Connection info
-        self.worker_ports = worker_ports
-        self.worker_port_range = worker_port_range
         self.funcx_service_address = funcx_service_address
 
         # Tuning info
-        self.worker_mode = worker_mode
-        self.scheduler_mode = scheduler_mode
-        self.container_type = container_type
-        self.prefetch_capacity = prefetch_capacity
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold
         self.poll_period = poll_period
         self.detach_endpoint = detach_endpoint
 
         # Logging info
-        self.log_max_bytes = log_max_bytes
-        self.log_backup_count = log_backup_count
-        self.working_dir = working_dir
-        self.worker_debug = worker_debug
+        self.log_dir = log_dir
         self.stdout = stdout
         self.stderr = stderr

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -56,7 +56,6 @@ class Config(RepresentationMixin):
                  # Tuning info
                  heartbeat_period=30,
                  heartbeat_threshold=120,
-                 poll_period=10,
                  detach_endpoint=True,
 
                  # Logging info
@@ -73,7 +72,6 @@ class Config(RepresentationMixin):
         # Tuning info
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold
-        self.poll_period = poll_period
         self.detach_endpoint = detach_endpoint
 
         # Logging info


### PR DESCRIPTION
This is mostly documentation changes and removal of obsolete options. Please note that I am renaming the `Config.working_dir` to `Config.log_dir` for internal consistency.

Fixes #453 