### PR TITLE
Don't put killer task status in task delta message from manager

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -418,7 +418,7 @@ class Manager(object):
                             to_send = [worker_id, pickle.dumps(task.task_id), pickle.dumps(task.container_id), task.pack()]
                             self.funcx_task_socket.send_multipart(to_send)
                             self.worker_map.update_worker_idle(task_type)
-                            if task.task_id != pickle.dumps(b"KILL"):
+                            if task.task_id != "KILL":
                                 logger.debug(f"Set task {task.task_id} to RUNNING")
                                 self.task_status_deltas[task.task_id] = TaskStatusCode.RUNNING
                             logger.debug("Sending complete!")


### PR DESCRIPTION
This is to fix a small issue in #462 , where the killer task status is reported in task delta from manager to interchange.