### PR TITLE
Refactor endpoint manager

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -166,19 +166,15 @@ def main(
     logger.debug("Command: {}".format(ctx.invoked_subcommand))
 
     global manager
-    manager = EndpointManager()
-
-    # Set global state variables, to avoid passing them around as arguments all the time
-    manager.DEBUG = debug
-    manager.funcx_dir = config_dir
-    manager.funcx_config_file = os.path.join(manager.funcx_dir, manager.funcx_config_file_name)
+    manager = EndpointManager(funcx_dir=config_dir,
+                              debug=debug)
 
     # Otherwise, we ensure that configs exist
     if not os.path.exists(manager.funcx_config_file):
-        manager.logger.info(f"No existing configuration found at {manager.funcx_config_file}. Initializing...")
+        logger.info(f"No existing configuration found at {manager.funcx_config_file}. Initializing...")
         manager.init_endpoint()
 
-    manager.logger.debug("Loading config files from {}".format(manager.funcx_dir))
+    logger.debug("Loading config files from {}".format(manager.funcx_dir))
 
     funcx_config = SourceFileLoader('global_config', manager.funcx_config_file).load_module()
     manager.funcx_config = funcx_config.global_options

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -31,6 +31,7 @@ from funcx_endpoint.endpoint.endpoint_manager import EndpointManager
 from funcx.sdk.client import FuncXClient
 
 app = typer.Typer()
+logger = None
 
 
 def version_callback(value):
@@ -158,12 +159,14 @@ def main(
     # Sets up global variables in the State wrapper (debug flag, config dir, default config file).
     # For commands other than `init`, we ensure the existence of the config directory and file.
 
-    funcx.set_stream_logger(level=logging.DEBUG if debug else logging.INFO)
+    global logger
+    funcx.set_stream_logger(name='funcx_endpoint',
+                            level=logging.DEBUG if debug else logging.INFO)
     logger = logging.getLogger('funcx')
     logger.debug("Command: {}".format(ctx.invoked_subcommand))
 
     global manager
-    manager = EndpointManager(logger)
+    manager = EndpointManager()
 
     # Set global state variables, to avoid passing them around as arguments all the time
     manager.DEBUG = debug

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -160,9 +160,9 @@ def main(
     # For commands other than `init`, we ensure the existence of the config directory and file.
 
     global logger
-    funcx.set_stream_logger(name='funcx_endpoint',
+    funcx.set_stream_logger(name='endpoint',
                             level=logging.DEBUG if debug else logging.INFO)
-    logger = logging.getLogger('funcx')
+    logger = logging.getLogger('endpoint')
     logger.debug("Command: {}".format(ctx.invoked_subcommand))
 
     global manager

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -29,7 +29,7 @@ from funcx_endpoint.executors.high_throughput import global_config as funcx_defa
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
 from funcx.sdk.client import FuncXClient
 
-logger = logging.getLogger("funcx_endpoint.endpoint_manager")
+logger = logging.getLogger("endpoint.endpoint_manager")
 
 
 class EndpointManager:

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -36,15 +36,23 @@ class EndpointManager:
     """ EndpointManager is primarily responsible for configuring, launching and stopping the Endpoint.
     """
 
-    def __init__(self):
+    def __init__(self,
+                 funcx_dir='{}/.funcx'.format(pathlib.Path.home()),
+                 debug=False):
         """ Initialize the EndpointManager
 
         Parameters
         ----------
+
+        funcx_dir: str
+            Directory path to the root of the funcx dirs. Usually ~/.funcx.
+
+        debug: Bool
+            Enable debug logging. Default: False
         """
         self.funcx_config_file_name = 'config.py'
-        self.DEBUG = False
-        self.funcx_dir = '{}/.funcx'.format(pathlib.Path.home())
+        self.debug = debug
+        self.funcx_dir = funcx_dir
         self.funcx_config_file = os.path.join(self.funcx_dir, self.funcx_config_file_name)
         self.funcx_default_config_template = funcx_default_config.__file__
         self.funcx_config = {}
@@ -251,7 +259,7 @@ class EndpointManager:
 
             optionals['logdir'] = endpoint_dir
 
-        if self.DEBUG:
+        if self.debug:
             optionals['logging_level'] = logging.DEBUG
 
         ic = EndpointInterchange(endpoint_config.config,

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -29,9 +29,19 @@ from funcx_endpoint.executors.high_throughput import global_config as funcx_defa
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
 from funcx.sdk.client import FuncXClient
 
+logger = logging.getLogger("funcx_endpoint.endpoint_manager")
+
 
 class EndpointManager:
-    def __init__(self, logger):
+    """ EndpointManager is primarily responsible for configuring, launching and stopping the Endpoint.
+    """
+
+    def __init__(self):
+        """ Initialize the EndpointManager
+
+        Parameters
+        ----------
+        """
         self.funcx_config_file_name = 'config.py'
         self.DEBUG = False
         self.funcx_dir = '{}/.funcx'.format(pathlib.Path.home())
@@ -39,6 +49,7 @@ class EndpointManager:
         self.funcx_default_config_template = funcx_default_config.__file__
         self.funcx_config = {}
         self.name = 'default'
+        global logger
         self.logger = logger
 
     def init_endpoint_dir(self, endpoint_config=None):

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -137,7 +137,6 @@ class EndpointInterchange(object):
             pass
 
         start_file_logger("{}/EndpointInterchange.log".format(self.logdir), name="funcx_endpoint", level=logging_level)
-        logger.info("logger location {}".format(logger.handlers))
         logger.info("Initializing EndpointInterchange process with Endpoint ID: {}".format(endpoint_id))
         self.config = config
         logger.info("Got config : {}".format(config))

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -27,16 +27,13 @@ class TestStart:
         shutil.rmtree(config_dir)
 
     def test_configure(self):
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
-
         manager.configure_endpoint("mock_endpoint", None)
         assert os.path.exists(config_dir)
 
     def test_double_configure(self):
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
@@ -73,8 +70,7 @@ class TestStart:
         mock_pidfile = mocker.patch('funcx_endpoint.endpoint.endpoint_manager.daemon.pidfile.PIDLockFile')
         mock_pidfile.return_value = None
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
@@ -113,8 +109,7 @@ class TestStart:
                 executors = None
             config = mock_executors()
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
@@ -139,8 +134,7 @@ class TestStart:
         mock_optionals['client_address'] = '127.0.0.1'
         mock_optionals['client_ports'] = (8080, 8081, 8082)
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
@@ -177,8 +171,7 @@ class TestStart:
         mock_funcx_config = {}
         mock_funcx_config['endpoint_address'] = '127.0.0.1'
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
         mock_optionals['logdir'] = config_dir
         manager.funcx_config = mock_funcx_config
@@ -197,7 +190,7 @@ class TestStart:
         mock_client = mocker.patch("funcx_endpoint.endpoint.endpoint_manager.FuncXClient")
         mock_client.return_value.register_endpoint.return_value = {'status': 'okay'}
 
-        manager = EndpointManager(logger)
+        manager = EndpointManager(funcx_dir=os.getcwd())
         manager.funcx_dir = f'{os.getcwd()}'
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
@@ -210,8 +203,7 @@ class TestStart:
         mock_client.return_value.register_endpoint.return_value = {'status': 'okay',
                                                                    'endpoint_id': 123456}
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
@@ -222,24 +214,21 @@ class TestStart:
         mock_uuid = mocker.patch('funcx_endpoint.endpoint.endpoint_manager.uuid.uuid4')
         mock_uuid.return_value = 123456
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
         assert '123456' == manager.check_endpoint_json(os.path.join(config_dir, 'endpoint.json'), None)
 
     def test_check_endpoint_json_no_json_given_uuid(self, mocker):
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)
         assert '234567' == manager.check_endpoint_json(os.path.join(config_dir, 'endpoint.json'), '234567')
 
     def test_check_endpoint_json_given_json(self, mocker):
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
 
         manager.configure_endpoint("mock_endpoint", None)

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -37,8 +37,7 @@ class TestStart:
         mock_queue = mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing.Queue")
         mock_queue.return_value = None
 
-        manager = EndpointManager(logger)
-        manager.funcx_dir = f'{os.getcwd()}'
+        manager = EndpointManager(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
         keys_dir = os.path.join(config_dir, 'certificates')
 


### PR DESCRIPTION
This PR makes updates EndpointManager init interface and the way loggers are handled.

* The EndpointManager init now takes all the info it needs at init, rather than being injected separately.
* The loggers in the `endpoint.py` and `endpoint_manager.py` are named `endpoint` to keep those logs separate from the EndpointInterchange.
* Loggers are now simple globals rather than being accessed from inside the EndpointManager object