### PR TITLE
Release v0.3.5 prep

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Documentation: https://funcx.readthedocs.io/en/latest/
 Quickstart
 ==========
 
-funcX is in a beta state with version `0.3.4` currently available on PyPI.
+funcX is in a beta state with version `0.3.5` currently available on PyPI.
 
 To install funcX, please ensure you have python3.6+.::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,13 +7,76 @@ funcx & funcx-endpoint v0.3.5
 
 Released on January 12th, 2021
 
+funcx v0.3.4 is a minor release that includes contributions (code, tests, reviews, and reports) from:
+Ben Clifford <benc@hawaga.org.uk>, Ben Galewsky <bengal1@illinois.edu>,
+Daniel S. Katz <d.katz@ieee.org>, Kirill Nagaitsev <knagaitsev@uchicago.edu>
+Michael McQuade <michael@giraffesyo.io>, Ryan Chard <rchard@anl.gov>,
+Stephen Rosen <sirosen@globus.org>, Wes Brewer <whbrew@gmail.com>
+Yadu Nand Babuji <yadudoc1729@gmail.com>, Zhuozhao Li <zhuozhl@clemson.edu>
 
 Bug Fixes
 ^^^^^^^^^
 
+* ``MaxResultSizeExceeded`` is now defined in ``funcx.utils.errors``. Fixes `issue#640 <https://github.com/funcx-faas/funcX/issues/640>`_
+
+* Fixed Websocket disconnect after idling for 10 mins. See `issue#562 <https://github.com/funcx-faas/funcX/issues/562>`_
+  funcX SDK will not auto-reconnect on remote-side disconnects
+
+* Cleaner logging on the ``funcx-endpoint``. See `PR#643 <https://github.com/funcx-faas/funcX/pull/643>`_
+  Previously available ``set_stream_logger``, ``set_file_logger`` methods are now removed.
+  For debugging the SDK use standard logging setup, like:
+
+  .. code-block::
+    import logging
+    def set_stream_logger(name="funcx", level=logging.DEBUG, format_string="%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"):
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        handler.setLevel(level)
+        formatter = logging.Formatter(format_string, datefmt="%Y-%m-%d %H:%M:%S")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+    set_stream_logger()
+
+* Warn and continue on failure to load a results ack file. `PR#616 <https://github.com/funcx-faas/funcX/pull/616>`_
+
+
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
+* Result size raised to 10MB from 512KB. See `PR#647 <https://github.com/funcx-faas/funcX/pull/647>`_
+
+* Version match constraints between the ``funcx-endpoint`` and the ``funcx-worker`` are now relaxed.
+  This allows containers of any supported python3 version to be used for running tasks.
+  See `PR#637 <https://github.com/funcx-faas/funcX/pull/637>`_
+
+* New example config for Polaris at Argonne Leadership Computing Facility
+
+* Simplify instructions for installing endpoint secrets to cluster. `PR#623 <https://github.com/funcx-faas/funcX/pull/623>`_
+
+* Webservice and Websocket service URLs are resolved by the names "production" and
+  "dev". These values can be passed to FuncX client init as in ``environment="dev"``,
+  or by setting the ``FUNCX_SDK_ENVIRONMENT`` environment variable.
+
+* Support for cancelling tasks in ``funcx_endpoint.executors.HighThroughputExecutor``. To cancel a
+  task, use the ``best_effort_cancel`` method on the task's ``future``. This method differs from the
+  concurrent futures ``future.cancel()`` method in that a running task can be cancelled.
+  ``best_effort_cancel`` returns ``True`` only if the task is cancellable with no guarantees that the
+  task will not execute. If the task is already complete, it returns ``False``
+
+  .. note:: Please note that this feature is not yet supported on the SDK.
+
+  Example:
+
+     .. code-block:: python
+
+        from funcx_endpoint.executors import HighThroughputExecutor
+        htex = HighThroughputExecutor(passthrough=False)
+        htex.start()
+
+        future = htex.submit(slow_function)
+        future.best_effort_cancel()
 
 
 funcx & funcx-endpoint v0.3.4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+funcx & funcx-endpoint v0.3.5
+-----------------------------
+
+
+Released on January 12th, 2021
+
+
+Bug Fixes
+^^^^^^^^^
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+
+
 funcx & funcx-endpoint v0.3.4
 -----------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ funcx & funcx-endpoint v0.3.5
 
 Released on January 12th, 2021
 
-funcx v0.3.4 is a minor release that includes contributions (code, tests, reviews, and reports) from:
+funcx v0.3.5 is a minor release that includes contributions (code, tests, reviews, and reports) from:
 Ben Clifford <benc@hawaga.org.uk>, Ben Galewsky <bengal1@illinois.edu>,
 Daniel S. Katz <d.katz@ieee.org>, Kirill Nagaitsev <knagaitsev@uchicago.edu>
 Michael McQuade <michael@giraffesyo.io>, Ryan Chard <rchard@anl.gov>,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -48,7 +48,7 @@ Exceptions
     funcx.utils.errors.SerializationError
     funcx.utils.errors.UserCancelledException
     funcx.utils.errors.InvalidScopeException
