### PR TITLE
Standardizing configs and setting init blocks to 0.

### DIFF
--- a/docs/configs/bluewaters.py
+++ b/docs/configs/bluewaters.py
@@ -24,16 +24,21 @@ config = Config(
             provider=TorqueProvider(
                 queue='normal',
                 launcher=AprunLauncher(overrides="-b -- bwpy-environ --"),
+
                 # string to prepend to #SBATCH blocks in the submit
                 scheduler_options=user_opts['bluewaters']['scheduler_options'],
 
                 # Command to be run before starting a worker, such as:
-                # 'module load bwpy; source activate parsl_env'.
+                # 'module load bwpy; source activate funcx env'.
                 worker_init=user_opts['bluewaters']['worker_init'],
-                init_blocks=1,
-                max_blocks=1,
-                min_blocks=1,
+
+                # Scale between 0-1 blocks with 2 nodes per block
                 nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
+                max_blocks=1,
+
+                # Hold blocks for 30 minutes
                 walltime='00:30:00'
             ),
         )

--- a/docs/configs/cooley.py
+++ b/docs/configs/cooley.py
@@ -21,6 +21,7 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             max_workers_per_node=2,
+            worker_debug=False,
             address=address_by_hostname(),
             provider=CobaltProvider(
                 queue='default',
@@ -34,11 +35,14 @@ config = Config(
                 # 'module load Anaconda; source activate funcx_env'.
                 worker_init=user_opts['cooley']['worker_init'],
 
-                walltime='00:30:00',
-                nodes_per_block=1,
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
                 init_blocks=0,
                 min_blocks=0,
-                max_blocks=4,
+                max_blocks=1,
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00',
             ),
         )
     ],

