### PR TITLE
Adding an isolated function deserialization checking mechanism.

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -50,6 +50,7 @@ class FuncXClient(FuncXErrorHandlingClient):
                  openid_authorizer=None,
                  funcx_service_address='https://api2.funcx.org/v2',
                  check_endpoint_version=False,
+                 use_offprocess_checker=True,
                  **kwargs):
         """
         Initialize the client
@@ -79,10 +80,16 @@ class FuncXClient(FuncXErrorHandlingClient):
             The address of the funcX web service to communicate with.
             Default: https://api.funcx.org/v2
 
+        use_offprocess_checker: Bool,
+            Use this option to disable the offprocess_checker in the FuncXSerializer used
+            by the client.
+            Default: True
+
         Keyword arguments are the same as for BaseClient.
 
         """
         self.func_table = {}
+        self.use_offprocess_checker = use_offprocess_checker
         self.funcx_home = os.path.expanduser(funcx_home)
 
         if not os.path.exists(self.TOKEN_DIR):
@@ -115,7 +122,7 @@ class FuncXClient(FuncXErrorHandlingClient):
                                           http_timeout=http_timeout,
                                           base_url=funcx_service_address,
                                           **kwargs)
-        self.fx_serializer = FuncXSerializer()
+        self.fx_serializer = FuncXSerializer(use_offprocess_checker=self.use_offprocess_checker)
 
         authclient = AuthClient(authorizer=openid_authorizer)
         user_info = authclient.oauth2_userinfo()

--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -28,6 +28,14 @@ class pickle_base64(fxPicker_shared):
 
 
 class code_dill_source(fxPicker_shared):
+    """ This method uses dill's getsource method to extract the function body and
+    then serializes it.
+
+    Code from interpretor/main        : Yes
+    Code from notebooks               : No
+    Works with mismatching py versions: Yes
+    Decorated fns                     : No
+    """
 
     _identifier = '04\n'
     _for_code = True
@@ -49,9 +57,13 @@ class code_dill_source(fxPicker_shared):
 
 
 class code_text_inspect(fxPicker_shared):
-    """ We use dill to get the source code out of the function object
-    and then exec the function body to load it in. The function object
-    is then returned by name.
+    """ This method uses the inspect library to extract the function body and
+    then serializes it.
+
+    Code from interpretor/main        : ?
+    Code from notebooks               : Yes
+    Works with mismatching py versions: Yes
+    Decorated fns                     : No
     """
 
     _identifier = '03\n'
@@ -74,7 +86,12 @@ class code_text_inspect(fxPicker_shared):
 
 
 class code_dill(fxPicker_shared):
-    """ We use dill to serialize the function object
+    """ This method uses dill to directly serialize a function.
+
+    Code from interpretor/main        : No
+    Code from notebooks               : Yes
+    Works with mismatching py versions: No
+    Decorated fns                     : Yes
     """
 
     _identifier = '01\n'
@@ -94,6 +111,15 @@ class code_dill(fxPicker_shared):
 
 
 class code_pickle(fxPicker_shared):
+    """ This method uses pickle to directly serialize a function.
+    Could be deprecated in favor of just using dill, but pickle is a little bit
+    faster.
+
+    Code from interpretor/main        : No
+    Code from notebooks               : Yes
+    Works with mismatching py versions: No
+    Decorated fns                     : Yes
+    """
 
     _identifier = '02\n'
     _for_code = True
@@ -113,15 +139,3 @@ class code_pickle(fxPicker_shared):
 
 def bar(x, y={'a': 3}):
     return x * y['a']
-
-
-if __name__ == '__main__':
-
-    bar(29)
-    # print(pickle_base64.identifier)
-    ct = code_text_inspect()
-    f = ct.serialize(bar)
-    # print("Serialized : ", f)
-    new_bar = ct.deserialize(f)
-    print("After deserialization : ", new_bar)
-    print("FN() : ", new_bar(10))

