### PR TITLE
Remove 'funcx_version' from test data

### DIFF
--- a/funcx_endpoint/tests/smoke_tests/conftest.py
+++ b/funcx_endpoint/tests/smoke_tests/conftest.py
@@ -25,7 +25,6 @@ _CONFIGS = {
         # assert versions are as expected on prod
         "forwarder_version": "0.3.3",
         "api_version": "0.3.3",
-        "funcx_version": "0.3.3",
         # This fn is public and searchable
         "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
         # For production tests, the target endpoint should be the tutorial_endpoint


### PR DESCRIPTION
Never used.

---

See also: https://github.com/funcx-faas/funcx-web-service/pull/263