### PR TITLE
Raise result size limit to 10MB

### DIFF
--- a/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
+++ b/funcx_endpoint/tests/smoke_tests/test_s3_indirect.py
@@ -23,11 +23,11 @@ def test_allowed_result_sizes(submit_function_and_get_result, endpoint, size):
 
 def test_result_size_too_large(submit_function_and_get_result, endpoint):
     """
-    funcX should raise a MaxResultSizeExceeded exception when results exceeds 512KB
+    funcX should raise a MaxResultSizeExceeded exception when results exceeds 10MB
     limit
     """
     r = submit_function_and_get_result(
-        endpoint, func=large_result_producer, func_args=(550000,)
+        endpoint, func=large_result_producer, func_args=(11 * 1024 * 1024,)
     )
     assert r.result is None
     assert "exception" in r.response

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -45,9 +45,9 @@ def test_allowed_result_sizes(fxc, endpoint, size):
     assert len(x) == size, "Result size does not match excepted size"
 
 
-def test_result_size_too_large(fxc, endpoint, size=550000):
+def test_result_size_too_large(fxc, endpoint, size=11 * 1024 * 1024):
     """
-    funcX should raise a MaxResultSizeExceeded exception when results exceeds 512KB
+    funcX should raise a MaxResultSizeExceeded exception when results exceeds 10MB
     limit
     """
     fn_uuid = fxc.register_function(


### PR DESCRIPTION
And fix `sys.getsizeof` on a bytestring to use `len` instead.

I've also updated tests which generated 550KB of data (exceeding the 512KB limit) to generate 11MB of data. This should generate the same error before and after the update. It therefore will keep smoke tests working when the tutorial endpoint is updated, for example.