### PR TITLE
Skip publish job on forked push and PR triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,8 @@ jobs:
         codecov --token=${{ secrets.CODECOV_TOKEN }}
 
   publish:
+    # only trigger on pushes to the main repo (not forks, and not PRs)
+    if: ${{ github.repository == 'funcx-faas/funcX' && github.event_name == 'push' }}
     needs: test
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
In order to run the `publish` step, the workflow must be executing
- on the main repo
- under a 'push' event

This means that the following activities will not run the `publish`
job:
- pushing a branch to a fork
- opening or updating a PR

PRs from forks would otherwise trigger the job and fail.