### PR TITLE
Don't swallow sigterm

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -462,6 +462,7 @@ class EndpointInterchange(object):
             logger.exception("Caught exception while saving unacked results")
         else:
             logger.info("Unacked results successfully saved to disk")
+        sys.exit(1)
 
     def start(self):
         """ Start the Interchange


### PR DESCRIPTION
`funcx-endpoint stop` doesn't work, nor does `pkill -f funcx`. We eat sigterms for breakfast, lunch, and dinner.
Solution? Exit.