### PR TITLE
Broaden htex interchange->executor error message phrasing

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -542,7 +542,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                         if tid == -1 and 'exception' in msg:
                             # TODO: This could be handled better we are essentially shutting down the
                             # client with little indication to the user.
-                            logger.warning("[MTHREAD] Executor shutting down due to version mismatch in interchange")
+                            logger.warning("[MTHREAD] Executor shutting down due to fatal exception from interchange")
                             self._executor_exception = fx_serializer.deserialize(msg['exception'])
                             logger.exception("[MTHREAD] Exception: {}".format(self._executor_exception))
                             # Set bad state to prevent new tasks from being submitted


### PR DESCRIPTION
Previously the error message claimed that the fatal error was due to
version mismatch.

This is not true: this same fatal error may occur in the case of a
BadRegistration.

This PR rephrases the error to be less misleading.

I have encountered this repeatedly during review of #909, and at
least I think Yadu was getting it while hacking on this code.

## Type of change
- Documentation update
- Code maintentance/cleanup
