### PR TITLE
Enable endpoint status report to send to forwarder

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -500,7 +500,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
 
                 elif isinstance(msgs, EPStatusReport):
                     logger.info("[MTHREAD] Received EPStatusReport {}".format(msgs))
-                    if self.passthrough and False:
+                    if self.passthrough:
                         self.results_passthrough.put(msgs)
 
                 else:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -501,7 +501,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                 elif isinstance(msgs, EPStatusReport):
                     logger.info("[MTHREAD] Received EPStatusReport {}".format(msgs))
                     if self.passthrough:
-                        self.results_passthrough.put(msgs)
+                        self.results_passthrough.put(pickle.dumps(msgs))
 
                 else:
                     logger.debug("[MTHREAD] Unpacking results")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -499,7 +499,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                     return
 
                 elif isinstance(msgs, EPStatusReport):
-                    logger.info("[MTHREAD] Received EPStatusReport {}".format(msgs))
+                    logger.debug("[MTHREAD] Received EPStatusReport {}".format(msgs))
                     if self.passthrough:
                         self.results_passthrough.put(pickle.dumps(msgs))
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -497,11 +497,11 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                 if msgs is None:
                     logger.debug("[MTHREAD] Got None, exiting")
                     return
+
                 elif isinstance(msgs, EPStatusReport):
-                    logger.debug("[MTHREAD] Received EPStatusReport")
-                    # TODO:YADU We are not propagating task status reports
-                    # if len(msgs.task_statuses):
-                    #    self.task_status_queue.put(msgs.task_statuses)
+                    logger.info("[MTHREAD] Received EPStatusReport {}".format(msgs))
+                    if self.passthrough and False:
+                        self.results_passthrough.put(msgs)
 
                 else:
                     logger.debug("[MTHREAD] Unpacking results")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -515,13 +515,13 @@ class Interchange(object):
         logger.debug("[STATUS] Status reporting loop starting")
 
         while not kill_event.is_set():
-            logger.info(f"Endpoint id : {self.endpoint_id}, {type(self.endpoint_id)}")
+            logger.debug(f"Endpoint id : {self.endpoint_id}, {type(self.endpoint_id)}")
             msg = EPStatusReport(
                 self.endpoint_id,
                 self.get_status_report(),
                 self.task_status_deltas
             )
-            logger.debug("[STATUS] Sending status report to forwarder, and clearing task deltas.")
+            logger.info("[STATUS] Sending status report to executor, and clearing task deltas.")
             status_report_queue.put(msg.pack())
             self.task_status_deltas.clear()
             time.sleep(self.heartbeat_period)
@@ -756,7 +756,7 @@ class Interchange(object):
             # Send status reports from this main thread to avoid thread-safety on zmq sockets
             try:
                 packed_status_report = status_report_queue.get(block=False)
-                logger.debug(f"[MAIN] forwarding status report queue: {packed_status_report}")
+                logger.info(f"[MAIN] forwarding status report: {packed_status_report}")
                 self.results_outgoing.send(packed_status_report)
             except queue.Empty:
                 pass

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -521,7 +521,7 @@ class Interchange(object):
                 self.get_status_report(),
                 self.task_status_deltas
             )
-            logger.info("[STATUS] Sending status report to executor, and clearing task deltas.")
+            logger.debug("[STATUS] Sending status report to executor, and clearing task deltas.")
             status_report_queue.put(msg.pack())
             self.task_status_deltas.clear()
             time.sleep(self.heartbeat_period)
@@ -756,7 +756,7 @@ class Interchange(object):
             # Send status reports from this main thread to avoid thread-safety on zmq sockets
             try:
                 packed_status_report = status_report_queue.get(block=False)
-                logger.info(f"[MAIN] forwarding status report: {packed_status_report}")
+                logger.debug(f"[MAIN] forwarding status report: {packed_status_report}")
                 self.results_outgoing.send(packed_status_report)
             except queue.Empty:
                 pass


### PR DESCRIPTION
# Description

This PR fixes the endpoint status report, which was disabled in funcx-endpoint 0.2.X.

fix #444 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