--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -135,7 +135,3 @@ class code_pickle(fxPicker_shared):
         chomped = self.chomp(payload)
         data = pickle.loads(codecs.decode(chomped.encode(), 'base64'))
         return data
-
-
-def bar(x, y={'a': 3}):
-    return x * y['a']

--- a/funcx_sdk/funcx/serialize/facade.py
+++ b/funcx_sdk/funcx/serialize/facade.py
@@ -61,6 +61,8 @@ class FuncXSerializer(object):
                         _, port = line.strip().split(':')
                         port = int(port)
                         return port
+                    elif 'CRITICAL ERROR' in line:
+                        raise Exception(line)
 
         raise Exception("Failed to determine off_process_checker's port")
 

--- a/funcx_sdk/funcx/serialize/facade.py
+++ b/funcx_sdk/funcx/serialize/facade.py
@@ -1,7 +1,12 @@
+import atexit
+import multiprocessing as mp
+import subprocess
+import uuid
+import time
 from funcx.serialize.concretes import *
 from funcx.serialize.base import METHODS_MAP_DATA, METHODS_MAP_CODE
+from funcx.serialize.off_process_checker import OffProcessClient
 import logging
-
 logger = logging.getLogger(__name__)
 
 
@@ -9,13 +14,28 @@ class FuncXSerializer(object):
     """ Wraps several serializers for one uniform interface
     """
 
-    def __init__(self):
+    def __init__(self, use_offprocess_checker=False):
         """ Instantiate the appropriate classes
         """
 
         # Do we want to do a check on header size here ? Probably overkill
         headers = list(METHODS_MAP_CODE.keys()) + list(METHODS_MAP_DATA.keys())
         self.header_size = len(headers[0])
+        self.use_offprocess_checker = use_offprocess_checker
+
+        if self.use_offprocess_checker:
+            self.serialize_lock = mp.Lock()
+
+            logger.debug("Starting off_process_checker")
+            try:
+                port = self._start_off_process_checker()
+            except Exception:
+                logger.exception("Off_process_checker instantiation failed")
+                self.use_offprocess_checker = False
+            else:
+                self.off_proc_client = OffProcessClient(port)
+                self.off_proc_client.connect()
+                atexit.register(self.cleanup)
 
         self.methods_for_code = {}
         self.methods_for_data = {}
@@ -25,8 +45,56 @@ class FuncXSerializer(object):
         for key in METHODS_MAP_DATA:
             self.methods_for_data[key] = METHODS_MAP_DATA[key]()
 
+    def _start_off_process_checker(self):
+        """ Kicks off off_process_checker using subprocess and returns the port on which it
+        is listening.
+        """
+        std_file = f'/tmp/{uuid.uuid4()}'
+        logger.debug(f"Writing off_process_checker logs to: {std_file}")
+        std_out = open(std_file, 'w')
+        self.serialize_proc = subprocess.Popen(['off_process_checker.py'], stdout=std_out, stderr=subprocess.STDOUT)
+        with open(std_file) as f:
+            for i in range(200, 3000, 200):
+                time.sleep(i / 100)  # Sleep incrementally waiting for process start
+                for line in f.readlines():
+                    if 'BINDING TO' in line:
+                        _, port = line.strip().split(':')
+                        port = int(port)
+                        return port
+
+        raise Exception("Failed to determine off_process_checker's port")
+
     def _list_methods(self):
         return self.methods_for_code, self.methods_for_data
+
+    def cleanup(self):
+        logger.debug("Cleaning up")
+        if self.use_offprocess_checker:
+            self.off_proc_client.close()
+            self.serialize_proc.terminate()
+
+    def deserialize_check(self, serialized_msg, timeout=1):
+        """
+        Parameters
+        ----------
+        serialized_msg
+
+        timeout : int
+           timeout in seconds to wait for result
+        """
+        if not self.use_offprocess_checker:
+            return False
+
+        with self.serialize_lock:
+            status, info = self.off_proc_client.send_recv(serialized_msg)
+
+            if status == 'SUCCESS':
+                return True
+            if status == 'PONG':
+                return status
+            else:
+                logger.exception("Got exception while attempting deserialization")
+                raise Exception(info)
 
     def serialize(self, data):
         serialized = None
