### PR TITLE
Fix typer autocomplete in funcx-endpoint

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -42,7 +42,10 @@ def version_callback(value):
 
 
 def complete_endpoint_name():
-    config_files = glob.glob(os.path.join(manager.funcx_dir, '*', 'config.py'))
+    # Manager context is not initialized at this point, so we assume the default
+    # the funcx_dir path of ~/.funcx
+    funcx_dir = os.path.join(pathlib.Path.home(), '.funcx')
+    config_files = glob.glob(os.path.join(funcx_dir, '*', 'config.py'))
     for config_file in config_files:
         yield os.path.basename(os.path.dirname(config_file))
 


### PR DESCRIPTION
# Description

As reported in #496, the typer autocomplete function relied on a non-existent manager context to come up with autocomplete responses. This PR sets the default funcx_dir to `<USERHOME/.funcx` and the autocomplete methods now work.

Now, when you press tab on the endpoint string in `funcx-endpoint start test_`, you get this:
```
(funcx_py3.7) yadu@borgmachine:/tmp/funcx$ funcx-endpoint start test_
backup             default            test_1             test_10            test_2             test_3             test_4             testing_local_dev  ws_test_1          
(funcx_py3.7) yadu@borgmachine:/tmp/funcx$ funcx-endpoint start test_10

(funcx_py3.7) yadu@borgmachine:/tmp/funcx$ funcx-endpoint stop def
backup             default            test_1             test_10 
```
Fixes #496 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
