### PR TITLE
Add batch submission to funcx executor 

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -67,6 +67,7 @@ class WebSocketPollingTask:
         # add the initial task group id, as this will be sent to
         # the WebSocket server immediately
         self.running_task_group_ids.add(self.init_task_group_id)
+        asyncio.set_event_loop(self.loop)
         self.task_group_ids_queue = asyncio.Queue()
         self.pending_tasks = {}
 

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -1,17 +1,9 @@
-import time
-import threading
-import queue
-import os
-import uuid
-import sys
-from concurrent.futures import Future
-import concurrent
-import logging
 import argparse
 import asyncio
 import atexit
 import concurrent
 import logging
+import queue
 import threading
 import time
 from concurrent.futures import Future
@@ -19,11 +11,6 @@ from concurrent.futures import Future
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
 
 logger = logging.getLogger("asyncio")
-logging.basicConfig(filename='ws.log',
-                    filemode='a',
-                    format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
-                    datefmt='%H:%M:%S',
-                    level=logging.DEBUG)
 
 
 class AtomicController:
@@ -97,7 +84,6 @@ class FuncXExecutor(concurrent.futures.Executor):
         self._task_counter = 0
         self._function_registry = {}
         self._function_future_map = {}
-        self._function_task_uuids = {}
         self.task_group_id = (
             self.funcx_client.session_task_group_id
         )  # we need to associate all batch launches with this id
@@ -109,6 +95,8 @@ class FuncXExecutor(concurrent.futures.Executor):
             self.task_group_id,
         )
         atexit.register(self.shutdown)
+
+        self.start()
 
     def start(self):
         self.task_outgoing = queue.Queue()

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -1,5 +1,6 @@
 import time
 import threading
+import queue
 import os
 import uuid
 import sys
@@ -15,7 +16,13 @@ import multiprocessing as mp
 import atexit
 
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
+
 logger = logging.getLogger("asyncio")
+logging.basicConfig(filename='ws.log',
+                    filemode='a',
+                    format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+                    datefmt='%H:%M:%S',
+                    level=logging.DEBUG)
 
 
 class AtomicController():
@@ -26,11 +33,11 @@ class AtomicController():
         self.start_callback = start_callback
         self.stop_callback = stop_callback
 
-    def increment(self):
+    def increment(self, count):
         with self.lock:
             if self._value == 0:
                 self.start_callback()
-            self._value += 1
+            self._value += count
 
     def decrement(self):
         with self.lock:
@@ -51,9 +58,13 @@ class FuncXExecutor(concurrent.futures.Executor):
     """ An executor
     """
 
-    def __init__(self, funcx_client,
+    def __init__(self,
+                 funcx_client,
                  results_ws_uri: str = 'ws://localhost:6000',
-                 label: str = 'FuncXExecutor'):
+                 label: str = 'FuncXExecutor',
+                 batch_interval: float = 1.0,
+                 batch_size = 100,
+        ):
         """
         Parameters
         ==========
@@ -72,16 +83,34 @@ class FuncXExecutor(concurrent.futures.Executor):
         self.funcx_client = funcx_client
         self.results_ws_uri = results_ws_uri
         self.label = label
+        self.batch_interval = batch_interval
+        self.batch_size = batch_size
+
         self._tasks = {}
+        self._task_counter = 0
         self._function_registry = {}
         self._function_future_map = {}
+        self._function_task_uuids = {}
         self.task_group_id = self.funcx_client.session_task_group_id  # we need to associate all batch launches with this id
 
+        # Start the task poller thread
         self.poller_thread = ExecutorPollerThread(self.funcx_client,
                                                   self._function_future_map,
                                                   self.results_ws_uri,
                                                   self.task_group_id)
+
         atexit.register(self.shutdown)
+
+    def start(self):
+        self.task_outgoing = queue.Queue()
+
+        self._kill_event = threading.Event()
+        # Start the task submission thread
+        self.task_submit_thread = threading.Thread(target=self.task_submit_thread,
+                                                   args=(self._kill_event,))
+        self.task_submit_thread.daemon = True
+        self.task_submit_thread.start()
+        logger.info("Started task submit thread")
 
     def submit(self, function, *args, endpoint_id=None, container_uuid=None, **kwargs):
         """Initiate an invocation
