### PR TITLE
Setup tox + CI for testing SDK under a matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,29 +22,24 @@ jobs:
         run: pre-commit run -a
 
   test-sdk:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
       - name: install requirements
         run: |
-          python -m pip install -U pip setuptools wheel
-          python -m pip install './funcx_sdk[test]'
-          pip install safety
-      - name: run safety check
-        run: safety check
-
-      # TODO: remove this test
-      # This is the weakest test which does anything, checking that the client can
-      # be imported. As soon as pytest is running again, remove this.
-      - name: check importable
-        run: python -c "from funcx.sdk.client import FuncXClient"
-      # - name: run pytest
-      #   run: |
-      #     cd funcx_sdk
-      #     pytest
+          python -m pip install tox
+      - name: run tests
+        run: |
+          cd funcx_sdk
+          tox -e py
 
   test-endpoint:
     runs-on: ubuntu-latest

--- a/funcx_sdk/tox.ini
+++ b/funcx_sdk/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{310,39,38,37,36}
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+extras = test
+commands = pytest funcx/tests/unit/ {posargs}


### PR DESCRIPTION
Test all python versions 3.6-3.10 (removal of 3.6 may be considered).

Configure tox to run only the unit tests, which can pass without external services being available.