### PR TITLE
Endpoint disconnect retry loop

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -221,6 +221,8 @@ class EndpointInterchange(object):
         self.tasks = set()
         self.task_status_deltas = {}
 
+        self._test_start = False
+
     def load_config(self):
         """ Load the config
         """
@@ -473,10 +475,9 @@ class EndpointInterchange(object):
         while not self._kill_event.is_set():
             self._start_threads_and_main()
             self.quiesce()
-            # TODO: Remove this break. It is only meant to maintain existing functionality
-            # that the interchange only runs once, but can be removed when there is a proper
-            # endpoint re-registration mechanism in place.
-            break
+            # this check is solely for testing to force this loop to only run once
+            if self._test_start:
+                break
 
         logger.info("EndpointInterchange shutdown complete.")
 

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -135,6 +135,8 @@ class TestStart:
 
         ic.results_outgoing = mocker.Mock()
 
+        # this must be set to force the retry loop in the start method to only run once
+        ic._test_start = True
         ic.start()
 
         # we need to ensure that retry_call is called during interchange


### PR DESCRIPTION
# Description

Enable the endpoint retry loop

# Testing

For how to test, see: https://github.com/funcx-faas/funcX/pull/576

## Type of change

- New feature (non-breaking change that adds functionality)
