### PR TITLE
549 invalid helm config

### DIFF
--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -22,7 +22,6 @@ data:
                 address=address_by_route(),
                 strategy=KubeSimpleStrategy(max_idletime=3600),
                 container_type='docker',
-                scheduler_mode='hard',
                 provider=KubernetesProvider(
                     init_blocks={{ .Values.initBlocks }},
                     min_blocks={{ .Values.minBlocks }},

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -21,6 +21,7 @@ data:
                 max_workers_per_node={{ .Values.maxWorkersPerPod }},
                 address=address_by_route(),
                 strategy=KubeSimpleStrategy(max_idletime=3600),
+                scheduler_mode='hard',
                 container_type='docker',
                 provider=KubernetesProvider(
                     init_blocks={{ .Values.initBlocks }},


### PR DESCRIPTION
# Problem
The endpoint created by the helm chart fails to launch with an exception

Fixes #549 

# Approach
Removed the offending line from the config and allow it to default
