### PR TITLE
Move MaxResultSizeExceeded to funcx.utils.errors

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -11,6 +11,7 @@ import zmq
 from parsl.app.errors import RemoteExceptionWrapper
 
 from funcx.serialize import FuncXSerializer
+from funcx.utils.errors import MaxResultSizeExceeded
 from funcx_endpoint.executors.high_throughput.messages import Message
 from funcx_endpoint.logging_config import setup_logging
 
@@ -18,22 +19,6 @@ log = logging.getLogger(__name__)
 
 DEFAULT_RESULT_SIZE_LIMIT_MB = 10
 DEFAULT_RESULT_SIZE_LIMIT_B = DEFAULT_RESULT_SIZE_LIMIT_MB * 1024 * 1024
-
-
-class MaxResultSizeExceeded(Exception):
-    """
-    Result produced by the function exceeds the maximum supported result size
-    threshold"""
-
-    def __init__(self, result_size, result_size_limit):
-        self.result_size = result_size
-        self.result_size_limit = result_size_limit
-
-    def __str__(self):
-        return (
-            f"Task result of {self.result_size}B exceeded current "
-            f"limit of {self.result_size_limit}B"
-        )
 
 
 class FuncXWorker:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -11,9 +11,27 @@ import zmq
 from parsl.app.errors import RemoteExceptionWrapper
 
 from funcx.serialize import FuncXSerializer
-from funcx.utils.errors import MaxResultSizeExceeded
 from funcx_endpoint.executors.high_throughput.messages import Message
 from funcx_endpoint.logging_config import setup_logging
+
+try:
+    from funcx.utils.errors import MaxResultSizeExceeded
+except ImportError:
+    # to-do: Remove this after funcx,funcx-endpoint==0.3.5 is released
+    class MaxResultSizeExceeded(Exception):
+        """Result produced by the function exceeds the maximum supported result size
+        threshold"""
+
+        def __init__(self, result_size: int, result_size_limit: int):
+            self.result_size = result_size
+            self.result_size_limit = result_size_limit
+
+        def __str__(self) -> str:
+            return (
+                f"Task result of {self.result_size}B exceeded current "
+                f"limit of {self.result_size_limit}B"
+            )
+
 
 log = logging.getLogger(__name__)
 

--- a/funcx_sdk/funcx/tests/test_result_size.py
+++ b/funcx_sdk/funcx/tests/test_result_size.py
@@ -1,7 +1,6 @@
 import pytest
 
-from funcx.utils.errors import TaskPending
-from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
+from funcx.utils.errors import MaxResultSizeExceeded, TaskPending
 
 
 def large_result_producer(size) -> str:

--- a/funcx_sdk/funcx/utils/errors.py
+++ b/funcx_sdk/funcx/utils/errors.py
@@ -104,3 +104,18 @@ class TaskPending(FuncxError):
 
     def __repr__(self):
         return f"Task is pending due to {self.reason}"
+
+
+class MaxResultSizeExceeded(Exception):
+    """Result produced by the function exceeds the maximum supported result size
+    threshold"""
+
+    def __init__(self, result_size: int, result_size_limit: int):
+        self.result_size = result_size
+        self.result_size_limit = result_size_limit
+
+    def __str__(self) -> str:
+        return (
+            f"Task result of {self.result_size}B exceeded current "
+            f"limit of {self.result_size_limit}B"
+        )

--- a/smoke_tests/tests/test_s3_indirect.py
+++ b/smoke_tests/tests/test_s3_indirect.py
@@ -1,6 +1,6 @@
 import pytest
 
-from funcx_endpoint.executors.high_throughput.funcx_worker import MaxResultSizeExceeded
+from funcx.utils.errors import MaxResultSizeExceeded
 
 
 def large_result_producer(size: int) -> str:


### PR DESCRIPTION
## Description

This PR removes the MaxResultSizeExceeded exception defined in funcx_endpoint.executors.high_throughput.funcx_worker and instead imports from funcx SDK.

Fixes #640

## Type of change
Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
