### PR TITLE
pidfile check improvements for endpoint: start, list, stop, delete

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -406,9 +406,6 @@ class EndpointManager:
 
         endpoint_name : str
             endpoint name for debugging purposes
-
-        log : bool
-            whether or not to log instructions for user if pidfile exists
         """
         if not os.path.exists(filepath):
             return {

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -176,7 +176,7 @@ class EndpointManager:
         # if the pidfile exists, we should return early because we don't
         # want to attempt to create a new daemon when one is already
         # potentially running with the existing pidfile
-        if self.check_pidfile(pid_path, log=True)['exists']:
+        if self.check_pidfile(pid_path)['exists']:
             return
 
         # Create a daemon context
@@ -325,7 +325,7 @@ class EndpointManager:
         self.name = name
         endpoint_dir = os.path.join(self.funcx_dir, self.name)
         pid_file = os.path.join(endpoint_dir, "daemon.pid")
-        pid_check = self.check_pidfile(pid_file)
+        pid_check = self.check_pidfile(pid_file, log=False)
 
         # The process is active if the PID file exists and the process it points to is a funcx-endpoint
         if pid_check['active']:
@@ -379,7 +379,7 @@ class EndpointManager:
         shutil.rmtree(endpoint_dir)
         self.logger.info("Endpoint <{}> has been deleted.".format(self.name))
 
-    def check_pidfile(self, filepath, match_name='funcx-endpoint', log=False):
+    def check_pidfile(self, filepath, match_name='funcx-endpoint', log=True):
         """ Helper function to identify possible dead endpoints
 
         Returns a record with 'exists' and 'active' fields indicating
@@ -456,7 +456,7 @@ class EndpointManager:
                 with open(endpoint_json, 'r') as f:
                     endpoint_info = json.load(f)
                     endpoint_id = endpoint_info['endpoint_id']
-                if self.check_pidfile(os.path.join(endpoint_dir, 'daemon.pid'))['active']:
+                if self.check_pidfile(os.path.join(endpoint_dir, 'daemon.pid'), log=False)['active']:
                     status = 'Active'
                 else:
                     status = 'Inactive'

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -455,8 +455,11 @@ class EndpointManager:
                 with open(endpoint_json, 'r') as f:
                     endpoint_info = json.load(f)
                     endpoint_id = endpoint_info['endpoint_id']
-                if self.check_pidfile(os.path.join(endpoint_dir, 'daemon.pid'))['active']:
+                pid_check = self.check_pidfile(os.path.join(endpoint_dir, 'daemon.pid'))
+                if pid_check['active']:
                     status = 'Active'
+                elif pid_check['exists']:
+                    status = 'Disconnected'
                 else:
                     status = 'Inactive'
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -366,8 +366,26 @@ class EndpointManager:
 
         shutil.rmtree(endpoint_dir)
 
-    def check_pidfile(self, filepath, match_name):
+    def check_pidfile(self, filepath, match_name='funcx-endpoint', log=False):
         """ Helper function to identify possible dead endpoints
+
+        Returns a record with 'exists' and 'active' fields indicating
+        whether the pidfile exists, and whether the process is active if it does exist
+        (The endpoint can only start correctly if there is no pidfile)
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the pidfile
+
+        match_name : str
+            Name of the process to check for if pidfile exists
+
+        endpoint_name : str
+            endpoint name for debugging purposes
+
+        log : bool
+            whether or not to log instructions for user if pidfile exists
         """
         if not os.path.exists(filepath):
             return


### PR DESCRIPTION
# Description

When you restart your computer and an endpoint is still running, the process will die but the `daemon.pid` file associated with it will remain. This fix allows `funcx-endpoint start` to better detect this issue, and it allows `funcx-endpoint stop` to clean up this broken scenario. `funcx-endpoint list` will now list this broken scenario as 'Inactive'.

`funcx-endpoint start` will clean up the broken `daemon.pid` file if it is broken, then start as usual:

![endpoint-start-cleanup](https://user-images.githubusercontent.com/22580625/122448419-5be2b800-cf6a-11eb-89a8-5c9ac040d387.png)

There have also been minor improvements to how `funcx-endpoint delete` works and logs.

Fixes https://github.com/funcx-faas/funcX/issues/327

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

(Documentation will still need updating to indicate how `funcx-endpoint` is expected to work)