### PR TITLE
Add the use of scriv to manage the changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,22 @@
+name: changelog
+on:
+  - pull_request
+
+jobs:
+  check_has_news_in_changelog_dir:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-news-is-good-news') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:  # do a deep fetch to allow merge-base and diff
+          fetch-depth: 0
+      - name: check PR adds a news file
+        run: |
+          news_files="$(git diff --name-only "$(git merge-base origin/main "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.rst)"
+          if [ -n "$news_files" ]; then
+            echo "Saw new files. changelog.d:"
+            echo "$news_files"
+          else
+            echo "No news files seen"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ FIXME: This doc is a stub.
 ### Recommended
 
 - [pre-commit](https://pre-commit.com/)
+- [scriv](https://scriv.readthedocs.io/en/latest/index.html)
 
 ## Linting
 
@@ -30,6 +31,19 @@ After installing `pre-commit`, run
 in the repo to configure hooks.
 
 > NOTE: If necessary, you can always skip hooks with `git commit --no-verify`
+
+## Adding Changelog Fragments
+
+Any change to the codebase must either include a changelog fragment (in some
+projects these are called "newsfiles") or be in a GitHub PR with the label
+`no-news-is-good-news`.
+
+To create a new changelog fragment, run
+
+    scriv create --edit
+
+and populate the fragment. It will include comments which instruct you on how
+to fill out the fragment.
 
 ## Installing Testing Requirements
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,7 @@
+# Changelog Fragments
+
+Create changelog entries with `scriv`
+
+Use `scriv create --edit` to create a changelog fragment
+
+Fragments are collected for release using `scriv collect --edit`

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,10 @@
+[scriv]
+format = rst
+rst_header_chars = -^
+output_file = docs/changelog.rst
+entry_title_template = funcx & funcx-endpoint v{{ version }}
+version = literal: funcx_sdk/funcx/sdk/version.py: __version__
+
+# compare against scriv default:
+# categories = Removed, Added, Changed, Deprecated, Fixed, Security
+categories = New Functionality, Bug Fixes, Removed, Deprecated, Changed, Security

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+.. scriv-insert-here
+
 funcx & funcx-endpoint v0.3.5
 -----------------------------
 


### PR DESCRIPTION
- add changelog.d/, and changelog.d/scriv.ini
- add github workflow which enforces the inclusion of changelog fragments in PRs (unless exempted by a label)

The config will pull version info from the funcx SDK package.

As there are two packages being maintained with a single changelog, the changelog.d/ dir is placed in the repo root.

---

At a later date, I'd like to rewrite the existing changelog to replace
`Bug Fixes -> Fixed`
`New Functionality -> Added`
and then remove the category config.

The default categories are less verbose and let us use the other defaults without a stylistic mismatch.
However, in case anyone is very attached to the current names, I've left that as a future issue.