@@ -110,37 +139,88 @@ class FuncXExecutor(concurrent.futures.Executor):
             # Please note that this is a partial implementation, not all function registration
             # options are fleshed out here.
             logger.debug("Function:{function} is not registered. Registering")
-            function_uuid = self.funcx_client.register_function(function,
-                                                                function_name=function.__name__,
-                                                                container_uuid=container_uuid)
-            self._function_registry[function] = function_uuid
-            logger.debug(f"Function registered with id:{function_uuid}")
+            try:
+                function_id = self.funcx_client.register_function(function,
+                                                                    function_name=function.__name__,
+                                                                    container_uuid=container_uuid)
+            except Exception:
+                logger.error("Error in registering {}".format(func.__name__))
+                raise Exception("Error in registering {}".format(func.__name__))
+            else:
+                self._function_registry[function] = function_id
+                logger.debug(f"Function registered with id:{function_id}")
+
+        task_id = self._task_counter
+        self._task_counter += 1
+
         assert endpoint_id is not None, "endpoint_id key-word argument must be set"
 
-        batch = self.funcx_client.create_batch(task_group_id=self.task_group_id)
-        batch.add(*args,
-                  endpoint_id=endpoint_id,
-                  function_id=self._function_registry[function],
-                  **kwargs)
-        r = self.funcx_client.batch_run(batch)
-        logger.debug(f"Batch submitted to task_group: {self.task_group_id}")
+        msg = {"task_id": task_id,
+               "function_id": function_id,
+               "endpoint_id": endpoint_id,
+               "args": args,
+               "kwargs": kwargs}
+        
+        self._tasks[task_id] = Future()
 
-        task_uuid = r[0]
-        logger.debug(f'Waiting on results for task ID: {task_uuid}')
-        # There's a potential for a race-condition here where the result reaches
-        # the poller before the future is added to the future_map
-        self._function_future_map[task_uuid] = Future()
+        # Post task to the the outgoing queue
+        self.task_outgoing.put(msg)
 
-        self.poller_thread.atomic_controller.increment()
-        res = self._function_future_map[task_uuid]
+        return self._tasks[task_id]
 
-        if not self.poller_thread or self.poller_thread.ws_handler.closed:
-            self.poller_thread = ExecutorPollerThread(self.funcx_client, self._function_future_map, self.results_ws_uri, self.task_group_id)
-        return res
+    def task_submit_thread(self, kill_event):
+        """Task submission thread that fetch tasks from task_outgoing queue,
+        batch function requests, and submit functions to funcX"""
+        while not kill_event.is_set():
+            messages = self._get_tasks_in_batch()
+            if messages:
+                logger.info("[TASK_SUBMIT_THREAD] Submitting {} tasks to funcX".format(len(messages)))
+            self._submit_tasks(messages)
+        logger.info("[TASK_SUBMIT_THREAD] Exiting")
+
+    def _submit_tasks(self, messages):
+        """Submit a batch of tasks
+        """
+        if messages:
+            batch = self.funcx_client.create_batch(task_group_id=self.task_group_id)
+            for msg in messages:
+                function_id, endpoint_id, args, kwargs = msg['function_id'], msg['endpoint_id'], msg['args'], msg['kwargs']
+                batch.add(*args, **kwargs,
+                          endpoint_id=endpoint_id,
+                          function_id=function_id)
+                logger.debug("[TASK_SUBMIT_THREAD] Adding msg {} to funcX batch".format(msg))
+            try:
+                batch_tasks = self.funcx_client.batch_run(batch)
+                logger.debug(f"Batch submitted to task_group: {self.task_group_id}")
+            except Exception:
+                logger.error("[TASK_SUBMIT_THREAD] Error submitting {} tasks to funcX".format(len(messages)))
+            else:
+                for i, msg in enumerate(messages):
+                    self._function_future_map[batch_tasks[i]] = self._tasks.pop(msg['task_id'])
+                self.poller_thread.atomic_controller.increment(len(messages))
+
+                if not self.poller_thread or self.poller_thread.ws_handler.closed:
+                    self.poller_thread = ExecutorPollerThread(self.funcx_client, self._function_future_map, self.results_ws_uri, self.task_group_id)
+
+    def _get_tasks_in_batch(self):
+        """Get tasks from task_outgoing queue in batch, either by interval or by batch size"""
+        messages = []
+        start = time.time()
+        while True:
+            if time.time() - start >= self.batch_size or len(messages) >= self.batch_interval:
+                break
+            try:
+                x = self.task_outgoing.get(timeout=0.1)
+            except queue.Empty:
+                break
+            else:
+                messages.append(x)
+        return messages
 
     def shutdown(self):
         if self.poller_thread:
             self.poller_thread.shutdown()
