### PR TITLE
Cleaned up for log modularization

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -140,7 +140,6 @@ class EndpointInterchange(object):
         global logger
 
         logger = set_file_logger(os.path.join(self.logdir, "EndpointInterchange.log"), name="funcx_endpoint", level=logging_level)
-        logger.info("logger location {}".format(logger.handlers))
         logger.info("Initializing EndpointInterchange process with Endpoint ID: {}".format(endpoint_id))
         self.config = config
         logger.info("Got config : {}".format(config))

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -23,7 +23,7 @@ from parsl.version import VERSION as PARSL_VERSION
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.sdk.client import FuncXClient
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import naive_interchange_task_dispatch
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.endpoint.taskqueue import TaskQueue

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -23,6 +23,7 @@ from parsl.version import VERSION as PARSL_VERSION
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.sdk.client import FuncXClient
+from funcx.utils.loggers import set_file_logger
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import naive_interchange_task_dispatch
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.endpoint.taskqueue import TaskQueue
@@ -136,7 +137,10 @@ class EndpointInterchange(object):
         except FileExistsError:
             pass
 
-        start_file_logger(os.path.join(self.logdir, "EndpointInterchange.log"), name="funcx_endpoint", level=logging_level)
+        global logger
+
+        logger = set_file_logger(os.path.join(self.logdir, "EndpointInterchange.log"), name="funcx_endpoint", level=logging_level)
+        logger.info("logger location {}".format(logger.handlers))
         logger.info("Initializing EndpointInterchange process with Endpoint ID: {}".format(endpoint_id))
         self.config = config
         logger.info("Got config : {}".format(config))
@@ -569,40 +573,6 @@ class EndpointInterchange(object):
             logger.debug("[MAIN] The status is {}".format(status))
 
         return status
-
-
-def start_file_logger(filename, name=__name__, level=logging.DEBUG, format_string=None):
-    """Add a stream log handler.
-
-    Parameters
-    ---------
-
-    filename: string
-        Name of the file to write logs to. Required.
-    name: string
-        Logger name. Default="parsl.executors.interchange"
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    global logger
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    if not len(logger.handlers):
-        handler = logging.FileHandler(filename)
-        handler.setLevel(level)
-        formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
 
 
 def starter(comm_q, *args, **kwargs):

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -34,7 +34,7 @@ from parsl.providers import LocalProvider
 
 
 from funcx_endpoint.executors.high_throughput import zmq_pipes
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 
 # TODO: YADU There's a bug here which causes some of the log messages to write out to stderr
 # "logging" python3 self.stream.flush() OSError: [Errno 9] Bad file descriptor
@@ -755,8 +755,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
 
 
 def executor_starter(htex, logdir, endpoint_id, logging_level=logging.DEBUG):
-
-    from funcx.utils.loggers import set_file_logger
 
     stdout = open(os.path.join(logdir, "executor.{}.stdout".format(endpoint_id)), 'w')
     stderr = open(os.path.join(logdir, "executor.{}.stderr".format(endpoint_id)), 'w')

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -562,6 +562,7 @@ def cli_run():
 
     try:
         global logger
+        # TODO The config options for the rotatingfilehandler need to be implemented and checked so that it is user configurable
         logger = set_file_logger(os.path.join(args.logdir, args.uid, 'manager.log'),
                                  name='funcx_manager',
                                  level=logging.DEBUG if args.debug is True else logging.INFO,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -26,7 +26,7 @@ from funcx.serialize import FuncXSerializer
 
 from parsl.version import VERSION as PARSL_VERSION
 
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 
 
 RESULT_TAG = 10
@@ -562,7 +562,6 @@ def cli_run():
 
     try:
         global logger
-        # TODO Update logger to use the RotatingFileHandler in the funcx.utils.loggers.set_file_logger
         logger = set_file_logger(os.path.join(args.logdir, args.uid, 'manager.log'),
                                  name='funcx_manager',
                                  level=logging.DEBUG if args.debug is True else logging.INFO,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -9,7 +9,7 @@ import os
 
 from parsl.app.errors import RemoteExceptionWrapper
 
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -25,7 +25,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.sdk.client import FuncXClient
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import naive_interchange_task_dispatch
 from funcx.serialize import FuncXSerializer
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -25,6 +25,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.sdk.client import FuncXClient
+from funcx.utils.loggers import set_file_logger
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import naive_interchange_task_dispatch
 from funcx.serialize import FuncXSerializer
 
@@ -172,10 +173,14 @@ class Interchange(object):
 
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
-        start_file_logger(os.path.join(self.logdir, 'interchange.log'),
-                          level=logging_level,
-                          max_bytes=log_max_bytes,
-                          backup_count=log_backup_count)
+
+        global logger
+        logger = set_file_logger(os.path.join(self.logdir, 'interchange.log'),
+                                 name="interchange",
+                                 level=logging_level,
+                                 max_bytes=log_max_bytes,
+                                 backup_count=log_backup_count)
+
         logger.info("logger location {}, logger filesize: {}, logger backup count: {}".format(logger.handlers,
                                                                                               log_max_bytes,
                                                                                               log_backup_count))
@@ -927,53 +932,6 @@ class Interchange(object):
             logger.debug("[MAIN] The status is {}".format(status))
 
         return status
-
-
-def start_file_logger(filename,
-                      name="interchange",
-                      level=logging.DEBUG,
-                      format_string=None,
-                      max_bytes=256 * 1024 * 1024,
-                      backup_count=1):
-    """Add a stream log handler.
-
-    Parameters
-    ---------
-
-    filename: string
-        Name of the file to write logs to. Set to None to have interchange logging
-        merged in with endpoint logging.
-    name: string
-        Logger name. Default="parsl.executors.interchange"
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-    max_bytes: int
-        The maximum bytes per logger file, default: 256MB
-    backup_count: int
-        The number of backup (must be non-zero) per logger file, default: 1
-
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    global logger
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    if not len(logger.handlers):
-        handler = RotatingFileHandler(filename, maxBytes=max_bytes, backupCount=backup_count)
-        handler.setLevel(level)
-        formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.info(
-            "logger location {}, logger filesize: {}, logger backup count: {}".format(
-                logger.handlers, max_bytes, backup_count))
 
 
 def starter(comm_q, *args, **kwargs):

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/zmq_pipes.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/zmq_pipes.py
@@ -5,7 +5,7 @@ import time
 import pickle
 import logging
 
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 from funcx_endpoint.executors.high_throughput.messages import Message
 
 logger = logging.getLogger(__name__)

