### PR TITLE
Add zmq linger option and set to 0 for all TaskQueues

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -165,7 +165,8 @@ class EndpointInterchange(object):
                                          mode='client',
                                          RCVTIMEO=1000,  # in milliseconds
                                          keys_dir=keys_dir,
-                                         set_hwm=True)
+                                         set_hwm=True,
+                                         linger=0)
 
         # TODO :Register all channels with the authentication string.
         self.command_channel.put('forwarder', pickle.dumps({"registration": endpoint_id}))
@@ -243,7 +244,8 @@ class EndpointInterchange(object):
                                        mode='client',
                                        set_hwm=True,
                                        keys_dir=self.keys_dir,
-                                       RCVTIMEO=1000)
+                                       RCVTIMEO=1000,
+                                       linger=0)
         self.task_incoming.put('forwarder', pickle.dumps({"registration": self.endpoint_id}))
         logger.info(f"Task incoming on tcp://{self.client_address}:{self.client_ports[0]}")
 
@@ -403,7 +405,8 @@ class EndpointInterchange(object):
                                           keys_dir=self.keys_dir,
                                           # Fail immediately if results cannot be sent back
                                           SNDTIMEO=0,
-                                          set_hwm=True)
+                                          set_hwm=True,
+                                          linger=0)
         self.results_outgoing.put('forwarder', pickle.dumps({"registration": self.endpoint_id}))
 
         # TODO: this resend must happen after any endpoint re-registration to

--- a/funcx_endpoint/funcx_endpoint/endpoint/taskqueue.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/taskqueue.py
@@ -21,6 +21,7 @@ class TaskQueue(object):
                  set_hwm=False,
                  RCVTIMEO=None,
                  SNDTIMEO=None,
+                 linger=None,
                  ironhouse: bool = False,
                  keys_dir: str = os.path.abspath('.curve'),
                  mode: str = 'client'):
@@ -80,6 +81,8 @@ class TaskQueue(object):
             self.zmq_socket.setsockopt(zmq.RCVTIMEO, RCVTIMEO)
         if SNDTIMEO is not None:
             self.zmq_socket.setsockopt(zmq.SNDTIMEO, SNDTIMEO)
+        if linger is not None:
+            self.zmq_socket.setsockopt(zmq.LINGER, linger)
 
         # all zmq setsockopt calls must be done before bind/connect is called
         if self.mode == 'server':


### PR DESCRIPTION
# Description

This is needed so that when `close` is called on sockets then the socket context is terminated, nothing blocks. If there are messages in the pipes, `close` will block indefinitely (default linger value is infinity).

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
