### PR TITLE
Add support for pinning workers to specific accelerators

### DIFF
--- a/changelog.d/20220131_083455_ward.logan.t_pincuda.rst
+++ b/changelog.d/20220131_083455_ward.logan.t_pincuda.rst
@@ -1,0 +1,33 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+- Added option for pinning workers to different accelerators
+
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20220131_083455_ward.logan.t_pincuda.rst
+++ b/changelog.d/20220131_083455_ward.logan.t_pincuda.rst
@@ -5,6 +5,7 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 - Added option for pinning workers to different accelerators
+- Log standard error and output from workers to disk
 
 .. Bug Fixes
 .. ^^^^^^^^^

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -313,12 +313,15 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
             self.available_accelerators = ()
         else:
             if isinstance(available_accelerators, int):
-                self.available_accelerators = \
-                    [str(i) for i in range(available_accelerators)]
+                self.available_accelerators = [
+                    str(i) for i in range(available_accelerators)
+                ]
             else:
                 self.available_accelerators = list(available_accelerators)
-            log.debug('Workers will be assigned '
-                      f'to accelerators: {self.available_accelerators}')
+            log.debug(
+                "Workers will be assigned "
+                f"to accelerators: {self.available_accelerators}"
+            )
 
         # FuncX specific options
         self.funcx_service_address = funcx_service_address

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -310,7 +310,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
 
         # Set the available accelerators
         if available_accelerators is None:
-            self.available_accelerators = 0
+            self.available_accelerators = ()
         else:
             if isinstance(available_accelerators, int):
                 self.available_accelerators = \

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -153,7 +153,12 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         or an integer defining the number of accelerators available.
         If an integer, sequential device IDs will be created starting at 0.
         The manager will ensure each worker is pinned to an accelerator and
-        will launch no more workers than the number of available accelerators.
+        will set the maximum number of workers per node to be no more
+        than the number of accelerators.
+
+        Workers are pinned to specific accelerators using environment variables,
+        such as by setting the ``CUDA_VISIBLE_DEVICES`` or
+        ``SYCL_DEVICE_FILTER`` to the selected accelerator.
         Default: None
 
     max_workers_per_node : int

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -375,7 +375,7 @@ class Manager:
                         try:
                             log.info(f"Removing worker:{worker_id_raw} from map")
                             self.worker_map.start_remove_worker(worker_type)
-                            self.worker_map.remove_worker(worker_id_raw)
+
                             log.info(
                                 f"Popping worker:{worker_to_kill} from worker_procs"
                             )
@@ -393,6 +393,8 @@ class Manager:
                                     f"Worker process exited with : {proc.returncode}"
                                 )
 
+                            # Now that the worker is dead, remove it from worker map
+                            self.worker_map.remove_worker(worker_id_raw)
                             raise TaskCancelled(worker_to_kill, self.uid)
                         except Exception as e:
                             log.exception(f"Raise exception, handling: {e}")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -795,7 +795,7 @@ def cli_run():
         "--available-accelerators",
         default=(),
         nargs="*",
-        help="List of available accelerators"
+        help="List of available accelerators",
     )
     parser.add_argument(
         "-t", "--task_url", required=True, help="REQUIRED: ZMQ url for receiving tasks"

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -32,6 +32,7 @@ except ImportError:
                 f"limit of {self.result_size_limit}B"
             )
 
+
 log = logging.getLogger(__name__)
 
 DEFAULT_RESULT_SIZE_LIMIT_MB = 10
