### PR TITLE
Adding a new exception class TaskPending

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -14,7 +14,7 @@ from funcx.serialize import FuncXSerializer
 # from funcx.sdk.utils.futures import FuncXFuture
 from funcx.sdk.error_handling_client import FuncXErrorHandlingClient
 from funcx.sdk.utils.batch import Batch
-from funcx.utils.errors import FailureResponse, VersionMismatch, SerializationError
+from funcx.utils.errors import FailureResponse, VersionMismatch, SerializationError, TaskPending
 from funcx.utils.handle_service_response import handle_response_errors
 
 try:
@@ -249,7 +249,7 @@ class FuncXClient(FuncXErrorHandlingClient):
         """
         task = self.get_task(task_id)
         if task['pending'] is True:
-            raise Exception(task['status'])
+            raise TaskPending(task['status'])
         else:
             if 'result' in task:
                 return task['result']

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -111,3 +111,14 @@ class InvalidScopeException(FuncxError):
 
     def __repr__(self):
         return "Invalid Scope: {}".format(self.message)
+
+
+class TaskPending(FuncxError):
+    """Task is pending and no result is available yet
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __repr__(self):
+        return "TaskPending due to {self.reason}"

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -121,4 +121,4 @@ class TaskPending(FuncxError):
         self.reason = reason
 
     def __repr__(self):
-        return "TaskPending due to {self.reason}"
+        return "Task is pending due to {self.reason}"


### PR DESCRIPTION
# Description

Adds a new exception class `TaskPending` when a blocking call to `client.get_result()` is made for a task that is pending.

Fixes #489 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

I need to add a test for this.
