### PR TITLE
Add support for disabling SSL certificate verification

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -155,6 +155,7 @@ def main(
         ctx: typer.Context,
         _: bool = typer.Option(None, "--version", "-v", callback=version_callback, is_eager=True),
         debug: bool = typer.Option(False, "--debug", "-d"),
+        disable_requests_verify: bool = typer.Option(False, "--disable-requests-verify", help="Disable SSL Certificate verification"),
         config_dir: str = typer.Option(os.path.join(pathlib.Path.home(), '.funcx'), "--config_dir", "-c", help="override default config dir")
 ):
     # Note: no docstring here; the docstring for @app.callback is used as a help message for overall app.
@@ -169,6 +170,7 @@ def main(
 
     global manager
     manager = EndpointManager(funcx_dir=config_dir,
+                              disable_requests_verify=disable_requests_verify,
                               debug=debug)
 
     # Otherwise, we ensure that configs exist

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -37,6 +37,7 @@ class EndpointManager:
 
     def __init__(self,
                  funcx_dir=os.path.join(pathlib.Path.home(), '.funcx'),
+                 disable_requests_verify=False,
                  debug=False):
         """ Initialize the EndpointManager
 
@@ -45,6 +46,9 @@ class EndpointManager:
 
         funcx_dir: str
             Directory path to the root of the funcx dirs. Usually ~/.funcx.
+
+        disable_requests_verify: Bool
+            Disable SSL certificate verification for all HTTPS calls
 
         debug: Bool
             Enable debug logging. Default: False
@@ -56,6 +60,7 @@ class EndpointManager:
         self.funcx_default_config_template = funcx_default_config.__file__
         self.funcx_config = {}
         self.name = 'default'
+        self.disable_requests_verify = disable_requests_verify
         global logger
         self.logger = logger
 
@@ -110,7 +115,7 @@ class EndpointManager:
         to ensure that multiple endpoint invocations do not mangle the funcx config files
         or the lockfile module.
         """
-        _ = FuncXClient()
+        _ = FuncXClient(disable_requests_verify=disable_requests_verify)
 
         if os.path.exists(self.funcx_config_file):
             typer.confirm(
@@ -165,6 +170,7 @@ class EndpointManager:
             raise Exception(f"Endpoint config file at {endpoint_dir} is missing executor definitions")
 
         funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address,
+                                   disable_requests_verify=disable_requests_verify,
                                    check_endpoint_version=True)
 
         endpoint_uuid = self.check_endpoint_json(endpoint_json, endpoint_uuid)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -155,6 +155,7 @@ class EndpointManager:
     def start_endpoint(self, name, endpoint_uuid, endpoint_config):
         self.name = name
 
+        endpoint_config.disable_request_verify = self.disable_requests_verify
         endpoint_dir = os.path.join(self.funcx_dir, self.name)
         endpoint_json = os.path.join(endpoint_dir, 'endpoint.json')
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -170,6 +170,7 @@ class EndpointManager:
         if not endpoint_config.config.executors:
             raise Exception(f"Endpoint config file at {endpoint_dir} is missing executor definitions")
 
+        logger.debug("[start_endpoint] disable_requests_verify = {self.disable_requests_verify}")
         funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address,
                                    disable_requests_verify=self.disable_requests_verify,
                                    check_endpoint_version=True)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -115,7 +115,7 @@ class EndpointManager:
         to ensure that multiple endpoint invocations do not mangle the funcx config files
         or the lockfile module.
         """
-        _ = FuncXClient(disable_requests_verify=disable_requests_verify)
+        _ = FuncXClient(disable_requests_verify=self.disable_requests_verify)
 
         if os.path.exists(self.funcx_config_file):
             typer.confirm(
@@ -170,7 +170,7 @@ class EndpointManager:
             raise Exception(f"Endpoint config file at {endpoint_dir} is missing executor definitions")
 
         funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address,
-                                   disable_requests_verify=disable_requests_verify,
+                                   disable_requests_verify=self.disable_requests_verify,
                                    check_endpoint_version=True)
 
         endpoint_uuid = self.check_endpoint_json(endpoint_json, endpoint_uuid)

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -270,6 +270,7 @@ class EndpointManager:
         optionals = {}
         optionals['client_address'] = reg_info['public_ip']
         optionals['client_ports'] = reg_info['tasks_port'], reg_info['results_port'], reg_info['commands_port'],
+        optionals['disable_requests_verify'] = self.disable_requests_verify
         if 'endpoint_address' in self.funcx_config:
             optionals['interchange_address'] = self.funcx_config['endpoint_address']
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -170,7 +170,7 @@ class EndpointManager:
         if not endpoint_config.config.executors:
             raise Exception(f"Endpoint config file at {endpoint_dir} is missing executor definitions")
 
-        logger.debug("[start_endpoint] disable_requests_verify = {self.disable_requests_verify}")
+        logger.debug(f"[start_endpoint] disable_requests_verify = {self.disable_requests_verify}")
         funcx_client = FuncXClient(funcx_service_address=endpoint_config.config.funcx_service_address,
                                    disable_requests_verify=self.disable_requests_verify,
                                    check_endpoint_version=True)

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -96,6 +96,7 @@ class EndpointInterchange(object):
                  endpoint_id=None,
                  keys_dir=".curve",
                  suppress_failure=True,
+                 disable_requests_verify=False,
                  ):
         """
         Parameters