+    funcx.utils.errors.MaxResultSizeExceeded
     funcx.utils.errors.HTTPError
     funcx.sdk.utils.throttling.MaxRequestsExceeded
     funcx.sdk.utils.throttling.MaxRequestSizeExceeded
-    funcx_endpoint.executors.high_throughput.funcx_worker.MaxResultSizeExceeded

--- a/docs/stubs/funcx.rst
+++ b/docs/stubs/funcx.rst
@@ -1,4 +1,4 @@
-﻿funcx
+funcx
 =====
 
 .. automodule:: funcx

--- a/docs/stubs/funcx.sdk.client.FuncXClient.rst
+++ b/docs/stubs/funcx.sdk.client.FuncXClient.rst
@@ -1,4 +1,4 @@
-﻿funcx.sdk.client.FuncXClient
+funcx.sdk.client.FuncXClient
 ============================
 
 .. currentmodule:: funcx.sdk.client

--- a/docs/stubs/funcx.sdk.error_handling_client.FuncXErrorHandlingClient.rst
+++ b/docs/stubs/funcx.sdk.error_handling_client.FuncXErrorHandlingClient.rst
@@ -1,4 +1,4 @@
-﻿funcx.sdk.error\_handling\_client.FuncXErrorHandlingClient
+funcx.sdk.error\_handling\_client.FuncXErrorHandlingClient
 ==========================================================
 
 .. currentmodule:: funcx.sdk.error_handling_client

--- a/docs/stubs/funcx.sdk.utils.batch.Batch.rst
+++ b/docs/stubs/funcx.sdk.utils.batch.Batch.rst
@@ -1,4 +1,4 @@
-﻿funcx.sdk.utils.batch.Batch
+funcx.sdk.utils.batch.Batch
 ===========================
 
 .. currentmodule:: funcx.sdk.utils.batch

--- a/docs/stubs/funcx.sdk.utils.throttling.MaxRequestSizeExceeded.rst
+++ b/docs/stubs/funcx.sdk.utils.throttling.MaxRequestSizeExceeded.rst
@@ -1,0 +1,6 @@
+funcx.sdk.utils.throttling.MaxRequestSizeExceeded
+=================================================
+
+.. currentmodule:: funcx.sdk.utils.throttling
+
+.. autoexception:: MaxRequestSizeExceeded

--- a/docs/stubs/funcx.sdk.utils.throttling.MaxRequestsExceeded.rst
+++ b/docs/stubs/funcx.sdk.utils.throttling.MaxRequestsExceeded.rst
@@ -1,0 +1,6 @@
+funcx.sdk.utils.throttling.MaxRequestsExceeded
+==============================================
+
+.. currentmodule:: funcx.sdk.utils.throttling
+
+.. autoexception:: MaxRequestsExceeded

--- a/docs/stubs/funcx.serialize.base.rst
+++ b/docs/stubs/funcx.serialize.base.rst
@@ -1,4 +1,4 @@
-﻿funcx.serialize.base
+funcx.serialize.base
 ====================
 
 .. automodule:: funcx.serialize.base

--- a/docs/stubs/funcx.serialize.concretes.rst
+++ b/docs/stubs/funcx.serialize.concretes.rst
@@ -1,4 +1,4 @@
-﻿funcx.serialize.concretes
+funcx.serialize.concretes
 =========================
 
 .. automodule:: funcx.serialize.concretes

--- a/docs/stubs/funcx.utils.errors.FailureResponse.rst
+++ b/docs/stubs/funcx.utils.errors.FailureResponse.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.FailureResponse
+funcx.utils.errors.FailureResponse
 ==================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.FuncXUnreachable.rst
+++ b/docs/stubs/funcx.utils.errors.FuncXUnreachable.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.FuncXUnreachable
+funcx.utils.errors.FuncXUnreachable
 ===================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.HTTPError.rst
+++ b/docs/stubs/funcx.utils.errors.HTTPError.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.HTTPError
+funcx.utils.errors.HTTPError
 ============================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.InvalidScopeException.rst
+++ b/docs/stubs/funcx.utils.errors.InvalidScopeException.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.InvalidScopeException
+funcx.utils.errors.InvalidScopeException
 ========================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.MalformedResponse.rst
+++ b/docs/stubs/funcx.utils.errors.MalformedResponse.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.MalformedResponse
+funcx.utils.errors.MalformedResponse
 ====================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.MaxResultSizeExceeded.rst
+++ b/docs/stubs/funcx.utils.errors.MaxResultSizeExceeded.rst
@@ -1,0 +1,6 @@
+funcx.utils.errors.MaxResultSizeExceeded
+========================================
+
+.. currentmodule:: funcx.utils.errors
+
+.. autoexception:: MaxResultSizeExceeded

--- a/docs/stubs/funcx.utils.errors.RegistrationError.rst
+++ b/docs/stubs/funcx.utils.errors.RegistrationError.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.RegistrationError
+funcx.utils.errors.RegistrationError
 ====================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.SerializationError.rst
+++ b/docs/stubs/funcx.utils.errors.SerializationError.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.SerializationError
+funcx.utils.errors.SerializationError
 =====================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.TaskPending.rst
