### PR TITLE
container_cmd fix

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -368,6 +368,7 @@ class Manager(object):
             self.worker_procs.update(self.worker_map.spin_up_workers(self.next_worker_q,
                                                                      mode=self.worker_mode,
                                                                      debug=self.debug,
+                                                                     container_cmd_options=self.container_cmd_options,
                                                                      address=self.address,
                                                                      uid=self.uid,
                                                                      logdir=self.logdir,


### PR DESCRIPTION
# Description

Fix container `spin_up_workers `not passing the correct `container_cmd_options`

Fixes # Add 'self.container_cmd_options` to new worker instances.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)

