### PR TITLE
Fixed exception handling for python version mismatch

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -522,7 +522,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                             # TODO: This could be handled better we are essentially shutting down the
                             # client with little indication to the user.
                             logger.warning("[MTHREAD] Executor shutting down due to version mismatch in interchange")
-                            self._executor_exception, _ = fx_serializer.deserialize(msg['exception'])
+                            self._executor_exception = fx_serializer.deserialize(msg['exception'])
                             logger.exception("[MTHREAD] Exception: {}".format(self._executor_exception))
                             # Set bad state to prevent new tasks from being submitted
                             self._executor_bad_state.set()


### PR DESCRIPTION
As described in Issue#486, when manager has an incompatible version with the interchange, it triggers
```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/site-packages/funcx_endpoint/executors/high_throughput/executor.py", line 525, in _queue_management_worker
    self._executor_exception, _ = fx_serializer.deserialize(msg['exception'])
TypeError: cannot unpack non-iterable ManagerLost object
```
This PR fixes the issue.