@@ -63,12 +64,12 @@ class FuncXWorker:
     """
 
     def __init__(
-            self,
-            worker_id,
-            address,
-            port,
-            worker_type="RAW",
-            result_size_limit=DEFAULT_RESULT_SIZE_LIMIT_B,
+        self,
+        worker_id,
+        address,
+        port,
+        worker_type="RAW",
+        result_size_limit=DEFAULT_RESULT_SIZE_LIMIT_B,
     ):
 
         self.worker_id = worker_id
@@ -227,7 +228,7 @@ def cli_run():
     # Redirect the stdout and stderr
     stdout_path = os.path.join(args.logdir, f"funcx_worker_{args.worker_id}.stdout")
     stderr_path = os.path.join(args.logdir, f"funcx_worker_{args.worker_id}.stderr")
-    with open(stdout_path, 'w') as fo, open(stderr_path, 'w') as fe:
+    with open(stdout_path, "w") as fo, open(stderr_path, "w") as fe:
         # Redirect the stdout
         old_stdout, old_stderr = sys.stdout, sys.stderr
         sys.stdout = fo

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -32,7 +32,6 @@ except ImportError:
                 f"limit of {self.result_size_limit}B"
             )
 
-
 log = logging.getLogger(__name__)
 
 DEFAULT_RESULT_SIZE_LIMIT_MB = 10
@@ -64,12 +63,12 @@ class FuncXWorker:
     """
 
     def __init__(
-        self,
-        worker_id,
-        address,
-        port,
-        worker_type="RAW",
-        result_size_limit=DEFAULT_RESULT_SIZE_LIMIT_B,
+            self,
+            worker_id,
+            address,
+            port,
+            worker_type="RAW",
+            result_size_limit=DEFAULT_RESULT_SIZE_LIMIT_B,
     ):
 
         self.worker_id = worker_id
@@ -225,13 +224,27 @@ def cli_run():
         debug=args.debug,
     )
 
-    worker = FuncXWorker(
-        args.worker_id,
-        args.address,
-        int(args.port),
-        worker_type=args.type,
-    )
-    worker.start()
+    # Redirect the stdout and stderr
+    stdout_path = os.path.join(args.logdir, f"funcx_worker_{args.worker_id}.stdout")
+    stderr_path = os.path.join(args.logdir, f"funcx_worker_{args.worker_id}.stderr")
+    with open(stdout_path, 'w') as fo, open(stderr_path, 'w') as fe:
+        # Redirect the stdout
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout = fo
+        sys.stderr = fe
+
+        try:
+            worker = FuncXWorker(
+                args.worker_id,
+                args.address,
+                int(args.port),
+                worker_type=args.type,
+            )
+            worker.start()
+        finally:
+            # Switch them back
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
 
 
 if __name__ == "__main__":

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -96,7 +96,7 @@ class FuncXWorker:
         signal.signal(signal.SIGTERM, self.handler)
 
     def handler(self, signum, frame):
-        log.error("Signal handler called with signal", signum)
+        log.error(f"Signal handler called with signal {signum}")
         sys.exit(1)
 
     def registration_message(self):

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -110,6 +110,7 @@ class Interchange:
         provider=None,
         max_workers_per_node=None,
         mem_per_worker=None,
+        available_accelerators=(),
         prefetch_capacity=None,
         scheduler_mode=None,
         container_type=None,
@@ -163,6 +164,10 @@ class Interchange:
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0. Default=1
 
+        available_accelerators: list of str
+            List of device IDs for accelerators available on each node
+            Default: Empty list
+
         container_cmd_options: str
             Container command strings to be added to associated container command.
             For example, singularity exec {container_cmd_options}
@@ -203,6 +208,7 @@ class Interchange:
         self.max_workers_per_node = max_workers_per_node
         self.mem_per_worker = mem_per_worker
         self.cores_per_worker = cores_per_worker
+        self.available_accelerators = available_accelerators
         self.prefetch_capacity = prefetch_capacity
 
         self.scheduler_mode = scheduler_mode
@@ -224,7 +230,7 @@ class Interchange:
         self.poll_period = poll_period
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold
-        # initalize the last heartbeat time to start the loop
+        # initialize the last heartbeat time to start the loop
         self.last_heartbeat = time.time()
 
         self.serializer = FuncXSerializer()
@@ -320,6 +326,7 @@ class Interchange:
                 "--container_cmd_options='{container_cmd_options}' "
                 "--scheduler_mode={scheduler_mode} "
                 "--worker_type={{worker_type}} "
