### PR TITLE
Add taskgroup reconnect

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/funcx_task.py
@@ -3,7 +3,7 @@ import asyncio
 
 class FuncXTask(asyncio.Future):
     """
-    Represents a submitted funcX task with an asychio wrapper
+    Represents a submitted funcX task with an asyncio wrapper
     """
 
     def __init__(self, task_id):

--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -127,9 +127,9 @@ class WebSocketPollingTask:
                 pass
             except ConnectionClosedOK:
                 if self.closed_by_main_thread:
-                    log.debug("WebSocket connection closed by main thread")
+                    log.info("WebSocket connection closed by main thread")
                 else:
-                    log.error("WebSocket connection closed unexpectedly")
+                    log.exception("WebSocket connection closed unexpectedly")
                 return
             else:
                 data = json.loads(raw_data)

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import typing
 import uuid
 from distutils.version import LooseVersion
 from inspect import getsource
@@ -61,6 +62,7 @@ class FuncXClient(FuncXErrorHandlingClient):
         loop=None,
         results_ws_uri="wss://api2.funcx.org/ws/v2/",
         use_offprocess_checker=True,
+        task_group_id: typing.Union[str, uuid.UUID] = uuid.uuid4(),
         **kwargs,
     ):
         """
@@ -109,13 +111,17 @@ class FuncXClient(FuncXErrorHandlingClient):
             used by the client.
             Default: True
 
+        task_group_id: str or UUID
+            Set the task_group_id to (re) connect to a  specific task_group.
+            Default: uuid.uuid4()
+
         Keyword arguments are the same as for BaseClient.
 
         """
         self.func_table = {}
         self.use_offprocess_checker = use_offprocess_checker
         self.funcx_home = os.path.expanduser(funcx_home)
-        self.session_task_group_id = str(uuid.uuid4())
+        self.session_task_group_id = str(task_group_id)
 
         if not os.path.exists(self.TOKEN_DIR):
             os.makedirs(self.TOKEN_DIR)

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -323,6 +323,7 @@ class ExecutorPollerThread:
         )
 
     def shutdown(self):
+        log.info("Shutting down")
         if self.ws_handler is None:
             return
 

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -67,14 +67,23 @@ class FuncXExecutor(concurrent.futures.Executor):
         ==========
 
         funcx_client : client object
-            Instance of FuncXClient to be used by the executor
-
-        results_ws_uri : str
-            Web sockets URI for the results
+        Instance of FuncXClient to be used by the executor
 
         label : str
-            Optional string label to name the executor.
-            Default: 'FuncXExecutor'
+        Optional string label to name the executor.
+        Default: 'FuncXExecutor'
+
+        batch_enabled: bool
+        Use option to enable batch automatic batching of task submissions
+        Default: False
+
+        batch_interval: float
+        Interval (in seconds) between submission of batches when batch is enabled.
+        Default: 1.0
+
+        batch_size: int
+        Maximum number of tasks within a batch
+        Default: 100
         """
 
         self.funcx_client = funcx_client

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -338,12 +338,22 @@ class ExecutorPollerThread:
         eventloop.run_until_complete(self.web_socket_poller())
 
     async def web_socket_poller(self):
-        # TODO: if WebSocket connection fails, we should either retry connecting and
-        # backoff or we should set an exception to all of the outstanding futures
-        await self.ws_handler.init_ws(start_message_handlers=False)
-        await self.ws_handler.handle_incoming(
-            self._function_future_map, auto_close=True
-        )
+        """Start ws and listen for tasks.
+        If a remote disconnect breaks the ws, close the ws and reconnect"""
+        while True:
+            await self.ws_handler.init_ws(start_message_handlers=False)
+            status = await self.ws_handler.handle_incoming(
+                self._function_future_map, auto_close=True
+            )
+            if status is False:
+                # handle_incoming broke from a remote side disconnect
+                # we should close and re-connect
+                log.info("Attempting ws close")
+                await self.ws_handler.close()
+                log.info("Attempting ws re-connect")
+            else:
+                # clean exit
+                break
 
     def shutdown(self):
         log.info("Shutting down")


### PR DESCRIPTION
# Description

This functionality was requested by @ericmjonas following reports of instability during large runs.

This PR adds a few key changes that allow you to track tasks launched from a separate failed SDK session.
This is done by explicitly specifying the `task_group_id` across SDK runs, keeping track of `task_ids` for which results have not been received, and explicitly requesting that they be tracked.

Here are the changes this PR adds:

Specify `task_group_id` to `FuncXClient` at init:
```python
 fx = FuncXExecutor(FuncXClient(task_group_id=task_group_id))
```

On a fresh session after a disconnect event, you can request tracking task_ids like this:
```python
from concurrent.futures import Future
...

futures = []
task_ids = [ < List >, < of >, <task_ids> ] 
for task_id in task_ids:
        future = Future()
        fx.add_task_to_poller(task_id, future)
        futures.append(future)

```

Fixes #562 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update