### PR TITLE
Updating version to 0.3.5-dev

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.4"
+__version__ = "0.3.5-dev"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.4"
+__version__ = "0.3.5-dev"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
# Description

Updating the version tags on funcx-sdk and funcx-endpoint to 0.3.5-dev to indicate that builds made off of main will be close to the upcoming 0.3.5 release. This is not a complete fix for #654 but a decent interim solution until we decide on a long-term fix for reporting a build's origin from the commit tree.

Fixes #654

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
