### PR TITLE
Remove process name check when checking endpoint status from pid

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -412,18 +412,17 @@ class EndpointManager:
                 "active": False
             }
 
-        older_pid = int(open(filepath, 'r').read().strip())
+        pid = int(open(filepath, 'r').read().strip())
 
         active = False
         try:
-            proc = psutil.Process(older_pid)
-            if proc.name() == match_name:
-                # this is the only case where the endpoint is active.
-                # If the process name does not match or no process exists,
-                # it means the endpoint has been terminated without proper cleanup
-                active = True
+            psutil.Process(pid)
         except psutil.NoSuchProcess:
             pass
+        else:
+            # this is the only case where the endpoint is active. If no process exists,
+            # it means the endpoint has been terminated without proper cleanup
+            active = True
 
         return {
             "exists": True,


### PR DESCRIPTION
# Description

Remove process name check, and rather just simply confirm the process with the pid exists

From what I can tell, there's no easy cross-platform way to set a process name so it's better that we just check the process with pid exists

Fixes https://github.com/funcx-faas/funcX/issues/558

## Type of change

- Bug fix (non-breaking change that fixes an issue)
