### PR TITLE
Fix embed of funcX model image

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ results. funcX securely communicates with remote endpoints, waits for resources
 to become available, and can even retry execution upon failure. funcX stores results (or
 errors) in the cloud-hosted service until they are retrieved by the user.
 
-.. image:: img/funcx-model.png
+.. image:: img/funcX-model.png
 
 
 Using funcX


### PR DESCRIPTION
The model image wasn't displaying on https://funcx.readthedocs.io/en/latest/

This PR should fix that.