+        self._kill_event.set()
         logger.debug(f"Executor:{self.label} shutting down")
 
 

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import time
 import threading
 import queue

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
                         help="URL at which the funcx-web-service is hosted")
     parser.add_argument("-e", "--endpoint_id", required=True,
                         help="Target endpoint to send functions to")
-    parser.add_argument("-c", "--count", default="10",
+    parser.add_argument("-c", "--count", default="15",
                         help="Number of tasks to launch")
     parser.add_argument("-d", "--debug", action='store_true',
                         help="Count of apps to launch")
@@ -44,10 +44,14 @@ if __name__ == '__main__':
 
     # set_stream_logger()
     fx = FuncXExecutor(FuncXClient(funcx_service_address=args.service_url))
+    fx.start()
 
+    start = time.time()
     print("Running simple test")
     test_simple(fx, args.endpoint_id)
-    print("Complete")
+    print(f"Complete in {time.time() - start}")
 
+    start = time.time()
     print(f"Running a test with a for loop of {args.count} tasks")
     test_loop(fx, args.endpoint_id, count=int(args.count))
+    print(f"Complete in {time.time() - start}")

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -53,13 +53,17 @@ if __name__ == "__main__":
     )
     parser.add_argument("-c", "--count", default="10", help="Number of tasks to launch")
     parser.add_argument(
+        "-b", "--batch", action="store_true", help="Enable batch or not"
+    )
+    parser.add_argument(
         "-d", "--debug", action="store_true", help="Count of apps to launch"
     )
     args = parser.parse_args()
 
     # set_stream_logger()
     fx = FuncXExecutor(
-        FuncXClient(funcx_service_address=args.service_url, results_ws_uri=args.ws_uri)
+        FuncXClient(funcx_service_address=args.service_url, results_ws_uri=args.ws_uri),
+        batch_enabled=args.batch,
     )
 
     start = time.time()

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -61,7 +61,6 @@ if __name__ == "__main__":
     fx = FuncXExecutor(
         FuncXClient(funcx_service_address=args.service_url, results_ws_uri=args.ws_uri)
     )
-    fx.start()    
 
     start = time.time()
     print("Running simple test")


### PR DESCRIPTION
# Description

This PR adds the batch submission functionality to funcx executor interface. Prior to this PR, funcx executor submits tasks one by one serially. With this PR, funcx executor has a default `batch_interval=1.0s` and `batch_size=100` to enable some batching. 

Batch submission can be disabled by `batch_enabled=False`, which is then exactly the same as now.

I am seeing substantial performance improvement for > 30 tasks with batching.
Test batching:
```
python funcx_sdk/funcx/tests/test_executor.py  -s https://api.dev.funcx.org/v2 -w wss://api.dev.funcx.org/ws/v2/ -e <endpoint_uuid> -c 50 -b
```

Test non-batching:
```
python funcx_sdk/funcx/tests/test_executor.py  -s https://api.dev.funcx.org/v2 -w wss://api.dev.funcx.org/ws/v2/ -e <endpoint_uuid> -c 50
```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)

