### PR TITLE
Compute ws uri from service address

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -17,7 +17,10 @@ from funcx.sdk.utils.batch import Batch
 from funcx.serialize import FuncXSerializer
 from funcx.utils.errors import SerializationError, TaskPending, VersionMismatch
 from funcx.utils.handle_service_response import handle_response_errors
-from funcx.utils.url_parsing import ws_uri_from_service_address
+from funcx.utils.url_parsing import (
+    validate_service_address,
+    ws_uri_from_service_address,
+)
 
 try:
     from funcx_endpoint.version import VERSION as ENDPOINT_VERSION
@@ -166,6 +169,7 @@ class FuncXClient(FuncXErrorHandlingClient):
             authorizer=search_authorizer, owner_uuid=user_info["sub"]
         )
         self.funcx_service_address = funcx_service_address
+        validate_service_address(self.funcx_service_address)
         self.check_endpoint_version = check_endpoint_version
 
         self.version_check()

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -17,6 +17,7 @@ from funcx.sdk.utils.batch import Batch
 from funcx.serialize import FuncXSerializer
 from funcx.utils.errors import SerializationError, TaskPending, VersionMismatch
 from funcx.utils.handle_service_response import handle_response_errors
+from funcx.utils.url_parsing import ws_uri_from_service_address
 
 try:
     from funcx_endpoint.version import VERSION as ENDPOINT_VERSION
@@ -59,7 +60,7 @@ class FuncXClient(FuncXErrorHandlingClient):
         check_endpoint_version=False,
         asynchronous=False,
         loop=None,
-        results_ws_uri="wss://api2.funcx.org/ws/v2/",
+        results_ws_uri=None,
         use_offprocess_checker=True,
         **kwargs,
     ):
@@ -170,6 +171,11 @@ class FuncXClient(FuncXErrorHandlingClient):
         self.version_check()
 
         self.results_ws_uri = results_ws_uri
+        if self.results_ws_uri is None:
+            self.results_ws_uri = ws_uri_from_service_address(
+                self.funcx_service_address
+            )
+
         self.asynchronous = asynchronous
         if asynchronous:
             self.loop = loop if loop else asyncio.get_event_loop()

--- a/funcx_sdk/funcx/tests/conftest.py
+++ b/funcx_sdk/funcx/tests/conftest.py
@@ -6,7 +6,10 @@ from funcx.sdk.executor import FuncXExecutor
 config = {
     "funcx_service_address": "https://api2.funcx.org/v2",
     "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
+    # should default to the correct ws_uri based on service address
+    # unless an irregular testing setup is being used, in which case
+    # --ws-uri should be specified too
+    "results_ws_uri": None,
 }
 
 

--- a/funcx_sdk/funcx/tests/test_basic.py
+++ b/funcx_sdk/funcx/tests/test_basic.py
@@ -52,7 +52,17 @@ def test_non_blocking(fxc, endpoint):
             break
 
 
-def test_malformed_service_address(fxc, endpoint):
+def test_correct_ws_uri_prod():
+    fxc = FuncXClient(funcx_service_address="https://api2.funcx.org/v2")
+    assert fxc.results_ws_uri == "wss://api2.funcx.org/ws/v2/"
+
+
+def test_correct_ws_uri_testing():
+    fxc = FuncXClient(funcx_service_address="http://localhost:5000/v2")
+    assert fxc.results_ws_uri == "ws://localhost:6000/ws/v2/"
+
+
+def test_malformed_service_address():
     with pytest.raises(InvalidServiceAddress):
         FuncXClient(funcx_service_address="http:/k8s-dev.funcx.org/api/v1")
 

--- a/funcx_sdk/funcx/tests/test_basic.py
+++ b/funcx_sdk/funcx/tests/test_basic.py
@@ -1,6 +1,9 @@
 import time
 
+import pytest
+
 from funcx.sdk.client import FuncXClient
+from funcx.utils.errors import InvalidServiceAddress
 
 
 def hello_world() -> str:
@@ -47,6 +50,11 @@ def test_non_blocking(fxc, endpoint):
             print(f"Result: {result}")
             assert result == hello_world(), "Result from remote function not correct"
             break
+
+
+def test_malformed_service_address(fxc, endpoint):
+    with pytest.raises(InvalidServiceAddress):
+        FuncXClient(funcx_service_address="http:/k8s-dev.funcx.org/api/v1")
 
 
 if __name__ == "__main__":

