### PR TITLE
Add action to set version numbers on release

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,38 @@
+name: Push to PyPI
+
+on:
+  release:
+    types: [released, prereleased]
+
+jobs:
+  publish-sdk:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip build
+    - name: Set the funcx version
+      env:
+        funcx_version: ${{ github.ref }}
+      run: |
+        sed "s/__version__ *= *\".*\"/__version__ = \"$funcx_version\"/" funcx_sdk/funcx/sdk/version.py > funcx_sdk/funcx/sdk/version.py
+        sed "s/__version__ *= *\".*\"/__version__ = \"$funcx_version\"/" funcx_endpoint/funcx_endpoint/version.py > funcx_endpoint/funcx_endpoint/version.py
+
+    - name: Push updated version to branch
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Bump version
+    - name: Build the sdk
+      run: |
+        cd funcx_sdk
+        python -m build --sdist --wheel
+    - name: Build the endpoint
+      run: |
+        cd funcx_endpoint
+        python -m build --sdist --wheel


### PR DESCRIPTION
Need to get add a GitHub Actions workflow for the pypi release. It still needs further development, but it seems like it needs to appear in master before it can be tested in a branch