--- a/docs/configs/cori.py
+++ b/docs/configs/cori.py
@@ -18,12 +18,15 @@ user_opts = {
 config = Config(
     executors=[
         HighThroughputExecutor(
-            label='Cori_HTEX_multinode',
+            max_workers_per_node=2,
+            worker_debug=False,
             address=address_by_interface('bond0.144'),
             provider=SlurmProvider(
-                'debug',  # Partition / QOS
-                nodes_per_block=2,
-                init_blocks=1,
+                partition='debug',  # Partition / QOS
+
+                # We request all hyperthreads on a node.
+                launcher=SrunLauncher(overrides='-c 272'),
+                
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['cori']['scheduler_options'],
@@ -32,12 +35,18 @@ config = Config(
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['cori']['worker_init'],
 
-                # We request all hyperthreads on a node.
-                launcher=SrunLauncher(overrides='-c 272'),
-                walltime='00:10:00',
-                # Slurm scheduler on Cori can be slow at times,
-                # increase the command timeouts
+                # Increase timeout as Cori's scheduler may be slow
+                # to respond
                 cmd_timeout=120,
+
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
+                max_blocks=1,
+
+                # Hold blocks for 10 minutes
+                walltime='00:10:00',
             ),
         ),
     ],

--- a/docs/configs/cori.py
+++ b/docs/configs/cori.py
@@ -26,7 +26,7 @@ config = Config(
 
                 # We request all hyperthreads on a node.
                 launcher=SrunLauncher(overrides='-c 272'),
-                
+
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['cori']['scheduler_options'],

--- a/docs/configs/frontera.py
+++ b/docs/configs/frontera.py
@@ -20,16 +20,12 @@ user_opts = {
 config = Config(
     executors=[
         HighThroughputExecutor(
-            label="frontera_htex",
             max_workers_per_node=2,
+            worker_debug=False,
             address=address_by_hostname(),
             provider=SlurmProvider(
-                cmd_timeout=60,     # Add extra time for slow scheduler responses
-                nodes_per_block=2,
-                init_blocks=1,
-                min_blocks=0,
-                max_blocks=1,
-                partition=user_opts['frontera']['partition'],  # Replace with partition name
+                partition=user_opts['frontera']['partition'],
+                launcher=SrunLauncher(),
 
                 # Enter scheduler_options if needed
                 scheduler_options=user_opts['frontera']['scheduler_options'],
@@ -38,9 +34,17 @@ config = Config(
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['frontera']['worker_init'],
 
-                # Ideally we set the walltime to the longest supported walltime.
-                walltime='00:10:00',
-                launcher=SrunLauncher(),
+                # Add extra time for slow scheduler responses
+                cmd_timeout=60,
+
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
+                max_blocks=1,
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00',
             ),
         )
     ],

--- a/docs/configs/midway.py
+++ b/docs/configs/midway.py
@@ -24,7 +24,7 @@ config = Config(
             provider=SlurmProvider(
                 partition='broadwl',
                 launcher=SrunLauncher(),
-                
+
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['midway']['scheduler_options'],

--- a/docs/configs/midway.py
+++ b/docs/configs/midway.py
@@ -18,13 +18,13 @@ user_opts = {
 config = Config(
     executors=[
         HighThroughputExecutor(
-            max_workers_per_node=10,
+            max_workers_per_node=2,
+            worker_debug=False,
             address=address_by_hostname(),
             provider=SlurmProvider(
-                'broadwl',
+                partition='broadwl',
                 launcher=SrunLauncher(),
-                nodes_per_block=2,
-                init_blocks=1,
+                
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['midway']['scheduler_options'],
@@ -33,9 +33,14 @@ config = Config(
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['midway']['worker_init'],
 
-                min_blocks=1,
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
                 max_blocks=1,
-                walltime='00:20:00'
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00'
             ),
         )
     ],

--- a/docs/configs/midway_singularity.py
+++ b/docs/configs/midway_singularity.py
@@ -27,7 +27,7 @@ config = Config(
             provider=SlurmProvider(
                 partition='broadwl',
                 launcher=SrunLauncher(),
-                
+
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['midway']['scheduler_options'],
@@ -41,7 +41,7 @@ config = Config(
                 init_blocks=0,
                 min_blocks=0,
                 max_blocks=1,
-                
+
                 # Hold blocks for 30 minutes
                 walltime='00:30:00'
             ),

--- a/docs/configs/midway_singularity.py
+++ b/docs/configs/midway_singularity.py
@@ -25,10 +25,9 @@ config = Config(
             container_type='singularity',
             container_cmd_options="-H /home/$USER",
             provider=SlurmProvider(
-                'broadwl',
+                partition='broadwl',
                 launcher=SrunLauncher(),
-                nodes_per_block=2,
-                init_blocks=1,
+                
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=knl,quad,cache'
                 scheduler_options=user_opts['midway']['scheduler_options'],
@@ -37,9 +36,14 @@ config = Config(
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['midway']['worker_init'],
 
-                min_blocks=1,
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
                 max_blocks=1,
-                walltime='00:20:00'
+                
+                # Hold blocks for 30 minutes
+                walltime='00:30:00'
             ),
         )
     ],

--- a/docs/configs/perlmutter.py
+++ b/docs/configs/perlmutter.py
@@ -18,12 +18,14 @@ user_opts = {
 config = Config(
     executors=[
         HighThroughputExecutor(
-            label='Cori_HTEX_multinode',
+            worker_debug=False,
             address=address_by_interface('bond0.144'),
             provider=SlurmProvider(
-                'GPU',  # Partition / QOS
-                nodes_per_block=2,
-                init_blocks=1,
+                partition='GPU',  # Partition / QOS
+
+                # We request all hyperthreads on a node.
+                launcher=SrunLauncher(overrides='-c 272'),
+                
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=gpu'
                 scheduler_options=user_opts['perlmutter']['scheduler_options'],
@@ -31,13 +33,19 @@ config = Config(
                 # Command to be run before starting a worker, such as:
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['perlmutter']['worker_init'],
-
-                # We request all hyperthreads on a node.
-                launcher=SrunLauncher(overrides='-c 272'),
-                walltime='00:10:00',
+                
                 # Slurm scheduler on Cori can be slow at times,
                 # increase the command timeouts
                 cmd_timeout=120,
+
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=2,
+                init_blocks=0,
+                min_blocks=0,
+                max_blocks=1,
+
+                # Hold blocks for 10 minutes
+                walltime='00:10:00',
             ),
         ),
     ],

--- a/docs/configs/perlmutter.py
+++ b/docs/configs/perlmutter.py
@@ -25,7 +25,7 @@ config = Config(
 
                 # We request all hyperthreads on a node.
                 launcher=SrunLauncher(overrides='-c 272'),
-                
+
                 # string to prepend to #SBATCH blocks in the submit
                 # script to the scheduler eg: '#SBATCH --constraint=gpu'
                 scheduler_options=user_opts['perlmutter']['scheduler_options'],
@@ -33,7 +33,7 @@ config = Config(
                 # Command to be run before starting a worker, such as:
                 # 'module load Anaconda; source activate parsl_env'.
                 worker_init=user_opts['perlmutter']['worker_init'],
-                
+
                 # Slurm scheduler on Cori can be slow at times,
                 # increase the command timeouts
                 cmd_timeout=120,

--- a/docs/configs/theta.py
+++ b/docs/configs/theta.py
@@ -21,11 +21,13 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             max_workers_per_node=1,
+            worker_debug=False,
             address=address_by_hostname(),
             provider=CobaltProvider(
                 queue='debug-flat-quad',
                 account=user_opts['theta']['account'],
                 launcher=AprunLauncher(overrides="-d 64"),
+
                 # string to prepend to #COBALT blocks in the submit
                 # script to the scheduler eg: '#COBALT -t 50'
                 scheduler_options=user_opts['theta']['scheduler_options'],
@@ -34,11 +36,14 @@ config = Config(
                 # 'module load Anaconda; source activate funcx_env'.
                 worker_init=user_opts['theta']['worker_init'],
 
-                walltime='00:30:00',
+                # Scale between 0-1 blocks with 2 nodes per block
                 nodes_per_block=2,
-                init_blocks=1,
-                min_blocks=1,
+                init_blocks=0,
+                min_blocks=0,
                 max_blocks=1,
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00'
             ),
         )
     ],

--- a/docs/configs/theta_singularity.py
+++ b/docs/configs/theta_singularity.py
@@ -31,7 +31,7 @@ config = Config(
                 queue='debug-flat-quad',
                 account=user_opts['theta']['account'],
                 launcher=AprunLauncher(overrides="-d 64"),
-                
+
                 # string to prepend to #COBALT blocks in the submit
                 # script to the scheduler eg: '#COBALT -t 50'
                 scheduler_options=user_opts['theta']['scheduler_options'],

--- a/docs/configs/theta_singularity.py
+++ b/docs/configs/theta_singularity.py
@@ -21,6 +21,7 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             max_workers_per_node=1,
+            worker_debug=False,
             address=address_by_hostname(),
             scheduler_mode='soft',
             worker_mode='singularity_reuse',
@@ -30,6 +31,7 @@ config = Config(
                 queue='debug-flat-quad',
                 account=user_opts['theta']['account'],
                 launcher=AprunLauncher(overrides="-d 64"),
+                
                 # string to prepend to #COBALT blocks in the submit
                 # script to the scheduler eg: '#COBALT -t 50'
                 scheduler_options=user_opts['theta']['scheduler_options'],
@@ -38,11 +40,14 @@ config = Config(
                 # 'module load Anaconda; source activate funcx_env'.
                 worker_init=user_opts['theta']['worker_init'],
 
-                walltime='00:30:00',
+                # Scale between 0-1 blocks with 2 nodes per block
                 nodes_per_block=2,
-                init_blocks=1,
-                min_blocks=1,
+                init_blocks=0,
+                min_blocks=0,
                 max_blocks=1,
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00'
             ),
         )
     ],

--- a/docs/configs/uchicago_ai_cluster.py
+++ b/docs/configs/uchicago_ai_cluster.py
@@ -22,6 +22,7 @@ GPU_MAP = ','.join([str(x) for x in range(1, TOTAL_WORKERS + 1)])
 config = Config(
     executors=[HighThroughputExecutor(
         label="fe.cs.uchicago",
+        worker_debug=False,
         address=address_by_hostname(),
         provider=SlurmProvider(
             channel=LocalChannel(),

--- a/docs/configs/uchicago_ai_cluster.py
+++ b/docs/configs/uchicago_ai_cluster.py
@@ -1,5 +1,4 @@
 from parsl.addresses import address_by_hostname
-from parsl.channels import LocalChannel
 from parsl.launchers import SrunLauncher
 from parsl.providers import LocalProvider, SlurmProvider
 
@@ -20,26 +19,33 @@ WORKERS_PER_NODE = int(GPUS_PER_NODE / GPUS_PER_WORKER)
 GPU_MAP = ','.join([str(x) for x in range(1, TOTAL_WORKERS + 1)])
 
 config = Config(
-    executors=[HighThroughputExecutor(
-        label="fe.cs.uchicago",
-        worker_debug=False,
-        address=address_by_hostname(),
-        provider=SlurmProvider(
-            channel=LocalChannel(),
-            nodes_per_block=NODES_PER_JOB,
-            init_blocks=1,
-            partition='general',
-            # Launch 4 managers per node, each bound to 1 GPU
-            # This is a hack. We use hostname ; to terminate the srun command, and start our own
-            # DO NOT MODIFY unless you know what you are doing.
-            launcher=SrunLauncher(overrides=(f'hostname; srun --ntasks={TOTAL_WORKERS} '
-                                             f'--ntasks-per-node={WORKERS_PER_NODE} '
-                                             f'--gpus-per-task=rtx2080ti:{GPUS_PER_WORKER} '
-                                             f'--gpu-bind=map_gpu:{GPU_MAP}')
+    executors=[
+        HighThroughputExecutor(
+            label="fe.cs.uchicago",
+            worker_debug=False,
+            address=address_by_hostname(),
+            provider=SlurmProvider(
+                partition='general',
+
+                # Launch 4 managers per node, each bound to 1 GPU
+                # This is a hack. We use hostname ; to terminate the srun command, and start our own
+                # DO NOT MODIFY unless you know what you are doing.
+                launcher=SrunLauncher(overrides=(f'hostname; srun --ntasks={TOTAL_WORKERS} '
+                                                 f'--ntasks-per-node={WORKERS_PER_NODE} '
+                                                 f'--gpus-per-task=rtx2080ti:{GPUS_PER_WORKER} '
+                                                 f'--gpu-bind=map_gpu:{GPU_MAP}')
+                ),
+
+                # Scale between 0-1 blocks with 2 nodes per block
+                nodes_per_block=NODES_PER_JOB,
+                init_blocks=0,
+                min_blocks=0,
+                max_blocks=1,
+
+                # Hold blocks for 30 minutes
+                walltime='00:30:00',
             ),
-            walltime='01:00:00',
-        ),
-    )],
+        )],
 )
 
 # fmt: on


### PR DESCRIPTION
# Description

Updating the configs in the docs so that they follow the same order and include similar default settings. Main focus to set scaling behavior so as to avoid provisioning nodes by default (init and min blocks = 0).

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
