### PR TITLE
Added an executor argument to print interchange log to console

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -175,12 +175,12 @@ class EndpointManager:
         # Create a daemon context
         # If we are running a full detached daemon then we will send the output to
         # log files, otherwise we can piggy back on our stdout
-        if endpoint_config.config.detach_endpoint:
-            stdout = open(os.path.join(endpoint_dir, endpoint_config.config.stdout), 'w+')
-            stderr = open(os.path.join(endpoint_dir, endpoint_config.config.stderr), 'w+')
-        else:
+        if endpoint_config.config.log_to_std_streams:
             stdout = sys.stdout
             stderr = sys.stderr
+        else:
+            stdout = open(os.path.join(endpoint_dir, endpoint_config.config.stdout), 'w+')
+            stderr = open(os.path.join(endpoint_dir, endpoint_config.config.stderr), 'w+')
 
         try:
             context = daemon.DaemonContext(working_directory=endpoint_dir,
@@ -189,7 +189,7 @@ class EndpointManager:
                                                os.path.join(endpoint_dir, 'daemon.pid')),
                                            stdout=stdout,
                                            stderr=stderr,
-                                           detach_process=endpoint_config.config.detach_endpoint)
+                                           detach_process=True)
 
         except Exception:
             self.logger.exception("Caught exception while trying to setup endpoint context dirs")

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -35,10 +35,9 @@ class Config(RepresentationMixin):
         Path where the endpoint's stderr should be written
         Default: ./interchange.stderr
 
-    detach_endpoint : Bool
-        Should the endpoint deamon be run as a detached process? This is good for
-        a real edge node, but an anti-pattern for kubernetes pods
-        Default: True
+    log_to_std_streams : Bool
+        Should the endpoint log to standard streams (stdout and stderr)?
+        Default: False
 
     log_dir : str
         Optional path string to the top-level directory where logs should be written to.
@@ -56,7 +55,7 @@ class Config(RepresentationMixin):
                  # Tuning info
                  heartbeat_period=30,
                  heartbeat_threshold=120,
-                 detach_endpoint=True,
+                 log_to_std_streams=False,
 
                  # Logging info
                  log_dir=None,
@@ -72,7 +71,7 @@ class Config(RepresentationMixin):
         # Tuning info
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold
-        self.detach_endpoint = detach_endpoint
+        self.log_to_std_streams = log_to_std_streams
 
         # Logging info
         self.log_dir = log_dir

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -141,6 +141,10 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
     suppress_failure : Bool
         If set, the interchange will suppress failures rather than terminate early. Default: False
 
+    log_to_std_streams : Bool
+        If set, the interchange's log will go to standard streams. Otherwise,
+        it goes to log file. Default: False
+
     heartbeat_threshold : int
         Seconds since the last message from the counterpart in the communication pair:
         (interchange, manager) after which the counterpart is assumed to be un-available. Default:120s
@@ -224,7 +228,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  poll_period=10,
                  container_image=None,
                  suppress_failure=False,
-                 interchange_log_to_file=True,
+                 log_to_std_streams=False,
                  run_dir=None,
                  endpoint_id=None,
                  managed=True,
@@ -269,7 +273,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.heartbeat_period = heartbeat_period
         self.poll_period = poll_period
         self.suppress_failure = suppress_failure
-        self.interchange_log_to_file = interchange_log_to_file
+        self.log_to_std_streams = log_to_std_streams
         self.run_dir = run_dir
         self.queue_proc = None
         self.interchange_local = interchange_local
@@ -406,7 +410,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "interchange_address": self.address,
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
-                                          "interchange_log_to_file": self.interchange_log_to_file,
+                                          "log_to_std_streams": self.log_to_std_streams,
                                           "logdir": os.path.join(self.run_dir, self.label),
                                           "suppress_failure": self.suppress_failure,
                                           "endpoint_id": self.endpoint_id,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -224,6 +224,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  poll_period=10,
                  container_image=None,
                  suppress_failure=False,
+                 interchange_log_to_file=True,
                  run_dir=None,
                  endpoint_id=None,
                  managed=True,
@@ -268,6 +269,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.heartbeat_period = heartbeat_period
         self.poll_period = poll_period
         self.suppress_failure = suppress_failure
+        self.interchange_log_to_file = interchange_log_to_file
         self.run_dir = run_dir
         self.queue_proc = None
         self.interchange_local = interchange_local
