### PR TITLE
Added logic to clean up executor interchange log

### DIFF
--- a/funcx_endpoint/funcx_endpoint/strategies/simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/simple.py
@@ -47,7 +47,13 @@ class SimpleStrategy(BaseStrategy):
 
     def _strategize(self, *args, **kwargs):
         task_breakdown = self.interchange.get_outstanding_breakdown()
-        logger.info(f"Task breakdown {task_breakdown}")
+        num_tasks = 0
+        for breakdown_item in task_breakdown:
+            num_tasks += breakdown_item[1]
+        if num_tasks > 0:
+            logger.info(f"Task breakdown {task_breakdown}")
+        else:
+            logger.debug(f"Task breakdown {task_breakdown}")
 
         min_blocks = self.interchange.provider.min_blocks
         max_blocks = self.interchange.provider.max_blocks

--- a/funcx_endpoint/funcx_endpoint/strategies/simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/simple.py
@@ -47,10 +47,14 @@ class SimpleStrategy(BaseStrategy):
 
     def _strategize(self, *args, **kwargs):
         task_breakdown = self.interchange.get_outstanding_breakdown()
-        num_tasks = 0
+
+        info_log = False
         for breakdown_item in task_breakdown:
-            num_tasks += breakdown_item[1]
-        if num_tasks > 0:
+            if breakdown_item[1] > 0:
+                info_log = True
+                break
+
+        if info_log:
             logger.info(f"Task breakdown {task_breakdown}")
         else:
             logger.debug(f"Task breakdown {task_breakdown}")


### PR DESCRIPTION
As described in Issue #511, for endpoint, there is a log line being generated every second for executor interchange, even there is no outstanding task. It is good for debugging, but might not be the case for production running. This PR changes the log level from `info` to `debug`, when there is no outstanding task.