### PR TITLE
Refactored funcx-manager, and updated unit test

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -278,7 +278,7 @@ class Manager(object):
             socks = dict(self.poller.poll(timeout=poll_timer))
 
             if self.funcx_task_socket in socks and socks[self.funcx_task_socket] == zmq.POLLIN:
-                _ = self.poll_funcx_task_socket(task_done_counter)
+                _, task_done_counter = self.poll_funcx_task_socket(task_done_counter)
 
             # Spin up any new workers according to the worker queue.
             # Returns the total number of containers that have spun up.
@@ -427,7 +427,7 @@ class Manager(object):
                 logger.debug(f"[WORKER_REMOVE] Removing worker {w_id} process object")
                 logger.debug(f"[WORKER_REMOVE] Worker processes: {self.worker_procs}")
 
-            return pickle.loads(message)
+            return pickle.loads(message), task_done_counter
 
         except Exception as e:
             logger.exception("[TASK_PULL_THREAD] FUNCX : caught {}".format(e))

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -48,18 +48,15 @@ class TestManager:
         manager.worker_procs.update(worker)
         assert len(manager.worker_procs) == 1
 
-        task_done_count = 0
-        reg_info, task_done_count = manager.poll_funcx_task_socket(task_done_count)
+        reg_info = manager.poll_funcx_task_socket(test=True)
         assert reg_info['worker_id'] == '0'
         assert reg_info['worker_type'] == 'RAW'
-        assert task_done_count == 0
 
         # Begin testing removing worker process
         task_type = "RAW"
         manager.remove_worker_init(task_type)
         manager.send_task_to_worker(task_type)
 
-        reg_info, task_done_count = manager.poll_funcx_task_socket(task_done_count)
-        assert reg_info is None
+        remove_info = manager.poll_funcx_task_socket(test=True)
+        assert remove_info is None
         assert len(manager.worker_procs) == 0
-        assert task_done_count == 0

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -49,7 +49,7 @@ class TestManager:
         assert len(manager.worker_procs) == 1
 
         task_done_count = 0
-        reg_info = manager.poll_funcx_task_socket(task_done_count)
+        reg_info, _ = manager.poll_funcx_task_socket(task_done_count)
         assert reg_info['worker_id'] == '0'
         assert reg_info['worker_type'] == 'RAW'
 
@@ -58,6 +58,6 @@ class TestManager:
         manager.remove_worker_init(task_type)
         manager.send_task_to_worker(task_type)
 
-        reg_info = manager.poll_funcx_task_socket(task_done_count)
+        reg_info, _ = manager.poll_funcx_task_socket(task_done_count)
         assert reg_info is None
         assert len(manager.worker_procs) == 0

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -49,15 +49,17 @@ class TestManager:
         assert len(manager.worker_procs) == 1
 
         task_done_count = 0
-        reg_info, _ = manager.poll_funcx_task_socket(task_done_count)
+        reg_info, task_done_count = manager.poll_funcx_task_socket(task_done_count)
         assert reg_info['worker_id'] == '0'
         assert reg_info['worker_type'] == 'RAW'
+        assert task_done_count == 0
 
         # Begin testing removing worker process
         task_type = "RAW"
         manager.remove_worker_init(task_type)
         manager.send_task_to_worker(task_type)
 
-        reg_info, _ = manager.poll_funcx_task_socket(task_done_count)
+        reg_info, task_done_count = manager.poll_funcx_task_socket(task_done_count)
         assert reg_info is None
         assert len(manager.worker_procs) == 0
+        assert task_done_count == 0

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_funcx_manager.py
@@ -48,30 +48,16 @@ class TestManager:
         manager.worker_procs.update(worker)
         assert len(manager.worker_procs) == 1
 
-        # Manager::pull_tasks()
-        poller = zmq.Poller()
-        poller.register(manager.funcx_task_socket, zmq.POLLIN)
-
-        # Manager::pull_tasks()
-        # We want to catch the worker's registration message
-        w_id, m_type, message = manager.funcx_task_socket.recv_multipart()
-        reg_info = pickle.loads(message)
+        task_done_count = 0
+        reg_info = manager.poll_funcx_task_socket(task_done_count)
         assert reg_info['worker_id'] == '0'
         assert reg_info['worker_type'] == 'RAW'
-        manager.worker_map.register_worker(w_id, reg_info['worker_type'])
 
         # Begin testing removing worker process
-        manager.remove_worker_init("RAW")
-        task = manager.task_queues["RAW"].get()
-        worker_id = manager.worker_map.get_worker("RAW")
-        to_send = [worker_id, pickle.dumps(task.task_id), pickle.dumps(task.container_id), task.pack()]
-        manager.funcx_task_socket.send_multipart(to_send)
+        task_type = "RAW"
+        manager.remove_worker_init(task_type)
+        manager.send_task_to_worker(task_type)
 
-        # We want to catch the worker's response to the remove message
-        w_id, m_type, message = manager.funcx_task_socket.recv_multipart()
-        assert m_type == b'WRKR_DIE'
-        assert pickle.loads(message) is None
-
-        manager.worker_map.remove_worker(w_id)
-        manager.worker_procs.pop(w_id.decode())
+        reg_info = manager.poll_funcx_task_socket(task_done_count)
+        assert reg_info is None
         assert len(manager.worker_procs) == 0


### PR DESCRIPTION
From the unit test of PR#462, we noticed the funcx-manager needs to be refactored to avoid code duplication and manual zmq handling. This PR refactored the funcx-manager by wrapping the functionalities of polling funcx task socket and sending task to workers. The unit test from PR#462 is also updated.