### PR TITLE
Point release v0.2.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Documentation: https://funcx.readthedocs.io/en/latest/
 Quickstart
 ==========
 
-funcX is in a beta state with version `0.2.2` currently available on PyPI.
+funcX is in a beta state with version `0.2.3` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 funcx & funcx-endpoint v0.2.3
 -----------------------------
 
-Released on May 20th, 2021
+Released on May 19th, 2021
 
 funcx v0.2.3 is a minor release that includes contributions (code, tests, reviews, and reports) from:
 Ben Galewsky <ben@peartreestudio.net>, Ryan Chard <rchard@anl.gov>, Weinan Si <siweinan@gmail.com>,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 **funcX** is currently in Alpha and early testing releases are available on `PyPI <https://pypi.org/project/funcx/>`_.
 
-The latest version available on PyPI is ``v0.2.2``.
+The latest version available on PyPI is ``v0.2.3``.
 
 You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/funcx/master?filepath=examples%2FTutorial.ipynb>`_
 

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.2.2
+funcx>=0.2.3
 pyzmq>=22.0.0
 retry

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
# Description

This PR bumps the versions to `funcx==0.2.3` and `funcx-endpoint==0.2.3`.
To keep `funcx-endpoint` in sync, it now requires `funcx>=0.2.3`.

## Type of change

- New feature (non-breaking change that adds functionality)