### PR TITLE
Bumping version to 0.3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Documentation: https://funcx.readthedocs.io/en/latest/
 Quickstart
 ==========
 
-funcX is in a beta state with version `0.3.2` currently available on PyPI.
+funcX is in a beta state with version `0.3.3` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 funcx & funcx-endpoint v0.3.3
 -----------------------------
 
-Released (tentatively) on September 20th, 2021
+Released on September 20th, 2021
 
 funcx v0.3.3 is a minor release that includes contributions (code, tests, reviews, and reports) from:
 

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.3a0"
+__version__ = "0.3.3"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.3.0
+funcx>=0.3.3<=0.4.0
 pyzmq>=22.0.0
 retry

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -7,6 +7,6 @@ python-daemon
 fair_research_login
 dill>=0.3
 typer>=0.3.0
-funcx>=0.3.3<=0.4.0
+funcx>=0.3.3,<0.4.0
 pyzmq>=22.0.0
 retry

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.3a0"
+__version__ = "0.3.3"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
# Description

Version bump to 0.3.3.

Please note that this PR updates the funcx-endpoint requirement line to use `funcx>=0.3.3,<0.4`

## Type of change

- Documentation update
- Code maintentance/cleanup
