### PR TITLE
Updating docs on blocking behavior, funcX service limits and exceptions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     # 'sphinx.ext.linkcode',
     "sphinx.ext.napoleon",
+    "sphinx.ext.autosectionlabel",
 ]
 
 autosummary_generate = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,7 @@ how to download and configure an endpoint for local (multi-process) execution. :
    actionprovider
    reference
    debugging
+   limits
    changelog
 
 Indices and tables

--- a/docs/limits.rst
+++ b/docs/limits.rst
@@ -1,0 +1,67 @@
+Limits
+------
+
+This section describes the limits placed by funcX to ensure high availability and reliability to
+all users sharing this hosted service. Routing high volumes of tasks and results between users
+and endpoints is resource-intensive from a computation, memory, and network transport perspective.
+To guarantee truly fire and forget tasks and fairness for all users funcX applies the limitations
+described below uniformly to all users.
+
+There are three mechanisms by which funcX controls the flow of tasks through the system:
+
+* Task-Rate limiting: Controls the rate at which you can submit new tasks to funcX
+* Data limits: Restricts the data volume for task inputs and outputs
+* Task TTL: Sets the maximum task lifetime after which stale tasks are abandoned
+
+
+Task-Rate Limiting
+^^^^^^^^^^^^^^^^^^
+
+funcX uses Task-Rate limiting to ensure the quality of service to all users on the funcX platform.
+These limits ensure that users might not accidentally overload the service with requests and overload
+the system for everyone else. Currently, funcX limits the number of requests submitted from a client to
+**20 requests per 10 seconds**.
+
+If this submission rate is exceeded, the SDK will raise a ``MaxRequestsExceeded`` exception.
+
+The recommended mechanism to submit a large number of tasks quickly while avoiding the rate-limiting is
+to use :ref:`Batching`. Please note that while many tasks could be submitted together as a single batch,
+each batch request is still subject to the limits on the data payload allowed per request described below.
+
+
+Data Limits
+^^^^^^^^^^^
+
+Data limits are used to ensure that the inputs and results associated with functions can be handled
+by funcx both at the user level as well as in the aggregate. Without these limits functions that either
+consume or produce large volumes of data could overload the system.
+
+The current data limit is set to **5MB** on task submissions, which applies to both individual functions
+as well as batch submissions. The SDK will raise a ``MaxRequestSizeExceeded`` exception when this limit
+is exceeded. This limit currently is much larger than the limit on result size since this limit applies
+to batch job requests.
+
+Similarly, there is a data limit of **512KB** on result size on a per-function basis. If the serialized
+result from a task exceeds this limit, a ``MaxResultSizeExceeded`` exception is reported by the SDK when
+the task request is queried. In this case, the result is unrecoverable.
+
+If your function results are larger than supported limits, the recommended approach is to write the
+results to disk and have a data transfer solution like `Globus <https://www.globus.org/data-transfer>`_
+move the data independently.
+
+
+Task TTL
+^^^^^^^^
+
+Task time to live (TTL) is a mechanism to identify tasks that are possibly abandoned. In a computing
+environment where tasks may take several days to be allocated compute resources (eg, by a cluster) or
+simply take days to run to completion, distinguishing between tasks that are blocked vs abandoned is
+difficult. On the other hand, tasks once launched can be lost on the client-side due to a crash or a
+programmatic error. To avoid such cases, funcX considers a task to be abandoned when there has been
+no activity on a task for more than **2 weeks**. However, when a result is available but has not been
+fetched by the client within **30 minutes** of completion, the result is marked as abandoned.
+
+
+
+
+

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -32,8 +32,8 @@ funcx-endpoint
     funcx_endpoint.strategies.kube_simple.KubeSimpleStrategy
 
 
-Exception
-=========
+Exceptions
+==========
 
 .. autosummary::
     :toctree: stubs
@@ -49,4 +49,6 @@ Exception
     funcx.utils.errors.UserCancelledException
     funcx.utils.errors.InvalidScopeException
     funcx.utils.errors.HTTPError
+    funcx.sdk.utils.throttling.MaxRequestsExceeded
+    funcx.sdk.utils.throttling.MaxRequestSizeExceeded
     funcx_endpoint.executors.high_throughput.funcx_worker.MaxResultSizeExceeded

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -170,15 +170,15 @@ corresponding to the functions in the batch with the ordering preserved.
   batch_res = fxc.batch_run(batch)
 
 
-There is also a batch result interface to retrieve the results of a batch.
+The batch result interface is useful to to fetch the results of a collection of task_ids.
 ``get_batch_result`` is called with a list of task_ids. It is non-blocking and returns
 a `dict` with task_ids as the keys and each value is a dict that contains status information
 and a result if it is available.
 
 .. code-block:: python
 
