### PR TITLE
Removing the redundant configure step in init_endpoint

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -137,7 +137,6 @@ class EndpointManager:
             print("[FuncX] Caught exception during registration {}".format(e))
 
         shutil.copyfile(self.funcx_default_config_template, self.funcx_config_file)
-        self.init_endpoint_dir()
 
     def check_endpoint_json(self, endpoint_json, endpoint_uuid):
         if os.path.exists(endpoint_json):


### PR DESCRIPTION
There's a redundant call to `EndpointManager.init_endpoint_dir` that creates an endpoint dir instead of leaving that responsibility to the `EndpointManager.configure_endpoint` step that follows. This currently has the `funcx-endpoint configure [<optional_endpoint_name>]` command fail with the `ConfigExists` exception due to the duplicate attempt to create the same dir.
This PR removes this redundant call.