--- a/funcx_sdk/funcx/tests/unit/test_url_parsing.py
+++ b/funcx_sdk/funcx/tests/unit/test_url_parsing.py
@@ -1,0 +1,51 @@
+import pytest
+
+from funcx.utils.errors import InvalidServiceAddress
+from funcx.utils.url_parsing import (
+    validate_service_address,
+    ws_uri_from_service_address,
+)
+
+
+def test_validate_service_address_invalid_port():
+    url = "https://api.dev.funcx.org:abc/v2"
+    with pytest.raises(InvalidServiceAddress):
+        validate_service_address(url)
+
+
+def test_validate_service_address_invalid_protocol():
+    url = "ws://api.dev.funcx.org:abc/v2"
+    with pytest.raises(InvalidServiceAddress):
+        validate_service_address(url)
+
+
+def test_validate_service_address_address_malformed():
+    url = "http:/api.dev.funcx.org:abc/v2"
+    with pytest.raises(InvalidServiceAddress):
+        validate_service_address(url)
+
+
+def test_ws_uri_from_service_address_testing():
+    # should expect port to switch from 5000 to 6000
+    url = "http://localhost:5000/v2"
+    res = ws_uri_from_service_address(url)
+    assert res == "ws://localhost:6000/ws/v2/"
+
+
+def test_ws_uri_from_service_address_dev():
+    url = "https://api.dev.funcx.org/v2"
+    res = ws_uri_from_service_address(url)
+    assert res == "wss://api.dev.funcx.org/ws/v2/"
+
+
+def test_ws_uri_from_service_address_prod():
+    url = "https://api2.funcx.org/v2"
+    res = ws_uri_from_service_address(url)
+    assert res == "wss://api2.funcx.org/ws/v2/"
+
+
+def test_ws_uri_from_service_address_other_port():
+    # should expect port to remain the same
+    url = "https://api.dev.funcx.org:5001/v2"
+    res = ws_uri_from_service_address(url)
+    assert res == "wss://api.dev.funcx.org:5001/ws/v2/"

