### PR TITLE
Updating batch status test to wait upto 60s for results

### DIFF
--- a/funcx_endpoint/tests/smoke_tests/test_running_functions.py
+++ b/funcx_endpoint/tests/smoke_tests/test_running_functions.py
@@ -28,9 +28,14 @@ def test_batch(fxc, endpoint):
 
     batch_res = fxc.batch_run(batch)
 
-    time.sleep(10)
+    total = 0
+    for _i in range(12):
+        time.sleep(5)
+        results = fxc.get_batch_result(batch_res)
+        try:
+            total = sum(results[tid]["result"] for tid in results)
+            break
+        except KeyError:
+            pass
 
-    results = fxc.get_batch_result(batch_res)
-
-    total = sum(results[tid]["result"] for tid in results)
     assert total == 2 * (sum(inputs)), "Batch run results do not add up"


### PR DESCRIPTION
# Description

Smoke tests have failed a couple of times recently when the batch tests failed to return results in the allotted 10s wait time.
This PR switches over to iteratively calling batch_status every 5s (max 60s) and exiting as soon as all the results are 
accounted for. While this slows down the tests when there is indeed a failure, it should minimize the false positives. 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
