### PR TITLE
Fixed endpoint restart cli

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -125,8 +125,8 @@ def stop_endpoint(name: str = typer.Argument("default", autocompletion=complete_
 @app.command(name="restart")
 def restart_endpoint(name: str = typer.Argument("default", autocompletion=complete_endpoint_name)):
     """Restarts an endpoint"""
-    manager.stop_endpoint(name)
-    manager.start_endpoint(name)
+    stop_endpoint(name)
+    start_endpoint(name)
 
 
 @app.command(name="list")


### PR DESCRIPTION
As Issue #488 described, `funcx-endpoint restart` cli did not work properly, because when its call to the `EndpointManager` lacks two (2) parameters. This PR fixes the issue.