### PR TITLE
Add small 404 error handling and move results_ws_uri option to client

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -7,7 +7,6 @@ import websockets
 from websockets.exceptions import InvalidHandshake, InvalidStatusCode
 
 from funcx.sdk.asynchronous.funcx_task import FuncXTask
-from funcx.sdk.executor import AtomicController
 
 logger = logging.getLogger("asyncio")
 
@@ -21,7 +20,7 @@ class WebSocketPollingTask:
 
     def __init__(self, funcx_client,
                  loop: AbstractEventLoop,
-                 atomic_controller: AtomicController = None,
+                 atomic_controller=None,
                  init_task_group_id: str = None,
                  results_ws_uri: str = 'wss://api.funcx.org/ws/v2/',
                  auto_start: bool = True):

--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -79,6 +79,8 @@ class WebSocketPollingTask:
         except InvalidStatusCode as e:
             if e.status_code == 404:
                 raise Exception('WebSocket service responsed with a 404. Please ensure you set the correct results_ws_uri')
+            else:
+                raise e
         except InvalidHandshake:
             raise Exception('Failed to authenticate user. Please ensure that you are logged in.')
 

--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -20,7 +20,7 @@ class WebSocketPollingTask:
 
     def __init__(self, funcx_client,
                  loop: AbstractEventLoop,
-                 atomic_controller = None,
+                 atomic_controller=None,
                  init_task_group_id: str = None,
                  results_ws_uri: str = 'wss://api.funcx.org/ws/v2/',
                  auto_start: bool = True):

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -54,6 +54,7 @@ class FuncXClient(FuncXErrorHandlingClient):
                  check_endpoint_version=False,
                  asynchronous=False,
                  loop=None,
+                 results_ws_uri='wss://api.funcx.org/ws/v2/',
                  use_offprocess_checker=True,
                  **kwargs):
         """
@@ -147,12 +148,13 @@ class FuncXClient(FuncXErrorHandlingClient):
 
         self.version_check()
 
+        self.results_ws_uri = results_ws_uri
         self.asynchronous = asynchronous
         if asynchronous:
             self.loop = loop if loop else asyncio.get_event_loop()
 
             # Start up an asynchronous polling loop in the background
-            self.ws_polling_task = WebSocketPollingTask(self, self.loop, self.session_task_group_id)
+            self.ws_polling_task = WebSocketPollingTask(self, self.loop, init_task_group_id=self.session_task_group_id, results_ws_uri=self.results_ws_uri)
         else:
             self.loop = None
 

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -29,11 +29,15 @@ def test_loop(fx, endpoint_id, count=10):
         print(fu.result())
 
 
+# test locally: python3 test_executor.py -e <endpoint_id>
+# test on dev: python3 test_executor.py -s https://api.dev.funcx.org/v2 -w wss://api.dev.funcx.org/ws/v2/ -e <endpoint_id>
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--service_url", default='http://localhost:5000/v2',
                         help="URL at which the funcx-web-service is hosted")
+    parser.add_argument("-w", "--ws_uri", default='ws://localhost:6000',
+                        help="WebSocket URI to get task results")
     parser.add_argument("-e", "--endpoint_id", required=True,
                         help="Target endpoint to send functions to")
     parser.add_argument("-c", "--count", default="10",
@@ -43,7 +47,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # set_stream_logger()
-    fx = FuncXExecutor(FuncXClient(funcx_service_address=args.service_url))
+    fx = FuncXExecutor(FuncXClient(funcx_service_address=args.service_url, results_ws_uri=args.ws_uri))
 
     print("Running simple test")
     test_simple(fx, args.endpoint_id)


### PR DESCRIPTION
# Description

Async interface doesn't currently allow setting a `results_ws_uri` due to how we set it up. We should let users set the `results_ws_uri` like this:

```
fxc = FuncXClient(funcx_service_address=service_url, asynchronous=True, results_ws_uri='wss://api.dev.funcx.org/ws/v2/')
```

And if using executor you need to swap to this:

```
fx = FuncXExecutor(FuncXClient(funcx_service_address=service_url, results_ws_uri='wss://api.dev.funcx.org/ws/v2/'))
```

Fixes #516

## Type of change

- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

(Breaking change only from the recent ws API additions)
