### PR TITLE
Adding f-string option to make the exception message format the varia…

### DIFF
--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -121,4 +121,4 @@ class TaskPending(FuncxError):
         self.reason = reason
 
     def __repr__(self):
-        return "Task is pending due to {self.reason}"
+        return f"Task is pending due to {self.reason}"


### PR DESCRIPTION
# Description

PR #490 Added a new TaskPending exception with an repr string that missed the f-string prefix.
This is preventing proper formatting of the TaskPending messages.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)