### PR TITLE
Updating results websocket url to wss://api2.funcx.org/ws/v2/

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -25,7 +25,7 @@ class WebSocketPollingTask:
         loop: AbstractEventLoop,
         atomic_controller=None,
         init_task_group_id: str = None,
-        results_ws_uri: str = "wss://api.funcx.org/ws/v2/",
+        results_ws_uri: str = "wss://api2.funcx.org/ws/v2/",
         auto_start: bool = True,
     ):
         """
@@ -50,7 +50,7 @@ class WebSocketPollingTask:
 
         results_ws_uri : str
             Web sockets URI for the results.
-            Default: wss://api.funcx.org/ws/v2
+            Default: wss://api2.funcx.org/ws/v2
 
         auto_start : Bool
             Set this to start the WebSocket client immediately.

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -57,7 +57,7 @@ class FuncXClient(FuncXErrorHandlingClient):
         check_endpoint_version=False,
         asynchronous=False,
         loop=None,
-        results_ws_uri="wss://api.funcx.org/ws/v2/",
+        results_ws_uri="wss://api2.funcx.org/ws/v2/",
         use_offprocess_checker=True,
         **kwargs,
     ):

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -160,7 +160,7 @@ def test_large_arrays(fx, endpoint):
 
 
 # test locally: python3 test_executor.py -e <endpoint_id>
-# test on dev: python3 test_executor.py -s https://api.dev.funcx.org/v2 -w wss://api.dev.funcx.org/ws/v2/ -e <endpoint_id>
+# test on dev: python3 test_executor.py -s https://api2.dev.funcx.org/v2 -w wss://api2.dev.funcx.org/ws/v2/ -e <endpoint_id>
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
# Description

Default results websockets URI were pointed at `wss://api.funcx.org/ws/v2/`. This PR updates it to `wss://api2.funcx.org/ws/v2/`

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
