### PR TITLE
Add singularity example configs to docs for midway and theta

### DIFF
--- a/docs/configs/midway_singularity.py
+++ b/docs/configs/midway_singularity.py
@@ -23,7 +23,7 @@ config = Config(
             scheduler_mode='soft',
             worker_mode='singularity_reuse',
             container_type='singularity',
-            container_cmd_options="-H /home/$USER",            
+            container_cmd_options="-H /home/$USER",
             provider=SlurmProvider(
                 'broadwl',
                 launcher=SrunLauncher(),

--- a/docs/configs/midway_singularity.py
+++ b/docs/configs/midway_singularity.py
@@ -1,0 +1,48 @@
+from parsl.addresses import address_by_hostname
+from parsl.launchers import SrunLauncher
+from parsl.providers import SlurmProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+
+# fmt: off
+
+# PLEASE UPDATE user_opts BEFORE USE
+user_opts = {
+    'midway': {
+        'worker_init': 'source ~/setup_funcx_test_env.sh',
+        'scheduler_options': '',
+    }
+}
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            max_workers_per_node=10,
+            address=address_by_hostname(),
+            scheduler_mode='soft',
+            worker_mode='singularity_reuse',
+            container_type='singularity',
+            container_cmd_options="-H /home/$USER",            
+            provider=SlurmProvider(
+                'broadwl',
+                launcher=SrunLauncher(),
+                nodes_per_block=2,
+                init_blocks=1,
+                # string to prepend to #SBATCH blocks in the submit
+                # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
+                scheduler_options=user_opts['midway']['scheduler_options'],
+
+                # Command to be run before starting a worker, such as:
+                # 'module load Anaconda; source activate parsl_env'.
+                worker_init=user_opts['midway']['worker_init'],
+
+                min_blocks=1,
+                max_blocks=1,
+                walltime='00:20:00'
+            ),
+        )
+    ],
+)
+
+# fmt: on

--- a/docs/configs/theta_singularity.py
+++ b/docs/configs/theta_singularity.py
@@ -1,0 +1,51 @@
+from parsl.addresses import address_by_hostname
+from parsl.launchers import AprunLauncher
+from parsl.providers import CobaltProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+
+# fmt: off
+
+# PLEASE UPDATE user_opts BEFORE USE
+user_opts = {
+    'theta': {
+        'worker_init': 'source ~/setup_funcx_test_env.sh',
+        'scheduler_options': '',
+        # Specify the account/allocation to which jobs should be charged
+        'account': '<YOUR_THETA_ALLOCATION>'
+    }
+}
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            max_workers_per_node=1,
+            address=address_by_hostname(),
+            scheduler_mode='soft',
+            worker_mode='singularity_reuse',
+            container_type='singularity',
+            container_cmd_options="-H /home/$USER",
+            provider=CobaltProvider(
+                queue='debug-flat-quad',
+                account=user_opts['theta']['account'],
+                launcher=AprunLauncher(overrides="-d 64"),
+                # string to prepend to #COBALT blocks in the submit
+                # script to the scheduler eg: '#COBALT -t 50'
+                scheduler_options=user_opts['theta']['scheduler_options'],
+
+                # Command to be run before starting a worker, such as:
+                # 'module load Anaconda; source activate funcx_env'.
+                worker_init=user_opts['theta']['worker_init'],
+
+                walltime='00:30:00',
+                nodes_per_block=2,
+                init_blocks=1,
+                min_blocks=1,
+                max_blocks=1,
+            ),
+        )
+    ],
+)
+
+# fmt: on

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -48,6 +48,10 @@ with the scheduler, and uses the `SrunLauncher` to launch workers.
 
 .. literalinclude:: configs/midway.py
 
+The following configuration is an example to use singularity container on Midway.
+
+.. literalinclude:: configs/midway_singularity.py
+
 
 Kubernetes Clusters
 ^^^^^^^^^^^^^^^^^^^
@@ -71,6 +75,11 @@ The following snippet shows an example configuration for executing on Argonne Le
 using the `CobaltProvider`. This configuration assumes that the script is being executed on the login nodes of Theta.
 
 .. literalinclude:: configs/theta.py
+
+The following configuration is an example to use singularity container on Theta.
+
+.. literalinclude:: configs/theta_singularity.py
+
 
 Cori (NERSC)
 ^^^^^^^^^^^^


### PR DESCRIPTION
# Description

This PR adds example singularity configs to docs for midway and theta.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
