### PR TITLE
Fixes broken link to intro notebook on binder

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart
 
 The latest version available on PyPI is ``v0.2.3``.
 
-You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/funcx/master?filepath=examples%2FTutorial.ipynb>`_
+You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb>`_
 
 
 Installation


### PR DESCRIPTION
# Description

While going through the [Quickstart section on ReadTheDocs](https://funcx.readthedocs.io/en/latest/quickstart.html) I noticed the link to mybinder.org site was 404-ing. I replaced the link so that it points to Introduction notebook in `https://github.com/funcx-faas/examples`

## Type of change

- Documentation update