+                "--available-accelerators {accelerator_list}"
             )
 
         self.current_platform = {
@@ -380,6 +387,7 @@ class Interchange:
             debug=debug_opts,
             max_workers=max_workers,
             cores_per_worker=self.cores_per_worker,
+            accelerator_list=" ".join(self.available_accelerators),
             # mem_per_worker=self.mem_per_worker,
             prefetch_capacity=self.prefetch_capacity,
             task_url=worker_task_url,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -906,7 +906,7 @@ class Interchange:
                 tasks = task_dispatch[manager]
                 if tasks:
                     log.info(
-                        "[MAIN] Sending task message \"{}...\" to manager {}".format(
+                        '[MAIN] Sending task message "{}..." to manager {}'.format(
                             str(tasks)[:50], manager
                         )
                     )
@@ -1133,7 +1133,7 @@ class Interchange:
         Raises:
              NotImplementedError
         """
-        log.info(f'Scaling out by {blocks} more blocks for task type {task_type}')
+        log.info(f"Scaling out by {blocks} more blocks for task type {task_type}")
         r = []
         for _i in range(blocks):
             if self.provider:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -906,8 +906,8 @@ class Interchange:
                 tasks = task_dispatch[manager]
                 if tasks:
                     log.info(
-                        "[MAIN] Sending task message {} to manager {}".format(
-                            tasks, manager
+                        "[MAIN] Sending task message \"{}...\" to manager {}".format(
+                            str(tasks)[:50], manager
                         )
                     )
                     serializd_raw_tasks_buffer = pickle.dumps(tasks)
@@ -1133,6 +1133,7 @@ class Interchange:
         Raises:
              NotImplementedError
         """
+        log.info(f'Scaling out by {blocks} more blocks for task type {task_type}')
         r = []
         for _i in range(blocks):
             if self.provider:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -10,7 +10,7 @@ import queue
 import sys
 import threading
 import time
-from typing import Dict, Tuple
+from typing import Dict, Sequence, Tuple
 
 import daemon
 import zmq
@@ -110,7 +110,7 @@ class Interchange:
         provider=None,
         max_workers_per_node=None,
         mem_per_worker=None,
-        available_accelerators=(),
+        available_accelerators: Sequence[str] = (),
         prefetch_capacity=None,
         scheduler_mode=None,
         container_type=None,
@@ -164,7 +164,7 @@ class Interchange:
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0. Default=1
 
-        available_accelerators: list of str
+        available_accelerators: sequence of str
             List of device IDs for accelerators available on each node
             Default: Empty list
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
@@ -3,8 +3,8 @@ import os
 import random
 import subprocess
 import time
-from queue import Queue, Empty
-from typing import List, Dict
+from queue import Empty, Queue
+from typing import Dict, List
 
 log = logging.getLogger(__name__)
 
@@ -13,9 +13,9 @@ class WorkerMap:
     """WorkerMap keeps track of workers"""
 
     def __init__(
-            self,
-            max_worker_count: int,
-            available_accelerators: List[str],
+        self,
+        max_worker_count: int,
+        available_accelerators: List[str],
     ):
         """
 
@@ -343,9 +343,11 @@ class WorkerMap:
             try:
                 device = self.available_accelerators.get_nowait()
             except Empty:
-                raise ValueError('No accelerators are available.'
-                                 ' New worker must be created only'
-                                 ' after another is removed')
+                raise ValueError(
+                    "No accelerators are available."
+                    " New worker must be created only"
+                    " after another is removed"
+                )
             self.assigned_accelerators[worker_id] = device
             log.info(f"Assigned worker '{worker_id}' to accelerator '{device}'")
 
@@ -390,7 +392,7 @@ class WorkerMap:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 shell=False,
-                env=environment_variables
+                env=environment_variables,
             )
 
         except Exception:

--- a/funcx_endpoint/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/funcx_endpoint/tests/conftest.py
@@ -1,0 +1,32 @@
+import uuid
+import os
+import pytest
+from parsl.providers import LocalProvider
+
+from funcx_endpoint.executors import HighThroughputExecutor
+
+
+@pytest.fixture(scope="module")
+def htex():
+    try:
+        os.remove("interchange.log")
+    except Exception:
+        pass
+
+    htex = HighThroughputExecutor(
+        worker_debug=True,
+        max_workers_per_node=2,
+        passthrough=False,
+        endpoint_id=str(uuid.uuid4()),
+        available_accelerators=2,
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=1,
+            max_blocks=1,
+        ),
+        run_dir=".",
+    )
+
+    htex.start()
+    yield htex
+    htex.shutdown()

--- a/funcx_endpoint/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/funcx_endpoint/tests/conftest.py
@@ -1,5 +1,6 @@
-import uuid
 import os
+import uuid
+
 import pytest
 from parsl.providers import LocalProvider
 

--- a/funcx_endpoint/funcx_endpoint/tests/test_accelerators.py
+++ b/funcx_endpoint/funcx_endpoint/tests/test_accelerators.py
@@ -1,0 +1,15 @@
+"""Test launching a executor where we pin workers to specific executors"""
+
+
+def slow_get_cuda(x):
+    from time import sleep
+    import os
+
+    sleep(2)
+    return os.environ.get('CUDA_VISIBLE_DEVICES')
+
+
+def test_assign_workers(htex):
+    futures = [htex.submit(slow_get_cuda, i) for i in range(4)]
+    devices = set(f.result() for f in futures)
+    assert devices == {'0', '1'}

--- a/funcx_endpoint/funcx_endpoint/tests/test_accelerators.py
+++ b/funcx_endpoint/funcx_endpoint/tests/test_accelerators.py
@@ -2,14 +2,14 @@
 
 
 def slow_get_cuda(x):
-    from time import sleep
     import os
+    from time import sleep
 
     sleep(2)
-    return os.environ.get('CUDA_VISIBLE_DEVICES')
+    return os.environ.get("CUDA_VISIBLE_DEVICES")
 
 
 def test_assign_workers(htex):
     futures = [htex.submit(slow_get_cuda, i) for i in range(4)]
-    devices = set(f.result() for f in futures)
-    assert devices == {'0', '1'}
+    devices = {f.result() for f in futures}
+    assert devices == {"0", "1"}

--- a/funcx_endpoint/funcx_endpoint/tests/test_cancel.py
+++ b/funcx_endpoint/funcx_endpoint/tests/test_cancel.py
@@ -2,40 +2,11 @@ import logging
 import os
 import random
 import time
-import uuid
 from concurrent.futures import CancelledError
 
 import pytest
-from parsl.providers import LocalProvider
-
-from funcx_endpoint.executors import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="module")
-def htex():
-    try:
-        os.remove("interchange.log")
-    except Exception:
-        pass
-
-    htex = HighThroughputExecutor(
-        worker_debug=True,
-        max_workers_per_node=1,
-        passthrough=False,
-        endpoint_id=str(uuid.uuid4()),
-        provider=LocalProvider(
-            init_blocks=1,
-            min_blocks=1,
-            max_blocks=1,
-        ),
-        run_dir=".",
-    )
-
-    htex.start()
-    yield htex
-    htex.shutdown()
 
 
 def double(x):

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
@@ -39,4 +39,4 @@ class TestWorkerMap:
         )
 
         last_call = mock_popen.mock_calls[-1]
-        assert last_call[-1]['env']["CUDA_VISIBLE_DEVICES"] == "0"
+        assert last_call[-1]["env"]["CUDA_VISIBLE_DEVICES"] == "0"

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
@@ -11,7 +11,8 @@ class TestWorkerMap:
         )
         mock_popen.return_value = "proc"
 
-        worker_map = WorkerMap(1)
+        # Test adding with no accelerators
+        worker_map = WorkerMap(1, [])
         worker = worker_map.add_worker(
             worker_id="0",
             address="127.0.0.1",
@@ -24,3 +25,18 @@ class TestWorkerMap:
         assert list(worker.keys()) == ["0"]
         assert worker["0"] == "proc"
         assert worker_map.worker_id_counter == 1
+        assert worker_map.available_accelerators is None
+
+        # Test with an accelerator
+        worker_map = WorkerMap(1, ["0"])
+        worker_map.add_worker(
+            worker_id="1",
+            address="127.0.0.1",
+            debug=logging.DEBUG,
+            uid="test1",
+            logdir=os.getcwd(),
+            worker_port=50001,
+        )
+
+        last_call = mock_popen.mock_calls[-1]
+        assert last_call.kwargs['env']["CUDA_VISIBLE_DEVICES"] == "0"

--- a/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
+++ b/funcx_endpoint/tests/funcx_endpoint/executors/high_throughput/test_worker_map.py
@@ -39,4 +39,4 @@ class TestWorkerMap:
         )
 
         last_call = mock_popen.mock_calls[-1]
-        assert last_call.kwargs['env']["CUDA_VISIBLE_DEVICES"] == "0"
+        assert last_call[-1]['env']["CUDA_VISIBLE_DEVICES"] == "0"


### PR DESCRIPTION
# Description

Fixes #664 

While working on this issue, I also added support logging worker stdout/stderr to disk (fixes #250 ). The change stores them in files next to the log for the worker.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