@@ -404,6 +406,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "interchange_address": self.address,
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
+                                          "interchange_log_to_file": self.interchange_log_to_file,
                                           "logdir": os.path.join(self.run_dir, self.label),
                                           "suppress_failure": self.suppress_failure,
                                           "endpoint_id": self.endpoint_id,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -25,7 +25,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
 from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.sdk.client import FuncXClient
-from funcx import set_file_logger
+from funcx import set_file_logger, set_stream_logger
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import naive_interchange_task_dispatch
 from funcx.serialize import FuncXSerializer
 
@@ -122,6 +122,7 @@ class Interchange(object):
                  cores_per_worker=1.0,
                  worker_debug=False,
                  launch_cmd=None,
+                 interchange_log_to_file=True,
                  logdir=".",
                  logging_level=logging.INFO,
                  endpoint_id=None,
@@ -179,18 +180,22 @@ class Interchange(object):
         """
 
         self.logdir = logdir
-        os.makedirs(self.logdir, exist_ok=True)
 
         global logger
-        logger = set_file_logger(os.path.join(self.logdir, 'interchange.log'),
-                                 name="interchange",
-                                 level=logging_level,
-                                 max_bytes=log_max_bytes,
-                                 backup_count=log_backup_count)
+        if interchange_log_to_file:
+            os.makedirs(self.logdir, exist_ok=True)
 
-        logger.info("logger location {}, logger filesize: {}, logger backup count: {}".format(logger.handlers,
-                                                                                              log_max_bytes,
-                                                                                              log_backup_count))
+            logger = set_file_logger(os.path.join(self.logdir, 'interchange.log'),
+                                     name="interchange",
+                                     level=logging_level,
+                                     max_bytes=log_max_bytes,
+                                     backup_count=log_backup_count)
+
+            logger.info("logger location {}, logger filesize: {}, logger backup count: {}".format(logger.handlers,
+                                                                                                  log_max_bytes,
+                                                                                                  log_backup_count))
+        else:
+            logger = set_stream_logger(name="interchange", level=logging_level)
 
         logger.info("Initializing Interchange process with Endpoint ID: {}".format(endpoint_id))
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -122,7 +122,7 @@ class Interchange(object):
                  cores_per_worker=1.0,
                  worker_debug=False,
                  launch_cmd=None,
-                 interchange_log_to_file=True,
+                 log_to_std_streams=False,
                  logdir=".",
                  logging_level=logging.INFO,
                  endpoint_id=None,
@@ -182,7 +182,9 @@ class Interchange(object):
         self.logdir = logdir
 
         global logger
-        if interchange_log_to_file:
+        if log_to_std_streams:
+            logger = set_stream_logger(name="interchange", level=logging_level)
+        else:
             os.makedirs(self.logdir, exist_ok=True)
 
             logger = set_file_logger(os.path.join(self.logdir, 'interchange.log'),
@@ -194,8 +196,6 @@ class Interchange(object):
             logger.info("logger location {}, logger filesize: {}, logger backup count: {}".format(logger.handlers,
                                                                                                   log_max_bytes,
                                                                                                   log_backup_count))
-        else:
-            logger = set_stream_logger(name="interchange", level=logging_level)
 
         logger.info("Initializing Interchange process with Endpoint ID: {}".format(endpoint_id))
 

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -42,7 +42,7 @@ data:
         heartbeat_threshold=200,
         log_dir='{{ .Values.logDir }}',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v2",
-        detach_endpoint={{- ternary "True" "False" .Values.detachEndpoint }}
+        log_to_std_streams={{- ternary "False" "True" .Values.detachEndpoint }}
     )
 
     # For now, visible_to must be a list of URNs for globus auth users or groups, e.g.:


### PR DESCRIPTION
As described in Issue#437, after endpoint's launch, the executor's log goes to a file, which makes debugging difficult within k8s, since the file log cannot be displayed by `kubectl logs`. This PR adds an executor level option to control the output of the log, and replaces the top level `detach_endpoint` with `log_to_std_streams`. We need to add `log_to_std_streams=True` at both top level and executor level to the default config file to make it print the executor interchange log to console, as follows.

```
config = Config(
    executors=[HighThroughputExecutor(
        log_to_std_streams=True,
        provider=LocalProvider(
            init_blocks=1,
            min_blocks=0,
            max_blocks=1,
        ),
    )],
    log_to_std_streams=True,
    funcx_service_address='https://api2.funcx.org/v2'
)
```