@@ -130,6 +131,9 @@ class EndpointInterchange(object):
 
         suppress_failure : Bool
              When set to True, the interchange will attempt to suppress failures. Default: False
+
+        disable_requests_verify: Bool
+            Disable SSL certificate verification for all HTTPS calls
         """
         self.logdir = logdir
         try:
@@ -148,7 +152,8 @@ class EndpointInterchange(object):
         self.interchange_address = interchange_address
         self.client_ports = client_ports
         self.suppress_failure = suppress_failure
-
+        self.disable_requests_verify = disable_requests_verify
+        
         self.heartbeat_period = self.config.heartbeat_period
         self.heartbeat_threshold = self.config.heartbeat_threshold
         # initalize the last heartbeat time to start the loop
@@ -173,7 +178,7 @@ class EndpointInterchange(object):
         self.pending_task_queue = Queue()
         self.containers = {}
         self.total_pending_task_count = 0
-        self.fxs = FuncXClient(disable_requests_verify=config.disable_requests_verify)
+        self.fxs = FuncXClient(disable_requests_verify=self.disable_requests_verify)
 
         logger.info("Interchange address is {}".format(self.interchange_address))
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -173,7 +173,7 @@ class EndpointInterchange(object):
         self.pending_task_queue = Queue()
         self.containers = {}
         self.total_pending_task_count = 0
-        self.fxs = FuncXClient()
+        self.fxs = FuncXClient(disable_requests_verify=config.disable_requests_verify)
 
         logger.info("Interchange address is {}".format(self.interchange_address))
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -45,10 +45,6 @@ class Config(RepresentationMixin):
     log_dir : str
         Optional path string to the top-level directory where logs should be written to.
         Default: None
-
-    disable_requests_verify : Bool
-        Disable SSL Certificate verification when connecting to the funcX hosted services.
-        This is equivalent to verify=False option in the requests library. Default = False
     """
 
     def __init__(
@@ -65,7 +61,6 @@ class Config(RepresentationMixin):
         log_dir=None,
         stdout="./interchange.stdout",
         stderr="./interchange.stderr",
-        disable_requests_verify=False
     ):
 
         # Execution backends
@@ -83,4 +78,3 @@ class Config(RepresentationMixin):
         self.log_dir = log_dir
         self.stdout = stdout
         self.stderr = stderr
-        self.disable_requests_verify = disable_requests_verify

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -45,6 +45,10 @@ class Config(RepresentationMixin):
     log_dir : str
         Optional path string to the top-level directory where logs should be written to.
         Default: None
