### PR TITLE
Make smoke tests check min version, not exact

### DIFF
--- a/funcx_endpoint/tests/smoke_tests/conftest.py
+++ b/funcx_endpoint/tests/smoke_tests/conftest.py
@@ -24,9 +24,9 @@ _CONFIGS = {
             "funcx_service_address": "https://api.dev.funcx.org/v2",
             "results_ws_uri": "wss://api.dev.funcx.org/ws/v2/",
         },
-        # assert versions are as expected on prod
-        "forwarder_version": "0.3.5",
-        "api_version": "0.3.5",
+        # assert versions are as expected on dev
+        "forwarder_min_version": "0.3.5",
+        "api_min_version": "0.3.5",
         # This fn is public and searchable
         "public_hello_fn_uuid": "f84351f9-6f82-45d8-8eca-80d8f73645be",
         "endpoint_uuid": _LOCAL_ENDPOINT_ID,
@@ -36,8 +36,8 @@ _CONFIGS = {
         # any arguments to the client object (default will point at prod stack)
         "client_args": {},
         # assert versions are as expected on prod
-        "forwarder_version": "0.3.5",
-        "api_version": "0.3.5",
+        "forwarder_min_version": "0.3.5",
+        "api_min_version": "0.3.5",
         # This fn is public and searchable
         "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
         # For production tests, the target endpoint should be the tutorial_endpoint

--- a/funcx_endpoint/tests/smoke_tests/test_version.py
+++ b/funcx_endpoint/tests/smoke_tests/test_version.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import requests
 
 
@@ -13,11 +15,13 @@ def test_web_service(fxc, endpoint, funcx_test_config):
     )
 
     service_version = response.json()
-    api_version = funcx_test_config.get("api_version")
-    if api_version is not None:
+    api_min_version = funcx_test_config.get("api_min_version")
+    if api_min_version is not None:
+        parsed_min = LooseVersion(api_min_version)
+        parsed_service = LooseVersion(service_version)
         assert (
-            service_version == api_version
-        ), f"Expected API version:{api_version}, got {service_version}"
+            parsed_service >= parsed_min
+        ), f"Expected API version >={api_min_version}, got {service_version}"
 
 
 def test_forwarder(fxc, endpoint, funcx_test_config):
@@ -32,11 +36,13 @@ def test_forwarder(fxc, endpoint, funcx_test_config):
     )
 
     forwarder_version = response.json()["forwarder"]
-    expected_version = funcx_test_config.get("forwarder_version")
-    if expected_version:
+    min_version = funcx_test_config.get("forwarder_min_version")
+    if min_version:
+        parsed_min = LooseVersion(min_version)
+        parsed_forwarder = LooseVersion(forwarder_version)
         assert (
-            forwarder_version == expected_version
-        ), f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
+            parsed_forwarder >= parsed_min
+        ), f"Expected Forwarder version >= {min_version}, got {forwarder_version}"
 
 
 def say_hello():


### PR DESCRIPTION
Check against the API response with a loose version comparison, not an equality check. This means that the smoke tests set a "floor" for what versions are allowed, but do not fail when a release is done.

---

Example of a failure (by modifying the config):
```
        forwarder_version = response.json()["forwarder"]
        min_version = funcx_test_config.get("forwarder_min_version")
        if min_version:
            parsed_min = LooseVersion(min_version)
            parsed_forwarder = LooseVersion(forwarder_version)
>           assert (
                parsed_forwarder >= parsed_min
            ), f"Expected Forwarder version >= {min_version}, got {forwarder_version}"
E           AssertionError: Expected Forwarder version >= 0.3.6, got 0.3.5
E           assert LooseVersion ('0.3.5') >= LooseVersion ('0.3.6')
```