### PR TITLE
Bound the `globus-sdk` version for funcx-endpoint

### DIFF
--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -5,6 +5,7 @@ texttable
 psutil
 python-daemon
 fair_research_login
+globus_sdk<3
 dill>=0.3
 typer>=0.3.0
 funcx>=0.3.3,<0.4.0


### PR DESCRIPTION
I found that something odd happened with version solving in `pip` when I did a `cd funcx_endpoint; pip install .`

For whatever reason, the solver picked the latest SDK version.
Until the funcx-sdk package is updated to use SDKv3, this won't work.

I haven't worked very hard to isolate and reproduce the issue because I don't think it's worth it. We should just pin the version until we can update, to guarantee that the solver can't fail like this.