### PR TITLE
Extend smoke test timeouts

### DIFF
--- a/funcx_endpoint/tests/smoke_tests/test_async.py
+++ b/funcx_endpoint/tests/smoke_tests/test_async.py
@@ -10,7 +10,7 @@ async def simple_task(fxc, endpoint):
     squared_function = fxc.register_function(squared)
     x = random.randint(0, 100)
     task = fxc.run(x, endpoint_id=endpoint, function_id=squared_function)
-    result = await asyncio.wait_for(task, 20)
+    result = await asyncio.wait_for(task, 60)
     assert result == squared(x), "Got wrong answer"
 
 

--- a/funcx_endpoint/tests/smoke_tests/test_executor.py
+++ b/funcx_endpoint/tests/smoke_tests/test_executor.py
@@ -11,4 +11,4 @@ def test_executor_basic(fx, endpoint):
     x = random.randint(0, 100)
     fut = fx.submit(double, x, endpoint_id=endpoint)
 
-    assert fut.result(timeout=10) == x * 2, "Got wrong answer"
+    assert fut.result(timeout=60) == x * 2, "Got wrong answer"

--- a/funcx_endpoint/tests/smoke_tests/test_running_functions.py
+++ b/funcx_endpoint/tests/smoke_tests/test_running_functions.py
@@ -5,7 +5,7 @@ def test_run_pre_registered_function(fxc, endpoint, tutorial_funcion_id):
     """This test confirms that we are connected to the default production DB"""
     fn_id = fxc.run(endpoint_id=endpoint, function_id=tutorial_funcion_id)
 
-    time.sleep(10)
+    time.sleep(30)
 
     result = fxc.get_result(fn_id)
     assert result == "Hello World!", f"Expected result: Hello World!, got {result}"


### PR DESCRIPTION
# Description

This PR extends the timeouts for the more finicky tests in the smoke_tests.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
