### PR TITLE
Changed path joining to using os.path.join()

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -41,7 +41,7 @@ def version_callback(value):
 
 
 def complete_endpoint_name():
-    config_files = glob.glob('{}/*/config.py'.format(manager.funcx_dir))
+    config_files = glob.glob(os.path.join(manager.funcx_dir, '*', 'config.py'))
     for config_file in config_files:
         yield os.path.basename(os.path.dirname(config_file))
 
@@ -152,7 +152,7 @@ def main(
         ctx: typer.Context,
         _: bool = typer.Option(None, "--version", "-v", callback=version_callback, is_eager=True),
         debug: bool = typer.Option(False, "--debug", "-d"),
-        config_dir: str = typer.Option('{}/.funcx'.format(pathlib.Path.home()), "--config_dir", "-c", help="override default config dir")
+        config_dir: str = typer.Option(os.path.join(pathlib.Path.home(), '.funcx'), "--config_dir", "-c", help="override default config dir")
 ):
     # Note: no docstring here; the docstring for @app.callback is used as a help message for overall app.
     # Sets up global variables in the State wrapper (debug flag, config dir, default config file).

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -34,7 +34,7 @@ class EndpointManager:
     def __init__(self, logger):
         self.funcx_config_file_name = 'config.py'
         self.DEBUG = False
-        self.funcx_dir = '{}/.funcx'.format(pathlib.Path.home())
+        self.funcx_dir = os.path.join(pathlib.Path.home(), '.funcx')
         self.funcx_config_file = os.path.join(self.funcx_dir, self.funcx_config_file_name)
         self.funcx_default_config_template = funcx_default_config.__file__
         self.funcx_config = {}
@@ -284,7 +284,7 @@ class EndpointManager:
 
         with open(os.path.join(endpoint_dir, 'endpoint.json'), 'w+') as fp:
             json.dump(reg_info, fp)
-            self.logger.debug("Registration info written to {}/endpoint.json".format(endpoint_dir))
+            self.logger.debug("Registration info written to {}".format(os.path.join(endpoint_dir, 'endpoint.json')))
 
         certs_dir = os.path.join(endpoint_dir, 'certificates')
         os.makedirs(certs_dir, exist_ok=True)
@@ -372,7 +372,7 @@ class EndpointManager:
         headings = ['Endpoint Name', 'Status', 'Endpoint ID']
         table.header(headings)
 
-        config_files = glob.glob('{}/*/config.py'.format(self.funcx_dir))
+        config_files = glob.glob(os.path.join(self.funcx_dir, '*', 'config.py'))
         for config_file in config_files:
             endpoint_dir = os.path.dirname(config_file)
             endpoint_name = os.path.basename(endpoint_dir)

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -136,7 +136,7 @@ class EndpointInterchange(object):
         except FileExistsError:
             pass
 
-        start_file_logger("{}/EndpointInterchange.log".format(self.logdir), name="funcx_endpoint", level=logging_level)
+        start_file_logger(os.path.join(self.logdir, "EndpointInterchange.log"), name="funcx_endpoint", level=logging_level)
         logger.info("logger location {}".format(logger.handlers))
         logger.info("Initializing EndpointInterchange process with Endpoint ID: {}".format(endpoint_id))
         self.config = config
@@ -205,7 +205,7 @@ class EndpointInterchange(object):
 
         working_dir = self.config.working_dir
         if self.config.working_dir is None:
-            working_dir = "{}/{}".format(self.logdir, "worker_logs")
+            working_dir = os.path.join(self.logdir, "worker_logs")
         logger.info("Setting working_dir: {}".format(working_dir))
 
         self.results_passthrough = multiprocessing.Queue()

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -309,7 +309,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                        heartbeat_period=self.heartbeat_period,
                                        heartbeat_threshold=self.heartbeat_threshold,
                                        poll_period=self.poll_period,
-                                       logdir="{}/{}".format(self.run_dir, self.label),
+                                       logdir=os.path.join(self.run_dir, self.label),
                                        worker_mode=self.worker_mode,
                                        container_image=self.container_image)
         self.launch_cmd = l_cmd
@@ -394,7 +394,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "interchange_address": self.address,
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
-                                          "logdir": "{}/{}".format(self.run_dir, self.label),
+                                          "logdir": os.path.join(self.run_dir, self.label),
                                           "suppress_failure": self.suppress_failure,
                                           "endpoint_id": self.endpoint_id,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
