### PR TITLE
Pin pyzmq to not use borked version

### DIFF
--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -9,5 +9,9 @@ globus_sdk<3
 dill>=0.3
 typer>=0.3.0
 funcx>=0.3.3,<0.4.0
-pyzmq>=22.0.0
+# disallow use of 22.3.0
+# whl packages on some platforms seem to produce ZMQ issues
+# FIXME: re-evaluate this and see if the version pin can be removed after the
+# forwarder is upgraded to a newer libzmq
+pyzmq>=22.0.0,!=22.3.0
 retry


### PR DESCRIPTION
pyzmq v22.3.0 is somehow not working, as we've discussed in various contexts.

We should re-test after upgrading the forwarder. I would only bother trying to report this upstream if it persists after that.