@@ -37,8 +105,9 @@ class FuncXSerializer(object):
             for method in self.methods_for_code.values():
                 try:
                     serialized = method.serialize(data)
+                    self.deserialize_check(serialized)
                 except Exception as e:
-                    logger.exception("Method {} did not work".format(method))
+                    logger.debug(f"[NON-CRITICAL] Method {method} failed with exception: {e}")
                     last_exception = e
                     continue
                 else:

--- a/funcx_sdk/funcx/serialize/facade.py
+++ b/funcx_sdk/funcx/serialize/facade.py
@@ -61,7 +61,7 @@ class FuncXSerializer(object):
                         _, port = line.strip().split(':')
                         port = int(port)
                         return port
-                    elif 'CRITICAL ERROR' in line:
+                    elif 'OFF_PROCESS_CHECKER FAILURE' in line:
                         raise Exception(line)
 
         raise Exception("Failed to determine off_process_checker's port")

--- a/funcx_sdk/funcx/serialize/facade.py
+++ b/funcx_sdk/funcx/serialize/facade.py
@@ -30,7 +30,7 @@ class FuncXSerializer(object):
             try:
                 port = self._start_off_process_checker()
             except Exception:
-                logger.exception("Off_process_checker instantiation failed")
+                logger.exception("[NON-CRITICAL] Off_process_checker instantiation failed. Continuing...")
                 self.use_offprocess_checker = False
             else:
                 self.off_proc_client = OffProcessClient(port)

--- a/funcx_sdk/funcx/serialize/off_process_checker.py
+++ b/funcx_sdk/funcx/serialize/off_process_checker.py
@@ -17,7 +17,6 @@ def server(port=0, host='', debug=False, datasize=102400):
         s.listen(1)
         conn, addr = s.accept()  # we only expect one incoming connection here.
         with conn:
-            print('Connected by', addr)
             while True:
 
                 b_msg = conn.recv(datasize)
@@ -28,11 +27,10 @@ def server(port=0, host='', debug=False, datasize=102400):
                 msg = pickle.loads(b_msg)
 
                 if msg == 'PING':
-                    ret_value = (('PING', None))
+                    ret_value = (('PONG', None))
                 else:
                     try:
-                        method = fxs.deserialize(msg)
-                        print("Deserialization result: ", method)
+                        method = fxs.deserialize(msg)  # noqa
                         del method
                     except Exception as e:
                         ret_value = (('DESERIALIZE_FAIL', str(e)))

--- a/funcx_sdk/funcx/serialize/off_process_checker.py
+++ b/funcx_sdk/funcx/serialize/off_process_checker.py
@@ -9,7 +9,7 @@ import pickle
 def server(port=0, host='', debug=False, datasize=102400):
 
     from funcx.serialize import FuncXSerializer
-    fxs = FuncXSerializer()
+    fxs = FuncXSerializer(use_offprocess_checker=False)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, port))
         bound_port = s.getsockname()[1]

