### PR TITLE
Removing debug logline dumping raw task message

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -312,7 +312,6 @@ class Manager(object):
                     logger.debug("Got heartbeat from interchange")
 
                 else:
-                    logger.warning("YADU: RAW Tasks {}".format(message))
                     tasks = [(rt['local_container'], Message.unpack(rt['raw_buffer'])) for rt in message]
 
                     task_recv_counter += len(tasks)


### PR DESCRIPTION
# Description

A log line in the funcx_manager was dumping the raw task message for debugging. This PR removes this.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
