### PR TITLE
Fix to smoke_tests: allow use of last release

### DIFF
--- a/smoke_tests/tests/test_s3_indirect.py
+++ b/smoke_tests/tests/test_s3_indirect.py
@@ -1,6 +1,11 @@
 import pytest
 
-from funcx.utils.errors import MaxResultSizeExceeded
+try:
+    from funcx.utils.errors import MaxResultSizeExceeded
+except ImportError:
+    from funcx_endpoint.executors.high_throughput.funcx_worker import (
+        MaxResultSizeExceeded,
+    )
 
 
 def large_result_producer(size: int) -> str:


### PR DESCRIPTION
The exception name is changing so we want the local name for

    tox -e localdeps

but we need to handle the import failing if we're running against the last endpoint/sdk release.