### PR TITLE
Expand daily build to all days

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,8 +1,8 @@
 name: daily
 on:
-  # build every weekday at 4:00 AM UTC
+  # build every day at 4:00 AM UTC
   schedule:
-    - cron: '0 4 * * 1-5'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Originally, I meant for this PR to also add `safety` to install extras, but I've decided not to do that.
Why? Because `safety` is not meant for analysis of the `funcx[test]` extra, only the main `funcx` requirements (and likewise for the endpoint).

I want to take some more time to think about how we're going to pull in `safety` -- a dedicated extra, adding it to a `funcx[dev]` extra (and not worrying about it checking test dependencies), a tox testenv, or maybe something else.