+++ b/docs/stubs/funcx.utils.errors.TaskPending.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.TaskPending
+funcx.utils.errors.TaskPending
 ==============================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.UserCancelledException.rst
+++ b/docs/stubs/funcx.utils.errors.UserCancelledException.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.UserCancelledException
+funcx.utils.errors.UserCancelledException
 =========================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx.utils.errors.VersionMismatch.rst
+++ b/docs/stubs/funcx.utils.errors.VersionMismatch.rst
@@ -1,4 +1,4 @@
-﻿funcx.utils.errors.VersionMismatch
+funcx.utils.errors.VersionMismatch
 ==================================
 
 .. currentmodule:: funcx.utils.errors

--- a/docs/stubs/funcx_endpoint.endpoint.endpoint.rst
+++ b/docs/stubs/funcx_endpoint.endpoint.endpoint.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.endpoint.endpoint
+funcx\_endpoint.endpoint.endpoint
 =================================
 
 .. automodule:: funcx_endpoint.endpoint.endpoint

--- a/docs/stubs/funcx_endpoint.endpoint.endpoint_manager.EndpointManager.rst
+++ b/docs/stubs/funcx_endpoint.endpoint.endpoint_manager.EndpointManager.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.endpoint.endpoint\_manager.EndpointManager
+funcx\_endpoint.endpoint.endpoint\_manager.EndpointManager
 ==========================================================
 
 .. currentmodule:: funcx_endpoint.endpoint.endpoint_manager

--- a/docs/stubs/funcx_endpoint.endpoint.interchange.EndpointInterchange.rst
+++ b/docs/stubs/funcx_endpoint.endpoint.interchange.EndpointInterchange.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.endpoint.interchange.EndpointInterchange
+funcx\_endpoint.endpoint.interchange.EndpointInterchange
 ========================================================
 
 .. currentmodule:: funcx_endpoint.endpoint.interchange
@@ -17,6 +17,7 @@
       ~EndpointInterchange.apply_reg_info
       ~EndpointInterchange.get_container
       ~EndpointInterchange.get_status_report
+      ~EndpointInterchange.handle_sigterm
       ~EndpointInterchange.load_config
       ~EndpointInterchange.migrate_tasks_to_internal
       ~EndpointInterchange.provider_status

--- a/docs/stubs/funcx_endpoint.endpoint.taskqueue.TaskQueue.rst
+++ b/docs/stubs/funcx_endpoint.endpoint.taskqueue.TaskQueue.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.endpoint.taskqueue.TaskQueue
+funcx\_endpoint.endpoint.taskqueue.TaskQueue
 ============================================
 
 .. currentmodule:: funcx_endpoint.endpoint.taskqueue

--- a/docs/stubs/funcx_endpoint.executors.high_throughput.funcx_worker.MaxResultSizeExceeded.rst
+++ b/docs/stubs/funcx_endpoint.executors.high_throughput.funcx_worker.MaxResultSizeExceeded.rst
@@ -1,6 +1,0 @@
-﻿funcx\_endpoint.executors.high\_throughput.funcx\_worker.MaxResultSizeExceeded
-==============================================================================
-
-.. currentmodule:: funcx_endpoint.executors.high_throughput.funcx_worker
-
-.. autoexception:: MaxResultSizeExceeded

--- a/docs/stubs/funcx_endpoint.strategies.base.BaseStrategy.rst
+++ b/docs/stubs/funcx_endpoint.strategies.base.BaseStrategy.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.strategies.base.BaseStrategy
+funcx\_endpoint.strategies.base.BaseStrategy
 ============================================
 
 .. currentmodule:: funcx_endpoint.strategies.base

--- a/docs/stubs/funcx_endpoint.strategies.kube_simple.KubeSimpleStrategy.rst
+++ b/docs/stubs/funcx_endpoint.strategies.kube_simple.KubeSimpleStrategy.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.strategies.kube\_simple.KubeSimpleStrategy
+funcx\_endpoint.strategies.kube\_simple.KubeSimpleStrategy
 ==========================================================
 
 .. currentmodule:: funcx_endpoint.strategies.kube_simple

--- a/docs/stubs/funcx_endpoint.strategies.simple.SimpleStrategy.rst
+++ b/docs/stubs/funcx_endpoint.strategies.simple.SimpleStrategy.rst
@@ -1,4 +1,4 @@
-﻿funcx\_endpoint.strategies.simple.SimpleStrategy
+funcx\_endpoint.strategies.simple.SimpleStrategy
 ================================================
 
 .. currentmodule:: funcx_endpoint.strategies.simple

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.5-dev"
+__version__ = "0.3.5"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.5-dev"
+__version__ = "0.3.5"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
# Description

This PR contains updates to docs and version files in preparation for releasing `v0.3.5`
* Updates to funcx and funcx-endpoint versions
* Updates to docs
* Updates to changelog with summarized notes on changes
 
* *Until we have `scriv` added to auto compose the changelog, which we'll have hopefully from the next release onwards, the changelog is updated manually. Please take a look at the changelog, and update if I've missed any items that need to be documented.*

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
- Code maintentance/cleanup
