### PR TITLE
Adding a minimal s3 smoke test

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install './funcx_sdk[test]'
+        python -m pip install './funcx_endpoint'
     - name: Run smoke tests to check liveness of hosted services
       run: |
         pytest -v funcx_endpoint/tests/smoke_tests --api-client-id ${{ secrets.API_CLIENT_ID }} --api-client-secret ${{ secrets.API_CLIENT_SECRET }}

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install './funcx_sdk[test]'
+        # fixme: Remove this next install line once issue #640 is fixed.
         python -m pip install './funcx_endpoint'
     - name: Run smoke tests to check liveness of hosted services
       run: |

--- a/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
+++ b/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
@@ -11,16 +11,12 @@ def large_arg_consumer(data: str) -> int:
     return len(data)
 
 
-test_cases = [200, 2000, 20000, 200000]
-
-
-@pytest.mark.parametrize("size", test_cases)
+@pytest.mark.parametrize("size", [200, 2000, 20000, 200000])
 def test_allowed_result_sizes(fx, endpoint, size):
     """funcX should allow all listed result sizes which are under 512KB limit"""
 
     future = fx.submit(large_result_producer, size, endpoint_id=endpoint)
-    x = future.result(timeout=60)
-    assert len(x) == size, "Result size does not match excepted size"
+    assert len(future.result(timeout=60)) == size
 
 
 def test_result_size_too_large(fx, endpoint, size=550000):
@@ -33,13 +29,12 @@ def test_result_size_too_large(fx, endpoint, size=550000):
         future.result(timeout=60)
 
 
-@pytest.mark.parametrize("size", test_cases)
+@pytest.mark.parametrize("size", [200, 2000, 20000, 200000])
 def test_allowed_arg_sizes(fx, endpoint, size):
     """funcX should allow all listed result sizes which are under 512KB limit"""
 
     future = fx.submit(large_arg_consumer, bytearray(size), endpoint_id=endpoint)
-    x = future.result(timeout=60)
-    assert x == size, "Arg size does not match excepted size"
+    assert future.result(timeout=60) == size
 
 
 @pytest.mark.skip(reason="As of 0.3.4, an arg size limit is not being enforced")

--- a/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
+++ b/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
@@ -42,7 +42,7 @@ def test_allowed_arg_sizes(fx, endpoint, size):
     assert x == size, "Arg size does not match excepted size"
 
 
-@pytest.mark.xfail(reason="As of 0.3.4, an arg size limit is not being enforced")
+@pytest.mark.skip(reason="As of 0.3.4, an arg size limit is not being enforced")
 def test_arg_size_too_large(fx, endpoint, size=55000000):
     """funcX should raise an exception for objects larger than some limit,
     which we are yet to define. This does not work right now.

--- a/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
+++ b/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
@@ -1,0 +1,53 @@
+import pytest
+
+from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
+
+
+def large_result_producer(size: int) -> str:
+    return bytearray(size)
+
+
+def large_arg_consumer(data: str) -> int:
+    return len(data)
+
+
+test_cases = [200, 2000, 20000, 200000]
+
+
+@pytest.mark.parametrize("size", test_cases)
+def test_allowed_result_sizes(fx, endpoint, size):
+    """funcX should allow all listed result sizes which are under 512KB limit"""
+
+    future = fx.submit(large_result_producer, size, endpoint_id=endpoint)
+    x = future.result(timeout=60)
+    assert len(x) == size, "Result size does not match excepted size"
+
+
+def test_result_size_too_large(fx, endpoint, size=550000):
+    """
+    funcX should raise a MaxResultSizeExceeded exception when results exceeds 512KB
+    limit
+    """
+    future = fx.submit(large_result_producer, size, endpoint_id=endpoint)
+    with pytest.raises(MaxResultSizeExceeded):
+        future.result(timeout=60)
+
+
+@pytest.mark.parametrize("size", test_cases)
+def test_allowed_arg_sizes(fx, endpoint, size):
+    """funcX should allow all listed result sizes which are under 512KB limit"""
+
+    future = fx.submit(large_arg_consumer, bytearray(size), endpoint_id=endpoint)
+    x = future.result(timeout=60)
+    assert x == size, "Arg size does not match excepted size"
+
+
+@pytest.mark.xfail(reason="As of 0.3.4, an arg size limit is not being enforced")
+def test_arg_size_too_large(fx, endpoint, size=55000000):
+    """funcX should raise an exception for objects larger than some limit,
+    which we are yet to define. This does not work right now.
+    """
+
+    future = fx.submit(large_arg_consumer, bytearray(size), endpoint_id=endpoint)
+    with pytest.raises(Exception):
+        future.result(timeout=60)


### PR DESCRIPTION
Adds tests that exercise IO, and indirectly tests storage to S3.

Apparently, arg sizes aren't being limited correctly and the test for that is marked as xfail.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
