### PR TITLE
Log result passing to forwarder only if an actual result (Not EPStatusReport)

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -448,10 +448,10 @@ class EndpointInterchange(object):
                 task_id = results["task_id"]
                 if task_id:
                     self.results_ack_handler.put(task_id, results["message"])
+                    logger.info(f"Passing result to forwarder for task {task_id}")
 
                 # results will be a pickled dict with task_id, container_id, and results/exception
                 self.results_outgoing.put('forwarder', results["message"])
-                logger.info("Passing result to forwarder")
 
             except queue.Empty:
                 pass


### PR DESCRIPTION
# Description

We do not want to be info logging endpoint status reports as results, since this will only confuse users. We should simply rely on the debug logs in the executor for EPStatusReport sending

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
