### PR TITLE
Fix endpoint requirements

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -16,7 +16,6 @@ import daemon
 import daemon.pidfile
 import psutil
 import requests
-import texttable as tt
 import typer
 from retry import retry
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -13,7 +13,7 @@ from string import Template
 import daemon
 import daemon.pidfile
 import psutil
-import texttable as tt
+import texttable
 import typer
 
 import funcx
@@ -390,7 +390,7 @@ class EndpointManager:
         self.logger.info("Endpoint <{}> has been cleaned up.".format(self.name))
 
     def list_endpoints(self):
-        table = tt.Texttable()
+        table = texttable.Texttable()
 
         headings = ['Endpoint Name', 'Status', 'Endpoint ID']
         table.header(headings)

--- a/funcx_endpoint/requirements.txt
+++ b/funcx_endpoint/requirements.txt
@@ -1,20 +1,43 @@
-requests>=2.20.0
-jsonschema>=3.2.0
-configobj
-texttable
-psutil
-python-daemon
-fair_research_login
+requests>=2.20.0,<3
 globus_sdk<3
-dill>=0.3
-typer>=0.3.0
 funcx>=0.3.3,<0.4.0
-# disallow use of 22.3.0
-# whl packages on some platforms seem to produce ZMQ issues
-# FIXME: re-evaluate this and see if the version pin can be removed after the
-# forwarder is upgraded to a newer libzmq
+
+# table printing used in list-endpoints
+texttable>=1.6.4,<2
+
+# although psutil does not declare itself to use semver, it appears to offer
+# strong backwards-compatibility promises based on its changelog, usage, and
+# history
+#
+# TODO: re-evaluate bound after we have an answer of some kind from psutil
+# see:
+#   https://github.com/giampaolo/psutil/issues/2002
+psutil<6
+
+# provides easy daemonization of the endpoint
+python-daemon>=2,<3
+
+# TODO: replace use of `typer` with `click` because
+# 1. `typer` is a thin wrapper over `click` offering very minimal additional
+#    functionality
+# 2. `click` follows semver and releases new major versions when known
+#    backwards-incompatible changes are introduced, making our application
+#    safer to distribute
+typer==0.4.0
+
+
+# disallow use of 22.3.0; the whl package on some platforms causes ZMQ issues
+#
+# NOTE: 22.3.0 introduced a patched version of libzmq.so to the wheel packaging
+# which may be the source of the problems , the problem can be fixed by
+# building from source, which may mean there's an issue in the packaged library
+# further investigation may be needed if the issue persists in the next pyzmq
+# release
 pyzmq>=22.0.0,!=22.3.0
-retry
+
+# TODO: evaluate removal of the 'retry' library after the update to
+# globus-sdk v3, which provides automatic retries on all API calls
+retry==0.9.2
 
 # 'parsl' is a core requirement of the funcx-endpoint, essential to a range
 # of different features and functions


### PR DESCRIPTION
This is based on #613 and is the equivalent change for the endpoint.

I did edit the use of `texttable` to make it more obvious if you `git grep texttable` that it is used in the endpoint. (I also think that the `import foo as bar` syntax in python should be used _extremely_ rarely. The only place I use it is for `typing`, and I've yet to see another well-justified use of it.)