### PR TITLE
Install funcx_endpoint for smoke tests

### DIFF
--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -23,6 +23,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install './funcx_sdk[test]'
+        # fixme: Remove this next install line once issue #640 is fixed.
+        python -m pip install './funcx_endpoint'
         python -m pip install safety
     - name: Run smoke tests to check liveness of hosted services
       run: |


### PR DESCRIPTION
# Description

This PR updates the hourly test to install `funcx_endpoint`. Currently we need `MaxResultSizeExceeded` is required from `funcx_endpoint` in testing. 

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
