### PR TITLE
Updating version to 0.3.6-dev

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.5"
+__version__ = "0.3.6-dev"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.5"
+__version__ = "0.3.6-dev"
 VERSION = __version__
 
 # app name to send as part of SDK requests


### PR DESCRIPTION
# Description

Updating version numbers to reflect that the `0.3.5` release is complete and that main is now `0.3.6-dev`.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
