### PR TITLE
Fix ZMQ poller registration

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/taskqueue.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/taskqueue.py
@@ -91,8 +91,7 @@ class TaskQueue(object):
             self.zmq_socket.connect("tcp://{}:{}".format(address, port))
 
         self.poller = zmq.Poller()
-        self.poller.register(self.zmq_socket, zmq.POLLOUT)
-        self.poller.register(self.zmq_socket, zmq.POLLIN)
+        self.poller.register(self.zmq_socket)
         os.makedirs(self.keys_dir, exist_ok=True)
         logger.debug(f"Initializing Taskqueue:{self.mode} on port:{self.port}")
 


### PR DESCRIPTION
`POLLOUT | POLLIN` is the default for `register()`. Setting `POLLOUT` and then setting `POLLIN` is probably not what was meant, since these are flags being set. On the *assumption* that `POLLOUT | POLLIN` is desired, this fixes the usage to align with that.