--- a/funcx_endpoint/funcx_endpoint/mock_broker/forwarder.py
+++ b/funcx_endpoint/funcx_endpoint/mock_broker/forwarder.py
@@ -6,7 +6,7 @@ import queue
 from multiprocessing import Queue
 
 from multiprocessing import Process
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 
 
 def double(x):

--- a/funcx_endpoint/tests/integration/test_executor.py
+++ b/funcx_endpoint/tests/integration/test_executor.py
@@ -1,6 +1,6 @@
 from funcx_endpoint.executors.high_throughput.executor import HighThroughputExecutor
 import logging
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 
 
 def double(x):

--- a/funcx_endpoint/tests/integration/test_executor_passthrough.py
+++ b/funcx_endpoint/tests/integration/test_executor_passthrough.py
@@ -1,6 +1,6 @@
 from funcx_endpoint.executors.high_throughput.executor import HighThroughputExecutor
 import logging
-from funcx.utils.loggers import set_file_logger
+from funcx import set_file_logger
 import uuid
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.executors.high_throughput.messages import Message, Task

--- a/funcx_endpoint/tests/integration/test_status.py
+++ b/funcx_endpoint/tests/integration/test_status.py
@@ -2,7 +2,7 @@ import argparse
 import time
 
 import funcx
-from funcx.utils.loggers import set_stream_logger
+from funcx import set_stream_logger
 from funcx.sdk.client import FuncXClient
 from funcx.serialize import FuncXSerializer
 

--- a/funcx_sdk/funcx/__init__.py
+++ b/funcx_sdk/funcx/__init__.py
@@ -8,56 +8,8 @@ __author__ = "The funcX team"
 __version__ = VERSION
 
 from funcx.sdk.client import FuncXClient
-
-
-def set_file_logger(filename, name='funcx', level=logging.DEBUG, format_string=None):
-    """Add a stream log handler.
-
-    Args:
-        - filename (string): Name of the file to write logs to
-        - name (string): Logger name
-        - level (logging.LEVEL): Set the logging level.
-        - format_string (string): Set the format string
-
-    Returns:
-       -  None
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger
-
-
-def set_stream_logger(name='funcx', level=logging.DEBUG, format_string=None):
-    """Add a stream log handler.
-
-    Args:
-         - name (string) : Set the logger name.
-         - level (logging.LEVEL) : Set to logging.DEBUG by default.
-         - format_string (string) : Set to None by default.
-
-    Returns:
-         - None
-    """
-    if format_string is None:
-        # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
-        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger
+from funcx.utils.loggers import file_format_string, stream_format_string
+from funcx.utils.loggers import set_file_logger, set_stream_logger
 
 
 logging.getLogger('funcx').addHandler(logging.NullHandler())

--- a/funcx_sdk/funcx/__init__.py
+++ b/funcx_sdk/funcx/__init__.py
@@ -8,8 +8,4 @@ __author__ = "The funcX team"
 __version__ = VERSION
 
 from funcx.sdk.client import FuncXClient
-from funcx.utils.loggers import file_format_string, stream_format_string
 from funcx.utils.loggers import set_file_logger, set_stream_logger
-
-
-logging.getLogger('funcx').addHandler(logging.NullHandler())

--- a/funcx_sdk/funcx/utils/loggers.py
+++ b/funcx_sdk/funcx/utils/loggers.py
@@ -62,3 +62,6 @@ def set_stream_logger(name='funcx', level=logging.DEBUG, format_string=None):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
+
+
+logging.getLogger('funcx').addHandler(logging.NullHandler())

--- a/funcx_sdk/funcx/utils/loggers.py
+++ b/funcx_sdk/funcx/utils/loggers.py
@@ -2,6 +2,12 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 
+file_format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+
+
+stream_format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+
+
 def set_file_logger(filename,
                     name='funcx',
                     level=logging.DEBUG,
@@ -22,7 +28,7 @@ def set_file_logger(filename,
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = file_format_string
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
@@ -46,8 +52,7 @@ def set_stream_logger(name='funcx', level=logging.DEBUG, format_string=None):
          - None
     """
     if format_string is None:
-        # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
-        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = stream_format_string
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
@@ -57,6 +62,3 @@ def set_stream_logger(name='funcx', level=logging.DEBUG, format_string=None):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
-
-
-logging.getLogger('funcx').addHandler(logging.NullHandler())


### PR DESCRIPTION
Before the PR:
`start_file_logger()` were defined separately in two files, which had the same functionality as `set_file_logger()`

In the PR:
Replaced `start_file_logger()` by `set_file_logger()`, and cleaned up the `loggers.py` module