### PR TITLE
Warn and continue on failure to load a results ack file

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/results_ack.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/results_ack.py
@@ -3,7 +3,9 @@ import time
 import os
 import pickle
 
-logger = logging.getLogger("endpoint." + __name__)
+# The logger path needs to start with endpoint. while the current path
+# start with funcx_endpoint.endpoint.
+logger = logging.getLogger("endpoint.results_ack")
 
 
 class ResultsAckHandler():


### PR DESCRIPTION
# Description

An endpoint would fail to start if it encountered a bad `results_ack.p` file. In bad termination events it is easy to end up with this file getting corrupt. This PR adds some handling around the `UnpicklingError` usually raised in this situation.

Here's an example of what happens now:
```
(funcx_py3.7) yadu@borgmachine:~/.funcx/foo$ funcx-endpoint start foo
2021-10-19 15:47:13 endpoint.endpoint_manager:175 [INFO]  Starting endpoint with uuid: 327622bd-5a55-4b6d-a83e-89d844df04d2
2021-10-19 15:47:13 endpoint.endpoint_manager:187 [INFO]  A prior Endpoint instance appears to have been terminated without proper cleanup. Cleaning up now.
2021-10-19 15:47:13 endpoint.endpoint_manager:390 [INFO]  Endpoint <foo> has been cleaned up.
2021-10-19 15:47:13 endpoint.endpoint_manager:196 [ERROR]  Caught exception while attempting load and persist of outstanding results
Traceback (most recent call last):
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/funcx_endpoint/endpoint/endpoint_manager.py", line 193, in start_endpoint
    results_ack_handler.load()
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/funcx_endpoint/endpoint/results_ack.py", line 86, in load
    self.unacked_results = pickle.load(fp)
_pickle.UnpicklingError: invalid load key, 'A'.

```

Here's the output with the changes from this PR:
```
(funcx_py3.7) yadu@borgmachine:~/src/funcx-clean$ funcx-endpoint start foo
2021-10-19 15:49:58 endpoint.endpoint_manager:175 [INFO]  Starting endpoint with uuid: 327622bd-5a55-4b6d-a83e-89d844df04d2
2021-10-19 15:49:58 endpoint.endpoint_manager:187 [INFO]  A prior Endpoint instance appears to have been terminated without proper cleanup. Cleaning up now.
2021-10-19 15:49:58 endpoint.endpoint_manager:390 [INFO]  Endpoint <foo> has been cleaned up.
[WARNING] Cached results /home/yadu/.funcx/foo/unacked_results.p appear to be corrupt. Proceeding without loading cached results
2021-10-19 15:49:58 endpoint.endpoint_manager:259 [INFO]  Launching endpoint daemon process

```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
