### PR TITLE
rename endpoint states to running, stopped, disconnected

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -455,11 +455,11 @@ class EndpointManager:
                     endpoint_id = endpoint_info['endpoint_id']
                 pid_check = self.check_pidfile(os.path.join(endpoint_dir, 'daemon.pid'))
                 if pid_check['active']:
-                    status = 'Active'
+                    status = 'Running'
                 elif pid_check['exists']:
                     status = 'Disconnected'
                 else:
-                    status = 'Inactive'
+                    status = 'Stopped'
 
             table.add_row([endpoint_name, status, endpoint_id])
 


### PR DESCRIPTION
# Description

As discussed on Slack, endpoint states should be renamed for more clarity, now that disconnected state has been added

Fixes https://github.com/funcx-faas/funcX/issues/524

## Type of change

- Code maintentance/cleanup