-  >>>results = fxc.get_batch_result(batch_res)
-  >>>print(results)
+  >>> results = fxc.get_batch_result(batch_res)
+  >>> print(results)
 
   {'10c9678c-b404-4e40-bfd4-81581f52f9db': {'pending': False,
                                             'status': 'success',

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -97,7 +97,7 @@ Arguments and data
 ------------------
 funcX functions operate the same as any other Python function. You can pass arguments \*args and \**kwargs
 and return values from functions. The only constraint is that data passed to/from a funcX function must be
-serializable (e.g., via Pickle) and less than 512KB in size.  Input arguments can be passed to the function
+serializable (e.g., via Pickle) and fall within :ref:`Limits` .  Input arguments can be passed to the function
 using the `run()` function. The following example shows how strings can be passed to and from a function.
 
 .. code-block:: python
@@ -156,7 +156,8 @@ Batching
 
 The SDK includes a batch interface to reduce the overheads of launching a function many times.
 To use this interface, you must first create a batch object and then pass that object
-to the ``batch_run`` function.
+to the ``batch_run`` function. ``batch_run`` is non-blocking and returns a list of task ids
+corresponding to the functions in the batch with the ordering preserved.
 
 .. code-block:: python
 

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -69,6 +69,10 @@ monitor status and retrieve results.
   tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df'
   task_id = fxc.run(endpoint_id=tutorial_endpoint, function_id=func_uuid)
 
+.. note::
+   funcX places limits on the size of the functions and the rate at which functions can be submitted.
+   Please refer to the limits section for TODO:YADU
+
 
 Retrieving Results
 -------------------
@@ -93,7 +97,7 @@ Arguments and data
 ------------------
 funcX functions operate the same as any other Python function. You can pass arguments \*args and \**kwargs
 and return values from functions. The only constraint is that data passed to/from a funcX function must be
-serializable (e.g., via Pickle) and less than 2 MB in size.  Input arguments can be passed to the function
+serializable (e.g., via Pickle) and less than 512KB in size.  Input arguments can be passed to the function
 using the `run()` function. The following example shows how strings can be passed to and from a function.
 
 .. code-block:: python
@@ -145,12 +149,14 @@ or publicly accessible functions via the `search_function()` function.
   print(search_results)
 
 
+.. _batching:
+
 Batching
 --------------
 
 The SDK includes a batch interface to reduce the overheads of launching a function many times.
 To use this interface, you must first create a batch object and then pass that object
-to the `batch_run` function.
+to the ``batch_run`` function.
 
 .. code-block:: python
 
@@ -159,29 +165,36 @@ to the `batch_run` function.
   for x in range(0,5):
     batch.add(x, endpoint_id=tutorial_endpoint, function_id=func_id)
 
+  # batch_run returns a list task ids
   batch_res = fxc.batch_run(batch)
 
+
 There is also a batch result interface to retrieve the results of a batch.
+``get_batch_result`` is called with a list of task_ids. It is non-blocking and returns
+a `dict` with task_ids as the keys and each value is a dict that contains status information
+and a result if it is available.
 
 .. code-block:: python
 
-  fxc.get_batch_result(batch_res)
+  >>>results = fxc.get_batch_result(batch_res)
+  >>>print(results)
 
+  {'10c9678c-b404-4e40-bfd4-81581f52f9db': {'pending': False,
+                                            'status': 'success',
+                                            'result': 0,
+                                            'completion_t': '1632876695.6450012'},
+   '587afd2e-59e0-4d2d-82ab-cee409784c4c': {'pending': False,
+                                            'status': 'success',
+                                            'result': 0,
+                                            'completion_t': '1632876695.7048604'},
+   '11f34d69-913a-4442-ae79-ede046585d8f': {'pending': True,
+                                            'status': 'waiting-for-ep'},
+   'a2d86014-28a8-486d-b86e-5f38c80d0333': {'pending': True,
+                                            'status': 'waiting-for-ep'},
+   'e453a993-73e6-4149-8078-86e7b8370c35': {'pending': True,
+                                            'status': 'waiting-for-ep'}
+  }
 
-Client Throttling
------------------
-
-In order to avoid overloading funcX, we place soft throttling restrictions on the funcX client.
-There are two key throttling measures: first, we limit the number of requests a client can make (20 requests every 10 seconds),
-and second, we limit the size of input and output transmitted through the service (5 MB per request).
-
-Batching requests and status can help reduce the number of requests made to the Web Service. In addition, the limit on
-the number of requests made to the Web Service can be removed by setting `throttling_enabled` to False.
-
-.. code-block:: python
-
-  fxc = FuncXClient()
-  fxc.throttling_enabled = False
 
 
 FuncXClient Reference:


### PR DESCRIPTION
# Description

* New section on limits, and some notes on how to effectively work within those limits
* Clarification on blocking behavior on batch operations
* Clarification on return values from batch ops
* Added missing throttling exceptions to references.
* Removed the bit on client throttling that tells the user how to disable client-side throttling, which IMO is a bad idea.

The limits section now covers 3 different mechanisms by which funcX limits what functions can run and how.

P.S The docs now say 30 mins is the TTL limit on results, which we don't enforce yet.


Fixes # (issue)
[ch10382]
[ch10725]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
