### PR TITLE
Cleanup linting on sdk tests

### DIFF
--- a/funcx_sdk/funcx/tests/conftest.py
+++ b/funcx_sdk/funcx/tests/conftest.py
@@ -4,7 +4,7 @@ from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
 
 config = {
-    "funcx_service_address": "https://api2.funcx.org/v2",  # For testing against local k8s
+    "funcx_service_address": "https://api2.funcx.org/v2",
     "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
 }

--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_endpoint.py
@@ -1,6 +1,5 @@
 import pytest
 
-from funcx.sdk.client import FuncXClient
 from funcx.utils.response_errors import EndpointNotFound
 
 

--- a/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
+++ b/funcx_sdk/funcx/tests/test_errors/test_invalid_function.py
@@ -1,8 +1,5 @@
-import time
-
 import pytest
 
-from funcx.sdk.client import FuncXClient
 from funcx.utils.response_errors import FunctionNotFound
 
 

--- a/funcx_sdk/funcx/tests/test_executor.py
+++ b/funcx_sdk/funcx/tests/test_executor.py
@@ -177,7 +177,8 @@ def test_batch_delays(batch_fx, endpoint):
 
 
 # test locally: python3 test_executor.py -e <endpoint_id>
-# test on dev: python3 test_executor.py -s https://api2.dev.funcx.org/v2 -w wss://api2.dev.funcx.org/ws/v2/ -e <endpoint_id>
+# test on dev:
+#   python3 test_executor.py -s https://api2.dev.funcx.org/v2 -w wss://api2.dev.funcx.org/ws/v2/ -e <endpoint_id>    # noqa:E501
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/funcx_sdk/funcx/tests/test_performance/test_performance.py
+++ b/funcx_sdk/funcx/tests/test_performance/test_performance.py
@@ -2,8 +2,6 @@ import time
 
 import pytest
 
-from funcx.sdk.client import FuncXClient
-
 
 def double(x):
     return x * 2

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -1,6 +1,5 @@
 import pytest
 
-from funcx.sdk.client import FuncXClient
 from funcx.utils.errors import TaskPending
 from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
 
@@ -47,7 +46,10 @@ def test_allowed_result_sizes(fxc, endpoint, size):
 
 
 def test_result_size_too_large(fxc, endpoint, size=550000):
-    """funcX should raise a MaxResultSizeExceeded exception when results exceeds 512KB limit"""
+    """
+    funcX should raise a MaxResultSizeExceeded exception when results exceeds 512KB
+    limit
+    """
     fn_uuid = fxc.register_function(
         large_result_producer, endpoint, description="LargeResultProducer"
     )


### PR DESCRIPTION
This is part 1 of 42 (give or take, depending on how I chunk things). I will give less explanation on subsequent PRs, but as this is the first, I should explain how I did things.

I wrote new linting config for use of black, isort, flake8, and pyupgrade in pre-commit. I then applied it to the whole codebase to get the fixers satisfied. This didn't pacify flake8 because these tools avoid making certain "unsafe" changes to the AST or CST, determined on a tool-by-tool basis.
Then I manually modifyied files and committed them in batches with `--no-verify` to avoid pre-commit failures.
Finally, there's one last commit which adds the new config -- which means that there is no commit in this series where linting is expected to fail.

Once all of the changes are merged, we can apply the new linting config, and apply any remaining fixup based on drift between the time of these changes and the application of the new config.

This approach will hopefully minimize conflicts and make conflict-handling easier, and I can rebase the "source" branch for these changes as we get chunks merged.
Here's the GitHub compare view on the original branch: https://github.com/funcx-faas/funcX/compare/main...sirosen:cleanup-linting

---

In this case we're eliminating unused imports, resolving lines which are too long, and in one case marking with noqa as it is appropriate here.

I'm against using noqa comments except when there's a sufficiently strong justification (i.e. don't use them for "I don't like this rule" cases). For a copy-paste-able shell command in a comment, it's better to noqa than to break it up with `\`, since it preserves the utility of copy-paste.