### PR TITLE
Pin back globus-sdk version

### DIFF
--- a/funcx_sdk/requirements.txt
+++ b/funcx_sdk/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.20.0
+globus-sdk<3
 jsonschema>=3.2.0
 configobj
 texttable


### PR DESCRIPTION
Right now it's unspecified, which is very, very, very wrong.

If it gets updated via transitive dependency doing its updates, a bunch of code in this repo which depends on SDK v2 or lower will break.