### PR TITLE
Fix subject line in hourly smoke test

### DIFF
--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -41,7 +41,7 @@ jobs:
           server_port: 465
           username: ${{secrets.MAIL_USERNAME}}
           password: ${{secrets.MAIL_PASSWORD}}
-          subject: ${{ github.repository }} - Tutorial test ${{ job.status }}
+          subject: ${{ github.repository }} - Hourly smoke test failed
           to: ryan.chard@gmail.com,rchard@anl.gov,chard@uchicago.edu,yadudoc1729@gmail.com,josh@globus.org,bengal1@illinois.edu,benc@hawaga.org.uk,sirosen@globus.org,uriel@globus.org
           from: funcX Tests # <user@example.com>
           body: The hourly ${{ github.repository }} workflow failed!


### PR DESCRIPTION
Previously, the subject line reported a success when sending failure messages.

```
Subject: funcx-faas/funcX - Tutorial test success
```

presumably because the `job.status` substitution does not match up with the boolean value of `    if: failure()`

Also rename "tutorial" to hourly smoke test.

## Type of change

- Bug fix (non-breaking change that fixes an issue)