### PR TITLE
Remove old config options from docs and helm chart config

### DIFF
--- a/docs/configs/kube.py
+++ b/docs/configs/kube.py
@@ -39,6 +39,5 @@ config = Config(
     ],
     heartbeat_period=15,
     heartbeat_threshold=200,
-    working_dir='.',
-    scaling_enabled=True,
+    log_dir='.',
 )

--- a/docs/configs/midway.py
+++ b/docs/configs/midway.py
@@ -36,5 +36,4 @@ config = Config(
             ),
         )
     ],
-    scaling_enabled=True
 )

--- a/docs/configs/theta.py
+++ b/docs/configs/theta.py
@@ -39,5 +39,4 @@ config = Config(
             ),
         )
     ],
-    scaling_enabled=True
 )

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -40,9 +40,8 @@ data:
         ],
         heartbeat_period=15,
         heartbeat_threshold=200,
-        working_dir='{{ .Values.workingDir }}',
+        log_dir='{{ .Values.logDir }}',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v2",
-        scaling_enabled=True,
         detach_endpoint={{- ternary "True" "False" .Values.detachEndpoint }}
     )
 

--- a/helm/funcx_endpoint/values.yaml
+++ b/helm/funcx_endpoint/values.yaml
@@ -12,7 +12,7 @@ image:
 workerImage: python:3.6-buster
 workerInit: pip install funcx-endpoint>=0.2.0
 workerNamespace: default
-workingDir: /tmp/worker_logs
+logDir: /tmp/worker_logs
 
 rbacEnabled: true
 nameOverride: funcx-endpoint


### PR DESCRIPTION
In PR #457 , we removed some old config options like `working_dir` and `scaling_enabled`. They need to be removed from docs and helm too.