--- a/funcx_sdk/funcx/tests/unit/test_url_parsing.py
+++ b/funcx_sdk/funcx/tests/unit/test_url_parsing.py
@@ -9,19 +9,19 @@ from funcx.utils.url_parsing import (
 
 def test_validate_service_address_invalid_port():
     url = "https://api.dev.funcx.org:abc/v2"
-    with pytest.raises(InvalidServiceAddress):
+    with pytest.raises(InvalidServiceAddress, match="Address is malformed"):
         validate_service_address(url)
 
 
 def test_validate_service_address_invalid_protocol():
-    url = "ws://api.dev.funcx.org:abc/v2"
-    with pytest.raises(InvalidServiceAddress):
+    url = "ws://api.dev.funcx.org/v2"
+    with pytest.raises(InvalidServiceAddress, match="Protocol must be HTTP/HTTPS"):
         validate_service_address(url)
 
 
 def test_validate_service_address_address_malformed():
-    url = "http:/api.dev.funcx.org:abc/v2"
-    with pytest.raises(InvalidServiceAddress):
+    url = "http:/api.dev.funcx.org/v2"
+    with pytest.raises(InvalidServiceAddress, match="Address is malformed"):
         validate_service_address(url)
 
 

--- a/funcx_sdk/funcx/tests/unit/test_url_parsing.py
+++ b/funcx_sdk/funcx/tests/unit/test_url_parsing.py
@@ -7,6 +7,36 @@ from funcx.utils.url_parsing import (
 )
 
 
+def test_validate_service_address_testing():
+    url = "http://localhost:5000/v2"
+    # should not raise because this is valid
+    validate_service_address(url)
+
+
+def test_validate_service_address_dev():
+    url = "https://api.dev.funcx.org/v2"
+    # should not raise because this is valid
+    validate_service_address(url)
+
+
+def test_validate_service_address_prod():
+    url = "https://api2.funcx.org/v2"
+    # should not raise because this is valid
+    validate_service_address(url)
+
+
+def test_validate_service_address_explicit_port():
+    url = "https://api.dev.funcx.org:443/v2"
+    # should not raise because this is valid
+    validate_service_address(url)
+
+
+def test_validate_service_address_incorrect_port():
+    url = "http://localhost:9000/v2"
+    with pytest.raises(InvalidServiceAddress, match="Port must be 443 or 5000"):
+        validate_service_address(url)
+
+
 def test_validate_service_address_invalid_port():
     url = "https://api.dev.funcx.org:abc/v2"
     with pytest.raises(InvalidServiceAddress, match="Address is malformed"):
@@ -36,6 +66,12 @@ def test_ws_uri_from_service_address_dev():
     url = "https://api.dev.funcx.org/v2"
     res = ws_uri_from_service_address(url)
     assert res == "wss://api.dev.funcx.org/ws/v2/"
+
+
+def test_ws_uri_from_service_address_dev_explicit_port():
+    url = "https://api.dev.funcx.org:443/v2"
+    res = ws_uri_from_service_address(url)
+    assert res == "wss://api.dev.funcx.org:443/ws/v2/"
 
 
 def test_ws_uri_from_service_address_prod():

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -104,3 +104,13 @@ class TaskPending(FuncxError):
 
     def __repr__(self):
         return f"Task is pending due to {self.reason}"
+
+
+class InvalidServiceAddress(FuncxError):
+    """funcX Service Address is invalid"""
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __repr__(self):
+        return f"Provided funcx_service_address is invalid: {self.reason}"

--- a/funcx_sdk/funcx/utils/url_parsing.py
+++ b/funcx_sdk/funcx/utils/url_parsing.py
@@ -11,9 +11,8 @@ def validate_service_address(service_address):
         if url_data.scheme != "http" and url_data.scheme != "https":
             raise InvalidServiceAddress("Protocol must be HTTP/HTTPS")
 
-        # note: this can occur with http://api.dev.funcx.org:5001/v2
         if url_data.netloc is None or url_data.hostname is None:
-            raise InvalidServiceAddress("hostname/port is malformed")
+            raise InvalidServiceAddress("Address is malformed")
     except Exception as e:
         raise InvalidServiceAddress(f"Address is malformed - {e}")
 

--- a/funcx_sdk/funcx/utils/url_parsing.py
+++ b/funcx_sdk/funcx/utils/url_parsing.py
@@ -1,10 +1,33 @@
 from urllib.parse import urlparse
 
+from funcx.utils.errors import InvalidServiceAddress
+
+
+def validate_service_address(service_address):
+    try:
+        url_data = urlparse(service_address)
+        # port must be accessed to raise port value issues
+        url_data.port
+        if url_data.scheme != "http" and url_data.scheme != "https":
+            raise InvalidServiceAddress("Protocol must be HTTP/HTTPS")
+
+        # note: this can occur with http://api.dev.funcx.org:5001/v2
+        if url_data.netloc is None or url_data.hostname is None:
+            raise InvalidServiceAddress("hostname/port is malformed")
+    except Exception as e:
+        raise InvalidServiceAddress(f"Address is malformed - {e}")
+
 
 def ws_uri_from_service_address(service_address):
     url_data = urlparse(service_address)
     scheme = "wss" if url_data.scheme == "https" else "ws"
     hostname = url_data.hostname
-    port_str = "" if url_data.port is None else f":{url_data.port}"
+    port = url_data.port
+    port_str = ""
+    # for testing purposes: the service address is typically
+    # localhost:5000 and ws uri is localhost:6000
+    if port == 5000:
+        port = 6000
+    port_str = "" if port is None else f":{port}"
     ws_uri = f"{scheme}://{hostname}{port_str}/ws/v2/"
     return ws_uri

--- a/funcx_sdk/funcx/utils/url_parsing.py
+++ b/funcx_sdk/funcx/utils/url_parsing.py
@@ -3,7 +3,15 @@ from urllib.parse import urlparse
 from funcx.utils.errors import InvalidServiceAddress
 
 
-def validate_service_address(service_address):
+def validate_service_address(service_address: str):
+    """Validate funcX service address, raising InvalidServiceAddress
+    if invalid
+
+    Parameters
+    ----------
+    service_address : str
+        funcX service address
+    """
     try:
         url_data = urlparse(service_address)
         # port must be accessed to raise port value issues
@@ -23,6 +31,18 @@ def validate_service_address(service_address):
 
 
 def ws_uri_from_service_address(service_address):
+    """Compute ws uri from funcX service address
+
+    Parameters
+    ----------
+    service_address : str
+        funcX service address
+
+    Returns
+    -------
+    str
+        WebSocket URI
+    """
     url_data = urlparse(service_address)
     scheme = "wss" if url_data.scheme == "https" else "ws"
     hostname = url_data.hostname

--- a/funcx_sdk/funcx/utils/url_parsing.py
+++ b/funcx_sdk/funcx/utils/url_parsing.py
@@ -7,7 +7,12 @@ def validate_service_address(service_address):
     try:
         url_data = urlparse(service_address)
         # port must be accessed to raise port value issues
-        url_data.port
+        port = url_data.port
+        # the only other valid service address ports are None (not specified)
+        # 443 for HTTPS, and 5000 for development
+        if not (port is None or port == 443 or port == 5000):
+            raise InvalidServiceAddress("Port must be 443 or 5000")
+
         if url_data.scheme != "http" and url_data.scheme != "https":
             raise InvalidServiceAddress("Protocol must be HTTP/HTTPS")
 

--- a/funcx_sdk/funcx/utils/url_parsing.py
+++ b/funcx_sdk/funcx/utils/url_parsing.py
@@ -1,0 +1,10 @@
+from urllib.parse import urlparse
+
+
+def ws_uri_from_service_address(service_address):
+    url_data = urlparse(service_address)
+    scheme = "wss" if url_data.scheme == "https" else "ws"
+    hostname = url_data.hostname
+    port_str = "" if url_data.port is None else f":{url_data.port}"
+    ws_uri = f"{scheme}://{hostname}{port_str}/ws/v2/"
+    return ws_uri


### PR DESCRIPTION
# Description

Compute ws uri by parsing the service address

https://app.shortcut.com/funcx/story/10152/funcx-client-should-compute-web-socket-service-uri

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
