### PR TITLE
Setup environment-based URL resolution

### DIFF
--- a/funcx_sdk/funcx/sdk/_environments.py
+++ b/funcx_sdk/funcx/sdk/_environments.py
@@ -20,5 +20,5 @@ def get_web_socket_url(envname: t.Optional[str]) -> str:
     prod = "wss://api2.funcx.org/ws/v2/"
     return {
         "production": prod,
-        "dev": "wss://api.dev.funcx.org/ws/v2",
+        "dev": "wss://api.dev.funcx.org/ws/v2/",
     }.get(env, prod)

--- a/funcx_sdk/funcx/sdk/_environments.py
+++ b/funcx_sdk/funcx/sdk/_environments.py
@@ -1,0 +1,24 @@
+import os
+import typing as t
+
+
+def _get_envname():
+    return os.getenv("FUNCX_SDK_ENVIRONMENT", "production")
+
+
+def get_web_service_url(envname: t.Optional[str]) -> str:
+    env = envname or _get_envname()
+    prod = "https://api2.funcx.org/v2"
+    return {
+        "production": prod,
+        "dev": "https://api.dev.funcx.org/v2",
+    }.get(env, prod)
+
+
+def get_web_socket_url(envname: t.Optional[str]) -> str:
+    env = envname or _get_envname()
+    prod = "wss://api2.funcx.org/ws/v2/"
+    return {
+        "production": prod,
+        "dev": "wss://api.dev.funcx.org/ws/v2",
+    }.get(env, prod)

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -93,8 +93,13 @@ class FuncXClient(FuncXErrorHandlingClient):
             Default: ``None``, will be created.
 
         funcx_service_address: str
-            The address of the funcX web service to communicate with.
-            Default: https://api.funcx.org/v2
+            For internal use only. The address of the web service.
+
+        results_ws_uri: str
+            For internal use only. The address of the websocket service.
+
+        environment: str
+            For internal use only. The name of the environment to use.
 
         asynchronous: bool
         Should the API use asynchronous interactions with the web service? Currently

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -9,6 +9,7 @@ from inspect import getsource
 from fair_research_login import JSONTokenStorage, NativeClient
 from globus_sdk import AuthClient
 
+from funcx.sdk._environments import get_web_service_url, get_web_socket_url
 from funcx.sdk.asynchronous.funcx_task import FuncXTask
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
 from funcx.sdk.error_handling_client import FuncXErrorHandlingClient
@@ -55,12 +56,13 @@ class FuncXClient(FuncXErrorHandlingClient):
         fx_authorizer=None,
         search_authorizer=None,
         openid_authorizer=None,
-        funcx_service_address="https://api2.funcx.org/v2",
+        funcx_service_address=None,
         check_endpoint_version=False,
         asynchronous=False,
         loop=None,
-        results_ws_uri="wss://api2.funcx.org/ws/v2/",
+        results_ws_uri=None,
         use_offprocess_checker=True,
+        environment=None,
         **kwargs,
     ):
         """
@@ -112,6 +114,12 @@ class FuncXClient(FuncXErrorHandlingClient):
         Keyword arguments are the same as for BaseClient.
 
         """
+        # resolve URLs if not set
+        if funcx_service_address is None:
+            funcx_service_address = get_web_service_url(environment)
+        if results_ws_uri is None:
+            results_ws_uri = get_web_socket_url(environment)
+
         self.func_table = {}
         self.use_offprocess_checker = use_offprocess_checker
         self.funcx_home = os.path.expanduser(funcx_home)

