### PR TITLE
Made worker killer tasks have consistent type

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -34,7 +34,7 @@ TASK_REQUEST_TAG = 11
 HEARTBEAT_CODE = (2 ** 32) - 1
 
 
-logger = logging.getLogger("funcx_manager")
+logger = None
 
 
 class Manager(object):
@@ -121,6 +121,10 @@ class Manager(object):
         poll_period : int
              Timeout period used by the manager in milliseconds. Default: 10ms
         """
+
+        global logger
+        if logger is None:
+            logger = logging.getLogger("funcx_manager")
 
         logger.info("Manager started")
 
@@ -490,14 +494,11 @@ class Manager(object):
 
         logger.debug("[WORKER_REMOVE] Appending KILL message to worker queue {}".format(worker_type))
         self.worker_map.to_die_count[worker_type] += 1
-        task_id = "KILL"
-        cont_id = "RAW"
-        task_buf = "KILL"
-        raw_buf = f'{task_id};{cont_id};{task_buf}'
-        task_buf = task_buf.encode('utf-8')
-        raw_buf = raw_buf.encode('utf-8')
-        self.task_queues[worker_type].put(Task(task_id, cont_id, task_buf,
-                                               raw_buffer=raw_buf))
+        task = Task(task_id='KILL',
+                    container_id='RAW',
+                    task_buffer='KILL')
+        task.pack()
+        self.task_queues[worker_type].put(task)
 
     def start(self):
         """

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -123,8 +123,11 @@ class Manager(object):
         """
 
         global logger
+        # This is expected to be used only in unit test
         if logger is None:
-            logger = logging.getLogger("funcx_manager")
+            logger = set_file_logger(os.path.join(logdir, uid, 'manager.log'),
+                                     name='funcx_manager',
+                                     level=logging.DEBUG)
 
         logger.info("Manager started")
 
@@ -497,7 +500,6 @@ class Manager(object):
         task = Task(task_id='KILL',
                     container_id='RAW',
                     task_buffer='KILL')
-        task.pack()
         self.task_queues[worker_type].put(task)
 
     def start(self):
@@ -571,6 +573,7 @@ def cli_run():
         pass
 
     try:
+        global logger
         # TODO Update logger to use the RotatingFileHandler in the funcx.utils.loggers.set_file_logger
         logger = set_file_logger(os.path.join(args.logdir, args.uid, 'manager.log'),
                                  name='funcx_manager',

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -104,11 +104,13 @@ class FuncXWorker(object):
             container_id = pickle.loads(p_container_id)
             logger.debug("Received task_id:{} with task:{}".format(task_id, msg))
 
-            if msg == b"KILL":
-                logger.info("[KILL] -- Worker KILL message received! ")
-                task_type = b'WRKR_DIE'
-                result = None
-                continue
+            if task_id == "KILL":
+                task = Message.unpack(msg)
+                if task.task_buffer.decode('utf-8') == "KILL":
+                    logger.info("[KILL] -- Worker KILL message received! ")
+                    task_type = b'WRKR_DIE'
+                    result = None
+                    continue
 
             logger.debug("Executing task...")
 

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -1,0 +1,22 @@
+from funcx_endpoint.executors.high_throughput.funcx_manager import Manager
+from funcx_endpoint.executors.high_throughput.messages import Task
+import queue
+
+
+class TestManager:
+
+    def test_remove_worker_init(self):
+        class MockMap:
+            def __init__(self):
+                self.to_die_count = {"RAW": 0}
+        manager = Manager(uid="mock_uid")
+        manager.worker_map = MockMap()
+        manager.task_queues = {"RAW": queue.Queue()}
+
+        manager.remove_worker_init("RAW")
+        task = manager.task_queues["RAW"].get()
+        assert isinstance(task, Task)
+        assert task.task_id == "KILL"
+        assert task.container_id == "RAW"
+        assert task.task_buffer.decode('utf-8') == "KILL"
+        assert task.raw_buffer.decode('utf-8') == "KILL;RAW;KILL"

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -18,5 +18,5 @@ class TestManager:
         assert isinstance(task, Task)
         assert task.task_id == "KILL"
         assert task.container_id == "RAW"
-        assert task.task_buffer.decode('utf-8') == "KILL"
-        assert task.raw_buffer.decode('utf-8') == "KILL;RAW;KILL"
+        assert task.task_buffer == "KILL"
+        assert task.raw_buffer.decode('utf-8') == 'TID=KILL;CID=RAW;KILL'

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -1,22 +1,77 @@
 from funcx_endpoint.executors.high_throughput.funcx_manager import Manager
 from funcx_endpoint.executors.high_throughput.messages import Task
 import queue
+import logging
+import pickle
+import zmq
+import os
+import shutil
+import pytest
 
 
 class TestManager:
 
+    @pytest.fixture(autouse=True)
+    def test_setup_teardown(self):
+        os.makedirs(os.path.join(os.getcwd(), 'mock_uid'))
+        yield
+        shutil.rmtree(os.path.join(os.getcwd(), 'mock_uid'))
+
     def test_remove_worker_init(self):
-        class MockMap:
-            def __init__(self):
-                self.to_die_count = {"RAW": 0}
-        manager = Manager(uid="mock_uid")
-        manager.worker_map = MockMap()
-        manager.task_queues = {"RAW": queue.Queue()}
+        manager = Manager(logdir='./', uid="mock_uid")
+        manager.worker_map.to_die_count["RAW"] = 0
+        manager.task_queues["RAW"] = queue.Queue()
 
         manager.remove_worker_init("RAW")
         task = manager.task_queues["RAW"].get()
         assert isinstance(task, Task)
         assert task.task_id == "KILL"
-        assert task.container_id == "RAW"
         assert task.task_buffer == "KILL"
-        assert task.raw_buffer.decode('utf-8') == 'TID=KILL;CID=RAW;KILL'
+
+    def test_manager_worker(self):
+        manager = Manager(logdir='./', uid="mock_uid")
+        manager.worker_map.to_die_count["RAW"] = 0
+        manager.task_queues["RAW"] = queue.Queue()
+        manager.logdir = "./"
+        manager.worker_type = 'RAW'
+
+        # Manager::start()
+        worker = manager.worker_map.add_worker(worker_id="0",
+                                               worker_type=manager.worker_type,
+                                               address=manager.address,
+                                               debug=logging.DEBUG,
+                                               uid=manager.uid,
+                                               logdir=manager.logdir,
+                                               worker_port=manager.worker_port)
+        # The worker process should have been spawned above,
+        # and it should have sent out the registration message
+        manager.worker_procs.update(worker)
+        assert len(manager.worker_procs) == 1
+
+        # Manager::pull_tasks()
+        poller = zmq.Poller()
+        poller.register(manager.funcx_task_socket, zmq.POLLIN)
+
+        # Manager::pull_tasks()
+        # We want to catch the worker's registration message
+        w_id, m_type, message = manager.funcx_task_socket.recv_multipart()
+        reg_info = pickle.loads(message)
+        assert reg_info['worker_id'] == '0'
+        assert reg_info['worker_type'] == 'RAW'
+        manager.worker_map.register_worker(w_id, reg_info['worker_type'])
+
+        # Begin testing removing worker process
+        manager.remove_worker_init("RAW")
+        task = manager.task_queues["RAW"].get()
+        worker_id = manager.worker_map.get_worker("RAW")
+        to_send = [worker_id, pickle.dumps(task.task_id), pickle.dumps(task.container_id), task.pack()]
+        manager.funcx_task_socket.send_multipart(to_send)
+
+        # We want to catch the worker's response to the remove message
+        w_id, m_type, message = manager.funcx_task_socket.recv_multipart()
+        assert m_type == b'WRKR_DIE'
+        assert pickle.loads(message) is None
+
+        manager.worker_map.remove_worker(w_id)
+        manager.worker_procs.pop(w_id.decode())
+        assert len(manager.worker_procs) == 0


### PR DESCRIPTION
Issue: The worker killer task does not use `class Task` as other tasks. Need to make it consistent.

After the PR:
The worker killer task is encoded to `Task` type before being put onto the task queue.

Note:
- `logger = logging.getLogger("funcx_manager")` was added to the top of `funcx_manager.py`. It does not change any behavior of the application, because `funcx-manager` is invoked only through the `cli_run()` of the module, and `logger` is re-set in `cli_run` via `set_file_logger` to its desired setting.
- The reason for adding this is for the correctness of the unit test. `logger` was originally declared in `cli_run` of `funcx_manager.py`, and used in the module thoroughly. When we initiates `Manager` in unit test by `manager = Manager()`, `Manager`'s constructor calls `logger`, but it cannot find `logger`, because it is out of scope (has not been declared yet). By adding `logger = logging.getLogger("funcx_manager")`, `Manager`'s constructor is able to use the `logger`.