+
+    disable_requests_verify : Bool
+        Disable SSL Certificate verification when connecting to the funcX hosted services.
+        This is equivalent to verify=False option in the requests library. Default = False
     """
 
     def __init__(
@@ -61,6 +65,7 @@ class Config(RepresentationMixin):
         log_dir=None,
         stdout="./interchange.stdout",
         stderr="./interchange.stderr",
+        disable_requests_verify=False
     ):
 
         # Execution backends
@@ -78,3 +83,4 @@ class Config(RepresentationMixin):
         self.log_dir = log_dir
         self.stdout = stdout
         self.stderr = stderr
+        self.disable_requests_verify = disable_requests_verify

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -189,6 +189,9 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         and SlurmProvider interfaces to request resources from the Slurm batch scheduler.
         Default: LocalProvider
 
+    disable_requests_verify: Bool 
+        Disable SSL Certificate verification for HTTPS/REST requests to the funcX hosted services. 
+        Default: False
     """
 
     def __init__(self,
@@ -230,7 +233,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  managed=True,
                  interchange_local=True,
                  passthrough=True,
-                 task_status_queue=None):
+                 task_status_queue=None,
+                 disable_requests_verify=False):
 
         logger.debug("Initializing HighThroughputExecutor")
         StatusHandlingExecutor.__init__(self, provider)
@@ -282,6 +286,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.container_image = container_image
         self.worker_mode = worker_mode
         self.last_response_time = time.time()
+
+        self.disable_requests_verify = disable_requests_verify
 
         if not launch_cmd:
             self.launch_cmd = ("process_worker_pool.py {debug} {max_workers} "
@@ -411,7 +417,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "logdir": os.path.join(self.run_dir, self.label),
                                           "suppress_failure": self.suppress_failure,
                                           "endpoint_id": self.endpoint_id,
-                                          "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
+                                          "logging_level": logging.DEBUG if self.worker_debug else logging.INFO,
+                                          "disable_requests_verify": self.disable_requests_verify
                                   },
         )
         self.queue_proc.start()

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -129,7 +129,8 @@ class Interchange(object):
                  suppress_failure=False,
                  log_max_bytes=256 * 1024 * 1024,
                  log_backup_count=1,
-                 ):
+                 disable_requests_verify=False,
+    ):
         """
         Parameters
         ----------
@@ -185,6 +186,9 @@ class Interchange(object):
 
         suppress_failure : Bool
              When set to True, the interchange will attempt to suppress failures. Default: False
+
+        disable_requests_verify : Bool
+             Disable SSL certificate verification for HTTPS communication with the funcX hosted services
         """
 
         self.logdir = logdir
@@ -259,7 +263,9 @@ class Interchange(object):
         self.pending_task_queue = {}
         self.containers = {}
         self.total_pending_task_count = 0
-        self.fxs = FuncXClient(funcx_service_address=funcx_service_address)
+        self.disable_requests_verify = disable_requests_verify
+        self.fxs = FuncXClient(funcx_service_address=funcx_service_address,
+                               disable_requests_verify=self.disable_requests_verify)
 
         logger.info("Interchange address is {}".format(self.interchange_address))
         self.worker_ports = worker_ports

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -59,6 +59,7 @@ class FuncXClient(FuncXErrorHandlingClient):
         loop=None,
         results_ws_uri="wss://api.funcx.org/ws/v2/",
         use_offprocess_checker=True,
+        disable_requests_verify=False,
         **kwargs,
     ):
         """
@@ -107,6 +108,10 @@ class FuncXClient(FuncXErrorHandlingClient):
             used by the client.
             Default: True
 
+        disable_requests_verify: Bool
+            Passes verify=False to the underlying requests library.
+            This disables SSL certificate verification. Default False
+
         Keyword arguments are the same as for BaseClient.
 
         """
@@ -153,6 +158,9 @@ class FuncXClient(FuncXErrorHandlingClient):
             base_url=funcx_service_address,
             **kwargs,
         )
+        self.disable_requests_verify = disable_requests_verify
+        if self.disable_requests_verify:
+            self._verify = False
         self.fx_serializer = FuncXSerializer(
             use_offprocess_checker=self.use_offprocess_checker
         )


### PR DESCRIPTION

# Description

Some sites like quartz@LLNL appear to be doing some sort of SSL proxying that the
requests library is unable to verify. However, since curl is able to handle https connection,
this might just be a limitation of the `requests` library that. This option disables the
checking, but still raises a warning 

```InsecureRequestWarning: Unverified HTTPS request is being made to host 'api2.funcx.org'. Adding certificate verification is strongly advised```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