--- a/funcx_sdk/funcx/serialize/off_process_checker.py
+++ b/funcx_sdk/funcx/serialize/off_process_checker.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import logging
+import socket
+import argparse
+import pickle
+
+
+def server(port=0, host='', debug=False, datasize=102400):
+
+    from funcx.serialize import FuncXSerializer
+    fxs = FuncXSerializer()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, port))
+        bound_port = s.getsockname()[1]
+        print(f"BINDING TO:{bound_port}", flush=True)
+        s.listen(1)
+        conn, addr = s.accept()  # we only expect one incoming connection here.
+        with conn:
+            print('Connected by', addr)
+            while True:
+
+                b_msg = conn.recv(datasize)
+                if not b_msg:
+                    print("Exiting")
+                    return
+
+                msg = pickle.loads(b_msg)
+
+                if msg == 'PING':
+                    ret_value = (('PING', None))
+                else:
+                    try:
+                        method = fxs.deserialize(msg)
+                        print("Deserialization result: ", method)
+                        del method
+                    except Exception as e:
+                        ret_value = (('DESERIALIZE_FAIL', str(e)))
+
+                    else:
+                        ret_value = (('SUCCESS', None))
+
+                ret_buf = pickle.dumps(ret_value)
+                conn.sendall(ret_buf)
+
+
+class OffProcessClient(object):
+
+    def __init__(self, port, host='', debug=False, datasize=102400):
+
+        self.port = port
+        self.host = host
+        self.debug = debug
+        self.datasize = datasize
+        self.socket = None
+
+    def connect(self):
+        if self.socket:
+            raise Exception("Socket already exists")
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.connect((self.host, self.port))
+
+    def send_recv(self, buf):
+        self.socket.sendall(pickle.dumps(buf))
+        ret_buf = self.socket.recv(self.datasize)
+        ret = pickle.loads(ret_buf)
+        return ret
+
+    def close(self):
+        if self.socket:
+            self.socket.close()
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--url", default='')
+    parser.add_argument("-p", "--port", default='0',
+                        help="Port over which the client can reach the server. Default= auto-pick")
+    parser.add_argument("-d", "--debug", action='store_true',
+                        help="Count of apps to launch")
+    parser.add_argument("-c", "--client", action='store_true',
+                        help="Launch the client instead of the server for testing")
+    args = parser.parse_args()
+
+    if args.client:
+        # For test/debug only
+        client = OffProcessClient(int(args.port), host=args.url, debug=args.debug)
+        client.connect()
+        for i in range(100):
+            x = client.send_recv('PING')
+
+    else:
+        server(int(args.port), host=args.url, debug=args.debug)

--- a/funcx_sdk/funcx/tests/test_fn_serialization.py
+++ b/funcx_sdk/funcx/tests/test_fn_serialization.py
@@ -61,3 +61,37 @@ def test_nested_scope_function(fxc, endpoint):
             time.sleep(2)
         else:
             break
+
+
+def increment_decorator(func):
+    def wrapper(*args, **kwargs):
+        x = func(*args, **kwargs)
+        return x + 1
+    return wrapper
+
+
+@increment_decorator
+def double(x):
+    return x * 2
+
+
+def test_decorated_function(fxc, endpoint):
+
+    x = 42
+    fn_uuid = fxc.register_function(double, endpoint, description='platinfo')
+    task_id = fxc.run(x,
+                      endpoint_id=endpoint,
+                      function_id=fn_uuid)
+
+    print("Task_id: ", task_id)
+
+    for i in range(5):
+        try:
+            r = fxc.get_result(task_id)
+            print(f"result : {r}")
+        except Exception:
+            time.sleep(2)
+        else:
+            break
+
+    assert r == double(x), "Results don't match"

--- a/funcx_sdk/funcx/tests/test_param_serialization.py
+++ b/funcx_sdk/funcx/tests/test_param_serialization.py
@@ -30,6 +30,8 @@ def test_params(fxc, endpoint, param):
         try:
             r = fxc.get_result(task_id)
             print(f"result : {r}")
+
+        # This is pretty terrible, until we fix the exception to differentiate TypeError
         except Exception:
             time.sleep(2)
         else:

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -25,6 +25,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering"
     ],
+    scripts=["funcx/serialize/off_process_checker.py"],
     keywords=[
         "funcX",
         "FaaS",


### PR DESCRIPTION
This change adds:
* off_process_checker.py: A subprocess'ed server that attempts
    deserialization in a clean isolated env and reports success/fail
* Updates to concretes.py to prioritize source based fn serialization
    methods that are cross-python-version reliable
* Updates to facade.py to launch the off_process_checker as a subprocess
    and send it fn's over a socket protected with a mutex. The checker will
    print the port it's listening to on a file.
* Adding off_process_checker as an installed script to setup.py

Needs testing code that I'm in the process of cleaning up to add onto this branch.