### PR TITLE
Port parsl BadRegistration error message clarification to funcx fork

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -67,15 +67,15 @@ class ManagerLost(Exception):
 class BadRegistration(Exception):
     ''' A new Manager tried to join the executor with a BadRegistration message
     '''
-
     def __init__(self, worker_id, critical=False):
         self.worker_id = worker_id
         self.tstamp = time.time()
         self.handled = "critical" if critical else "suppressed"
 
     def __repr__(self):
-        return "Manager:{} caused a {} failure".format(self.worker_id,
-                                                       self.handled)
+        return "Manager {} attempted to register with a bad registration message. Caused a {} failure".format(
+            self.worker_id,
+            self.handled)
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
This clarification was introduced as part of
https://github.com/Parsl/parsl/pull/980

I have not examined the rest of that PR for relevance to this fork.

I've encountered confusion due to the phrasing of this error twice during the review of PR #606 

## Type of change

- Documentation update
- Code maintentance/cleanup