--- a/funcx_sdk/funcx/tests/unit/test_client_init.py
+++ b/funcx_sdk/funcx/tests/unit/test_client_init.py
@@ -1,0 +1,85 @@
+from unittest import mock
+
+import globus_sdk
+import pytest
+
+import funcx
+
+
+@pytest.fixture(autouse=True)
+def _clear_sdk_env(monkeypatch):
+    monkeypatch.delenv("FUNCX_SDK_ENVIRONMENT", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _mock_login(monkeypatch):
+    mock_fair_research_client_object = mock.Mock()
+    monkeypatch.setattr(
+        "funcx.sdk.client.NativeClient",
+        mock.Mock(return_value=mock_fair_research_client_object),
+    )
+    mock_fair_research_client_object.get_authorizers_by_scope.return_value = {
+        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all": (
+            globus_sdk.NullAuthorizer()
+        ),
+        "urn:globus:auth:scope:search.api.globus.org:all": globus_sdk.NullAuthorizer(),
+        "openid": globus_sdk.NullAuthorizer(),
+    }
+
+    mock_auth_client = mock.Mock()
+    monkeypatch.setattr(
+        "funcx.sdk.client.AuthClient", mock.Mock(return_value=mock_auth_client)
+    )
+    mock_auth_client.oauth2_userinfo.return_value = {"sub": "foo"}
+
+    monkeypatch.setattr("funcx.sdk.client.SearchHelper", mock.Mock())
+    monkeypatch.setattr("funcx.sdk.client.FuncXClient.version_check", mock.Mock())
+
+
+@pytest.mark.parametrize("env", [None, "dev", "production"])
+@pytest.mark.parametrize("usage_method", ["env_var", "param"])
+@pytest.mark.parametrize("explicit_params", ["neither", "web", "ws", "both"])
+def test_client_init_sets_addresses_by_env(
+    monkeypatch, env, usage_method, explicit_params
+):
+    if env in (None, "production"):
+        web_uri = "https://api2.funcx.org/v2"
+        ws_uri = "wss://api2.funcx.org/ws/v2/"
+    elif env in ("dev",):
+        web_uri = "https://api.dev.funcx.org/v2"
+        ws_uri = "wss://api.dev.funcx.org/ws/v2/"
+    else:
+        raise NotImplementedError
+
+    # either pass the env as a param or set it in the environment
+    kwargs = {}
+    if usage_method == "param":
+        kwargs["environment"] = env
+    elif usage_method == "env_var":
+        if env is not None:
+            monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", env)
+    else:
+        raise NotImplementedError
+
+    # create the client, either with just the input env or with explicit parameters
+    # for explicit params, alter the expected URI(s)
+    if explicit_params == "neither":
+        client = funcx.FuncXClient(**kwargs)
+    elif explicit_params == "web":
+        web_uri = "http://localhost:5000"
+        client = funcx.FuncXClient(funcx_service_address=web_uri, **kwargs)
+    elif explicit_params == "ws":
+        ws_uri = "ws://localhost:8081"
+        client = funcx.FuncXClient(results_ws_uri=ws_uri, **kwargs)
+    elif explicit_params == "both":
+        web_uri = "http://localhost:5000"
+        ws_uri = "ws://localhost:8081"
+        client = funcx.FuncXClient(
+            funcx_service_address=web_uri, results_ws_uri=ws_uri, **kwargs
+        )
+    else:
+        raise NotImplementedError
+
+    # finally, confirm that the addresses were set correctly
+    assert client.funcx_service_address == web_uri
+    assert client.results_ws_uri == ws_uri

--- a/funcx_sdk/funcx/tests/unit/test_environment_lookups.py
+++ b/funcx_sdk/funcx/tests/unit/test_environment_lookups.py
@@ -21,6 +21,6 @@ def test_web_socket_url(monkeypatch):
     assert get_web_socket_url(None) == "wss://api2.funcx.org/ws/v2/"
     assert get_web_socket_url("production") == "wss://api2.funcx.org/ws/v2/"
     assert get_web_socket_url("no-such-env-name-known") == "wss://api2.funcx.org/ws/v2/"
-    assert get_web_socket_url("dev") == "wss://api.dev.funcx.org/ws/v2"
+    assert get_web_socket_url("dev") == "wss://api.dev.funcx.org/ws/v2/"
     monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", "dev")
-    assert get_web_socket_url(None) == "wss://api.dev.funcx.org/ws/v2"
+    assert get_web_socket_url(None) == "wss://api.dev.funcx.org/ws/v2/"

--- a/funcx_sdk/funcx/tests/unit/test_environment_lookups.py
+++ b/funcx_sdk/funcx/tests/unit/test_environment_lookups.py
@@ -1,0 +1,26 @@
+import pytest
+
+from funcx.sdk._environments import get_web_service_url, get_web_socket_url
+
+
+@pytest.fixture(autouse=True)
+def _clear_sdk_env(monkeypatch):
+    monkeypatch.delenv("FUNCX_SDK_ENVIRONMENT", raising=False)
+
+
+def test_web_service_url(monkeypatch):
+    assert get_web_service_url(None) == "https://api2.funcx.org/v2"
+    assert get_web_service_url("production") == "https://api2.funcx.org/v2"
+    assert get_web_service_url("no-such-env-name-known") == "https://api2.funcx.org/v2"
+    assert get_web_service_url("dev") == "https://api.dev.funcx.org/v2"
+    monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", "dev")
+    assert get_web_service_url(None) == "https://api.dev.funcx.org/v2"
+
+
+def test_web_socket_url(monkeypatch):
+    assert get_web_socket_url(None) == "wss://api2.funcx.org/ws/v2/"
+    assert get_web_socket_url("production") == "wss://api2.funcx.org/ws/v2/"
+    assert get_web_socket_url("no-such-env-name-known") == "wss://api2.funcx.org/ws/v2/"
+    assert get_web_socket_url("dev") == "wss://api.dev.funcx.org/ws/v2"
+    monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", "dev")
+    assert get_web_socket_url(None) == "wss://api.dev.funcx.org/ws/v2"


### PR DESCRIPTION
This is the alternative to #655 I was suggesting in chat.
Environment name -> URLs, with no support for a "local dev" environment.

I like the class-based interface used by the globus-sdk better than this for the long term because it allows dynamic registration of additional environments, but it's not necessary for a first cut at something simpler than what we have today.

---

webservice and websocket service URLs are resolved by the names "production" and "dev". These values can be passed to FuncX client init as in `environment="dev"`, or by setting the `FUNCX_SDK_ENVIRONMENT` environment variable. Unknown names are treated as aliases for `production`.

Unit tests cover the helpers which resolve these names.

If explicit values are passed to `FuncXClient` for the URLs, they are used instead of any environment-based URL.