### PR TITLE
Do NOT merge: Multiprocessing issue on macos with python3.8 and python3.9

### DIFF
--- a/funcx_endpoint/funcx_endpoint/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/__init__.py
@@ -2,3 +2,8 @@ from funcx_endpoint.version import VERSION
 
 __author__ = "The funcX team"
 __version__ = VERSION
+
+import platform
+import multiprocessing
+if platform.system() == 'Darwin':
+    multiprocessing.set_start_method('fork', force=True)

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -13,7 +13,7 @@ import queue
 import pickle
 import daemon
 import uuid
-from multiprocessing import Process
+from funcx_endpoint.executors.high_throughput.mac_safe_process import mpProcess
 from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 
 from funcx_endpoint.executors.high_throughput.messages import HeartbeatReq, EPStatusReport, Heartbeat
@@ -377,38 +377,38 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         """
         comm_q = mpQueue(maxsize=10)
         print(f"Starting local interchange with endpoint id: {self.endpoint_id}")
-        self.queue_proc = Process(target=interchange.starter,
-                                  args=(comm_q,),
-                                  kwargs={"client_address": self.address,
-                                          "client_ports": (self.outgoing_q.port,
-                                                           self.incoming_q.port,
-                                                           self.command_client.port),
-                                          "provider": self.provider,
-                                          "strategy": self.strategy,
-                                          "poll_period": self.poll_period,
-                                          "heartbeat_period": self.heartbeat_period,
-                                          "heartbeat_threshold": self.heartbeat_threshold,
-                                          "working_dir": self.working_dir,
-                                          "worker_debug": self.worker_debug,
-                                          "max_workers_per_node": self.max_workers_per_node,
-                                          "mem_per_worker": self.mem_per_worker,
-                                          "cores_per_worker": self.cores_per_worker,
-                                          "prefetch_capacity": self.prefetch_capacity,
-                                          # "log_max_bytes": self.log_max_bytes,
-                                          # "log_backup_count": self.log_backup_count,
-                                          "scheduler_mode": self.scheduler_mode,
-                                          "worker_mode": self.worker_mode,
-                                          "container_type": self.container_type,
-                                          "container_cmd_options": self.container_cmd_options,
-                                          "funcx_service_address": self.funcx_service_address,
-                                          "interchange_address": self.address,
-                                          "worker_ports": self.worker_ports,
-                                          "worker_port_range": self.worker_port_range,
-                                          "logdir": os.path.join(self.run_dir, self.label),
-                                          "suppress_failure": self.suppress_failure,
-                                          "endpoint_id": self.endpoint_id,
-                                          "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
-                                  },
+        self.queue_proc = mpProcess(target=interchange.starter,
+                                    args=(comm_q,),
+                                    kwargs={"client_address": self.address,
+                                            "client_ports": (self.outgoing_q.port,
+                                                             self.incoming_q.port,
+                                                             self.command_client.port),
+                                            "provider": self.provider,
+                                            "strategy": self.strategy,
+                                            "poll_period": self.poll_period,
+                                            "heartbeat_period": self.heartbeat_period,
+                                            "heartbeat_threshold": self.heartbeat_threshold,
+                                            "working_dir": self.working_dir,
+                                            "worker_debug": self.worker_debug,
+                                            "max_workers_per_node": self.max_workers_per_node,
+                                            "mem_per_worker": self.mem_per_worker,
+                                            "cores_per_worker": self.cores_per_worker,
+                                            "prefetch_capacity": self.prefetch_capacity,
+                                            # "log_max_bytes": self.log_max_bytes,
+                                            # "log_backup_count": self.log_backup_count,
+                                            "scheduler_mode": self.scheduler_mode,
+                                            "worker_mode": self.worker_mode,
+                                            "container_type": self.container_type,
+                                            "container_cmd_options": self.container_cmd_options,
+                                            "funcx_service_address": self.funcx_service_address,
+                                            "interchange_address": self.address,
+                                            "worker_ports": self.worker_ports,
+                                            "worker_port_range": self.worker_port_range,
+                                            "logdir": os.path.join(self.run_dir, self.label),
+                                            "suppress_failure": self.suppress_failure,
+                                            "endpoint_id": self.endpoint_id,
+                                            "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
+                                    },
         )
         self.queue_proc.start()
         try:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_process.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_process.py
@@ -1,0 +1,5 @@
+import platform
+if platform.system() == 'Darwin':
+    from parsl.executors.high_throughput.mac_safe_process import MacSafeProcess as mpProcess
+else:
+    from multiprocessing import Process as mpProcess


### PR DESCRIPTION
As reported in #491 , launching funcx on macos with python3.8 and python3.9 would trigger the semaphore error message. We just worked on a project to fix the similar issue for parsl. This PR tries to use the solution from parsl, to make funcx fully work on macos.

The PR imports module from updated parsl. Before the parsl change can be picked up from pip, the change here will NOT work.

For now (before the parsl change is fully reflected in pip), to test the change here is working, we can do the following on a macos with python3.8 or python3.9 environment
1. Create a conda environment, e.g., `conda create --name funcx-py38 python=3.8`, and activate it.
2. From `funcx_sdk/requirements.txt`, remove `parsl>=1.1.0a0`.
3. Manually install parsl by `pip install git+https://github.com/Parsl/parsl.git@yrao2-macos-fork`.
4. Install funcx client and endpoint as usual by `pip install ./funcx_sdk` and `pip install ./funcx_endpoint`.
5. Configure and start an endpoint.
6. Submit a function against the endpoint.