### PR TITLE
Remove flake8 exemption for wildcard imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,10 +8,6 @@
 # D203: 1 blank line required before class docstring
 # E124: closing bracket does not match visual indentation
 # E126: continuation line over-indented for hanging indent
-# F403: ‘from module import *’ used; unable to detect undefined names
-# F405: name may be undefined, or defined from star imports: module
-# Ignoring the next one for valid tests
-# F811: redefinition of unused name from line N
 # This one is bad. Sometimes ordering matters, conditional imports
 # setting env vars necessary etc.
 # E402: module level import not at top of file
@@ -21,7 +17,7 @@
 # E203,W503,W504: conflict with black formatting sometimes
 # B008: a flake8-bugbear rule which fails on idiomatic typer usage (consider
 # re-enabling this once everything else is fixed and updating usage)
-ignore = D203, E124, E126, F403, F405, F811, E402, E129, W605, W503, W504, E203, F401, B008
+ignore = D203, E124, E126, E402, E129, W605, W503, W504, E203, F401, B008
 # TODO: reduce this to 88 once `black` is applied to all code
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -23,7 +23,6 @@ from retry import retry
 import funcx
 import zmq
 
-from funcx.utils.errors import *
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.executors.high_throughput import global_config as funcx_default_config
 from funcx_endpoint.endpoint.interchange import EndpointInterchange

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -22,7 +22,6 @@ import zmq
 from globus_sdk import GlobusAPIError, NetworkError
 
 import funcx_endpoint
-from funcx.utils.errors import *
 from funcx.utils.response_errors import FuncxResponseError
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.executors.high_throughput import global_config as funcx_default_config

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -25,7 +25,7 @@ fx_serializer = FuncXSerializer()
 # from parsl.executors.high_throughput import interchange
 from funcx_endpoint.executors.high_throughput import interchange
 
-from parsl.executors.errors import *
+from parsl.executors.errors import BadMessage, ScalingFailed
 # from parsl.executors.base import ParslExecutor
 from parsl.executors.status_handling import StatusHandlingExecutor
 from parsl.dataflow.error import ConfigurationError

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -18,10 +18,14 @@ import psutil
 import subprocess
 
 from funcx_endpoint.executors.high_throughput.container_sched import naive_scheduler
-from funcx_endpoint.executors.high_throughput.messages import TaskStatusCode, ManagerStatusReport
+from funcx_endpoint.executors.high_throughput.messages import (
+    EPStatusReport,
+    Heartbeat,
+    ManagerStatusReport,
+    TaskStatusCode
+)
 from funcx_endpoint.executors.high_throughput.worker_map import WorkerMap
 from funcx_endpoint.executors.high_throughput.messages import Message, COMMAND_TYPES, MessageType, Task
-from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Heartbeat, TaskStatusCode
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 

--- a/funcx_endpoint/funcx_endpoint/mock_broker/mock_broker.py
+++ b/funcx_endpoint/funcx_endpoint/mock_broker/mock_broker.py
@@ -6,7 +6,7 @@ creates an appropriate forwarder to which the endpoint can connect up.
 
 
 import bottle
-from bottle import post, run, request, app, route
+from bottle import post, run, request, route
 import argparse
 import json
 import uuid

--- a/funcx_endpoint/tests/integration/test_config.py
+++ b/funcx_endpoint/tests/integration/test_config.py
@@ -1,14 +1,12 @@
 from funcx_endpoint.endpoint.utils.config import Config
 import os
+import funcx
+import logging
 
 config = Config()
 
 
 if __name__ == '__main__':
-
-    import funcx
-    import os
-    import logging
     funcx.set_stream_logger()
     logger = logging.getLogger(__file__)
 

--- a/funcx_endpoint/tests/integration/test_serialization.py
+++ b/funcx_endpoint/tests/integration/test_serialization.py
@@ -25,10 +25,6 @@ def test_2():
     assert fn(2) == 6, "Expected 6 got {}".format(fn(2))
 
 
-def foo(x, y=3):
-    return x * y
-
-
 def test_code_1():
     def bar(x, y=5):
         return x * 5

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -96,16 +96,6 @@ class HTTPError(FuncxError):
         return f"HTTP request failed: {self.message}"
 
 
-class InvalidScopeException(FuncxError):
-    """Invalid API Scope"""
-
-    def __init__(self, message):
-        self.message = message
-
-    def __repr__(self):
-        return f"Invalid Scope: {self.message}"
-
-
 class TaskPending(FuncxError):
     """Task is pending and no result is available yet"""
 

--- a/funcx_sdk/parsl/app/errors.py
+++ b/funcx_sdk/parsl/app/errors.py
@@ -4,7 +4,6 @@ from types import TracebackType
 from typing import Any, Callable, TypeVar, Union
 
 import dill
-from six import reraise
 from tblib import Traceback
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Wildcard imports undermine the capabilities of static analyzers (namely `flake8`, but also pylint) and make it more difficult to understand code.

Once a wildcard import is done, any apparently unbound name could be taken from the wildcard import. It's not knowable without traversing more modules.

They are *always* avoidable. In the extremely rare case that names from a module or package must be rebound in another namespace, they should all be imported explicitly and the `F401` flake8 rule (unused imports) should be ignored. Given that these cases are often about re-exporting names, we can even avoid this with the inclusion of an `__all__` list or tuple.
In the case of `__init__.py` modules which exist solely for the purpose of rebinding names as package-level members, we may prefer to add a per-file-ignore for F401, or to simply always define an `__all__` tuple. Either approach is satisfactory, and avoids undermining `flake8`.

In several cases, the use of wildcard imports and allowance for F811 has masked redefinition of names with identical content -- presumably copy-paste mistakes in the past. These should not be allowed.

When doing replacements within `funcx_endpoint`, I have manually replicated the styles of `black`+`isort`, so that we will have a marginally smaller diff when we run those tools on that package.