### PR TITLE
Reconnect on remote disconnect

### DIFF
--- a/funcx_sdk/funcx/tests/test_longduration.py
+++ b/funcx_sdk/funcx/tests/test_longduration.py
@@ -1,0 +1,37 @@
+import random
+import time
+
+
+def double(x):
+    return x * 2
+
+
+def failing_task():
+    raise IndexError()
+
+
+def delay_n(n):
+    import time
+
+    time.sleep(n)
+    return n
+
+
+def noop():
+    return
+
+
+def test_random_delay(fx, endpoint, base_delay=600, n=10):
+    """Tests tasks that run 10mins which is the websocket disconnect period"""
+
+    futures = {}
+    for _i in range(n):
+        delay = base_delay + random.randint(10, 30)
+        fut = fx.submit(delay_n, delay, endpoint_id=endpoint)
+        futures[fut] = delay
+
+    time.sleep(3)
+
+    for fut in futures:
+        assert fut.result(timeout=700) == futures[fut]
+        print(f"I slept for {fut.result()} seconds")


### PR DESCRIPTION
# Description

Our funcx-websocket-service disconnects idle connections after about 10 minutes (https://github.com/funcx-faas/funcx-websocket-service/blob/main/funcx_websocket_service/connection.py#L52). This disconnection messed with the client, since we don't have any reconnect logic. This PR adds support for identifying these remote side disconnects, cleanly closing down the websockets, and reconnecting.

This is difficult to test in CI since the test has to have an idle connection for >10mins which would slow down tests drastically. I'm working on a getting this tested atm and will add a mocked test separately.

Fixes #562 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
