### PR TITLE
Same file by default for endpoint stdout/stderr and file logger

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -188,8 +188,8 @@ class EndpointManager:
         # If we are running a full detached daemon then we will send the output to
         # log files, otherwise we can piggy back on our stdout
         if endpoint_config.config.detach_endpoint:
-            stdout = open(os.path.join(endpoint_dir, endpoint_config.config.stdout), 'w+')
-            stderr = open(os.path.join(endpoint_dir, endpoint_config.config.stderr), 'w+')
+            stdout = open(os.path.join(endpoint_dir, endpoint_config.config.stdout), 'a+')
+            stderr = open(os.path.join(endpoint_dir, endpoint_config.config.stderr), 'a+')
         else:
             stdout = sys.stdout
             stderr = sys.stderr

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -140,7 +140,7 @@ class EndpointInterchange(object):
 
         global logger
 
-        logger = set_file_logger(os.path.join(self.logdir, "EndpointInterchange.log"), name="funcx_endpoint", level=logging_level)
+        logger = set_file_logger(os.path.join(self.logdir, "endpoint.log"), name="funcx_endpoint", level=logging_level)
         logger.info("Initializing EndpointInterchange process with Endpoint ID: {}".format(endpoint_id))
         self.config = config
         logger.info("Got config : {}".format(config))

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -59,8 +59,8 @@ class Config(RepresentationMixin):
         detach_endpoint=True,
         # Logging info
         log_dir=None,
-        stdout="./EndpointInterchange.log",
-        stderr="./EndpointInterchange.log",
+        stdout="./endpoint.log",
+        stderr="./endpoint.log",
     ):
 
         # Execution backends

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -59,8 +59,8 @@ class Config(RepresentationMixin):
         detach_endpoint=True,
         # Logging info
         log_dir=None,
-        stdout="./interchange.stdout",
-        stderr="./interchange.stderr",
+        stdout="./EndpointInterchange.log",
+        stderr="./EndpointInterchange.log",
     ):
 
         # Execution backends


### PR DESCRIPTION
# Description

Change functionality of endpoint logging such that it all appends to same file by default

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