@@ -428,9 +428,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                                                                   self.command_client.port),
                                                    worker_port_range="{},{}".format(self.worker_port_range[0],
                                                                                     self.worker_port_range[1]),
-                                                   logdir="{}/runinfo/{}/{}".format(self.provider.channel.script_dir,
-                                                                                    os.path.basename(self.run_dir),
-                                                                                    self.label),
+                                                   logdir=os.path.join(self.provider.channel.script_dir, 'runinfo',
+                                                                       os.path.basename(self.run_dir), self.label),
                                                    suppress_failure=suppress_failure)
 
         if self.provider.worker_init:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -563,7 +563,7 @@ def cli_run():
     try:
         global logger
         # TODO Update logger to use the RotatingFileHandler in the funcx.utils.loggers.set_file_logger
-        logger = set_file_logger('{}/{}/manager.log'.format(args.logdir, args.uid),
+        logger = set_file_logger(os.path.join(args.logdir, args.uid, 'manager.log'),
                                  name='funcx_manager',
                                  level=logging.DEBUG if args.debug is True else logging.INFO,
                                  max_bytes=float(args.log_max_bytes),  # TODO: Test if this still works on forwarder_rearch_1

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -5,6 +5,7 @@ import argparse
 import zmq
 import sys
 import pickle
+import os
 
 from parsl.app.errors import RemoteExceptionWrapper
 
@@ -53,7 +54,7 @@ class FuncXWorker(object):
         self.deserialize = self.serializer.deserialize
 
         global logger
-        logger = set_file_logger('{}/funcx_worker_{}.log'.format(logdir, worker_id),
+        logger = set_file_logger(os.path.join(logdir, f'funcx_worker_{worker_id}.log'),
                                  name="worker_log",
                                  level=logging.DEBUG if debug else logging.INFO)
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -172,7 +172,7 @@ class Interchange(object):
 
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
-        start_file_logger("{}/interchange.log".format(self.logdir),
+        start_file_logger(os.path.join(self.logdir, 'interchange.log'),
                           level=logging_level,
                           max_bytes=log_max_bytes,
                           backup_count=log_backup_count)
@@ -311,7 +311,7 @@ class Interchange(object):
         logger.info("Loading endpoint local config")
         working_dir = self.working_dir
         if self.working_dir is None:
-            working_dir = "{}/{}".format(self.logdir, "worker_logs")
+            working_dir = os.path.join(self.logdir, "worker_logs")
         logger.info("Setting working_dir: {}".format(working_dir))
 
         self.provider.script_dir = working_dir

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
@@ -3,6 +3,7 @@ import logging
 import random
 import subprocess
 import time
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +199,7 @@ class WorkerMap(object):
                f'-a {address} '
                f'-p {worker_port} '
                f'-t {worker_type} '
-               f'--logdir={logdir}/{uid} ')
+               f'--logdir={os.path.join(logdir, uid)} ')
 
         logger.info("Command string :\n {}".format(cmd))
 

--- a/funcx_endpoint/tests/integration/test_config.py
+++ b/funcx_endpoint/tests/integration/test_config.py
@@ -16,8 +16,6 @@ if __name__ == '__main__':
 
     if config.working_dir is None:
         working_dir = os.path.join(endpoint_dir, "worker_logs")
-    # if self.worker_logdir_root is not None:
-    #      worker_logdir = os.path.join(self.worker_logdir_root, self.label)
 
     print("Loading : ", config)
     # Set script dir

--- a/funcx_endpoint/tests/integration/test_config.py
+++ b/funcx_endpoint/tests/integration/test_config.py
@@ -1,5 +1,5 @@
 from funcx_endpoint.endpoint.utils.config import Config
-
+import os
 
 config = Config()
 
@@ -15,9 +15,9 @@ if __name__ == '__main__':
     endpoint_dir = "/home/yadu/.funcx/default"
 
     if config.working_dir is None:
-        working_dir = "{}/{}".format(endpoint_dir, "worker_logs")
+        working_dir = os.path.join(endpoint_dir, "worker_logs")
     # if self.worker_logdir_root is not None:
-    #      worker_logdir = "{}/{}".format(self.worker_logdir_root, self.label)
+    #      worker_logdir = os.path.join(self.worker_logdir_root, self.label)
 
     print("Loading : ", config)
     # Set script dir


### PR DESCRIPTION
Current path joining:
Using direct string concatenation with linux/mac convention: `{}/{}`

After the PR change:
Using python universal path joining tool: `os.path.join()`