### PR TITLE
Enforce a limit of result size on the worker side

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -49,7 +49,7 @@ class FuncXWorker(object):
 
     result_size_limit : int
      Maximum result size allowed in Bytes
-     Default = 10 MB == 2**20 Bytes
+     Default = 10 MB == 10 * (2**20) Bytes
 
 
     Funcx worker will use the REP sockets to:
@@ -58,7 +58,7 @@ class FuncXWorker(object):
          send(result)
     """
 
-    def __init__(self, worker_id, address, port, logdir, debug=False, worker_type='RAW', result_size_limit=2 ** 20):
+    def __init__(self, worker_id, address, port, logdir, debug=False, worker_type='RAW', result_size_limit=10 * (2 ** 20)):
 
         self.worker_id = worker_id
         self.address = address

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -1,0 +1,49 @@
+from funcx.sdk.client import FuncXClient
+import argparse
+import pytest
+import time
+from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
+
+
+def large_result_producer(size) -> str:
+    return bytearray(size)
+
+
+def wait_for_task(fxc, task_id, walltime: int = 2):
+    import time
+    start = time.time()
+    while True:
+        if time.time() > start + walltime:
+            raise Exception("Timeout")
+        try:
+            r = fxc.get_result(task_id)
+        except Exception:
+            print("Not available yet")
+            time.sleep(1)
+        else:
+            return r
+
+
+def test_large_result(fxc, endpoint, size=(2 ** 21)):
+    fn_uuid = fxc.register_function(large_result_producer, endpoint, description='LargeResultProducer')
+    task_id = fxc.run(size,  # This is the current result size limit
+                      endpoint_id=endpoint,
+                      function_id=fn_uuid)
+
+    print("Task_id: ", task_id)
+    # Replace the stupid sleep
+    time.sleep(5)
+    with pytest.raises(MaxResultSizeExceeded):
+        fxc.get_result(task_id)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-e", "--endpoint_id", required=True)
+    args = parser.parse_args()
+
+    fxc = FuncXClient()
+    endpoint = args.endpoint_id
+    test_large_result(fxc, endpoint, 2**10)
+    test_large_result(fxc, endpoint, 2**21)

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -46,4 +46,4 @@ if __name__ == '__main__':
     fxc = FuncXClient()
     endpoint = args.endpoint_id
     test_large_result(fxc, endpoint, 2**10)
-    test_large_result(fxc, endpoint, 2**21)
+    test_large_result(fxc, endpoint, 11 * (2**20))  # 11 MB exceeds the limit

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -24,7 +24,7 @@ def wait_for_task(fxc, task_id, walltime: int = 2):
             return r
 
 
-def test_large_result(fxc, endpoint, size=(2 ** 21)):
+def test_large_result(fxc, endpoint, size=(11 * (2 ** 20))):
     fn_uuid = fxc.register_function(large_result_producer, endpoint, description='LargeResultProducer')
     task_id = fxc.run(size,  # This is the current result size limit
                       endpoint_id=endpoint,


### PR DESCRIPTION
# Description

Please refer to #494. This PR adds a result size limit of 10MB. The worker will raise a `MaxResultSizeExceeded` exception
when it finds an object that exceeds this limit. Test included. Here's a snippet of the exception message that is now produced:

```
Task_id:  15735a5b-3e22-4cfa-bc0f-46cd3853e9cf
Got exception  Task result of 2833101B exceeded current limit of 1048576B
Traceback (most recent call last):
  File "test_result_size.py", line 53, in <module>
    test_large_result(fxc, endpoint, 2**21)
  File "test_result_size.py", line 35, in test_large_result
    r = fxc.get_result(task_id)
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/funcx/sdk/client.py", line 258, in get_result
    task['exception'].reraise()
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/parsl/app/errors.py", line 131, in reraise
    reraise(t, v, tb)
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/six.py", line 702, in reraise
    raise value.with_traceback(tb)
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/funcx_endpoint/executors/high_throughput/funcx_worker.py", line 140, in start
    self.result_size_limit)
funcx_endpoint.executors.high_throughput.funcx_worker.MaxResultSizeExceeded: Task result of 2833101B exceeded current limit of 1048576B

```

Fixes #494 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
