### PR TITLE
Ensure isort is applied consistently

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
 profile = black
-known_first_party = funcx
+known_first_party = funcx,funcx_endpoint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,9 @@ repos:
   rev: 5.8.0
   hooks:
     - id: isort
+      # explicitly pass settings file so that isort does not try to deduce
+      # which settings to use based on a file's directory
+      args: ["--settings-path", ".isort.cfg"]
       # FIXME: temporary exclude to reduce conflicts, remove this
       exclude: ^funcx_endpoint/
       # end FIXME

--- a/docs/configs/bluewaters.py
+++ b/docs/configs/bluewaters.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
 from parsl.launchers import AprunLauncher
 from parsl.providers import TorqueProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/cori.py
+++ b/docs/configs/cori.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_interface
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/frontera.py
+++ b/docs/configs/frontera.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/kube.py
+++ b/docs/configs/kube.py
@@ -1,8 +1,9 @@
+from parsl.addresses import address_by_route
+
 from funcx_endpoint.endpoint.utils.config import Config
 from funcx_endpoint.executors import HighThroughputExecutor
 from funcx_endpoint.providers.kubernetes.kube import KubernetesProvider
 from funcx_endpoint.strategies import KubeSimpleStrategy
-from parsl.addresses import address_by_route
 
 # fmt: off
 

--- a/docs/configs/midway.py
+++ b/docs/configs/midway.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/perlmutter.py
+++ b/docs/configs/perlmutter.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_interface
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/theta.py
+++ b/docs/configs/theta.py
@@ -1,8 +1,9 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
 from parsl.launchers import AprunLauncher
 from parsl.providers import CobaltProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/docs/configs/uchicago_ai_cluster.py
+++ b/docs/configs/uchicago_ai_cluster.py
@@ -1,9 +1,10 @@
-from funcx_endpoint.endpoint.utils.config import Config
-from funcx_endpoint.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
 from parsl.channels import LocalChannel
 from parsl.launchers import SrunLauncher
 from parsl.providers import LocalProvider, SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
 
 # fmt: off
 

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -2,9 +2,9 @@ import argparse
 import time
 
 import pytest
-from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
 
 from funcx.sdk.client import FuncXClient
+from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
 
 
 def large_result_producer(size) -> str:

--- a/funcx_sdk/setup.cfg
+++ b/funcx_sdk/setup.cfg
@@ -1,6 +1,6 @@
 [isort]
 profile = black
-known_first_party = funcx
+known_first_party = funcx,funcx_endpoint
 
 [flake8]
 # config to be black-compatible


### PR DESCRIPTION
As found by @Loonride in #535, there's something wrong with the `isort` config. I've never seen this before, and I'm not sure what exactly is happening, but I do have a fix that should work.

Without this change, `isort` behavior could change on a branch unexpectedly. We aren't fully sure of the reason for this, but we can enforce a specific config so that the behavior cannot change.

- Explicitly set the `--settings-path` in pre-commit config so that `.isort.cfg` is always used. Otherwise, `isort` will try to deduce which config to use based on the file being fixed
- Set `funcx_endpoint` as first-party in `.isort.cfg` and `funcx_sdk/setup.cfg`. Perhaps there's a better way, but keeping both configs in sync is an easy solution for now.
- Apply the resulting fixes from `pre-commit run -a`

The thing I still don't get is why the behavior is changing between #535 and `main`. It seems that `isort` is making a different judgement about which config to use (and in the case of the PR branch, not finding the `.isort.cfg` at all). But I'm satisfied to let that remain a mystery for now.