### PR TITLE
Bumping version to v0.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Documentation: https://funcx.readthedocs.io/en/latest/
 Quickstart
 ==========
 
-funcX is in a beta state with version `0.2.3` currently available on PyPI.
+funcX is in a beta state with version `0.3.0` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 **funcX** client and endpoint software releases are available on `PyPI <https://pypi.org/project/funcx/>`_.
 
-The latest version available on PyPI is ``v0.2.3``.
+The latest version available on PyPI is ``v0.3.0``.
 
 You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb>`_
 
@@ -28,7 +28,7 @@ To check if your endpoint/client have network access and can connect to the func
 
   >>> curl https://api2.funcx.org/v2/version
 
-This should return a version string, for example: ``"0.2.2"``
+This should return a version string, for example: ``"0.3.0"``
 
 .. note:: The funcx client is supported on MacOS, Linux, and Windows. The funcx-endpoint
    is only supported on Linux.

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.2.3
+funcx>=0.3.0
 pyzmq>=22.0.0
 retry

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
This PR only bumps the version number to v0.3.0