### PR TITLE
Add stress tests

### DIFF
--- a/funcx_endpoint/tests/stress_tests/README.rst
+++ b/funcx_endpoint/tests/stress_tests/README.rst
@@ -1,0 +1,52 @@
+Stress Tests
+============
+
+These tests are designed to test the behavior of a deployment under various forms of stress
+that it might face in production.
+
+The goals of these tests are to:
+* Test how well various components behave under stress
+* Confirm that when limits are exceeded, proper exceptions are returned
+* Indirectly test the internals
+
+How-to
+------
+
+These test have to be updated minimally for each deployment, with updates to the `conftest.py`
+similar to how it's done in the smoke_tests
+
+
+
+Running tests
+-------------
+
+* Install requirements:
+
+     >> pip install -r requirements.txt
+
+* Run tests:
+
+     >> pytest .
+
+Running Against dev deployment
+------------------------------
+
+To run against the dev deployment, first start a local endpoint that points at the dev deployment.
+Then use
+
+.. code-block:: bash
+
+    export FUNCX_LOCAL_ENDPOINT_ID=<SET_YOUR_FUNCX_ENDPOINT_ID>
+    pytest . --funcx-config dev
+
+You can configure it to use a different local endpoint name (not `default`) by
+setting the `FUNCX_LOCAL_ENDPOINT_NAME` env var.
+
+Additional ways of settings the endpoint ID to use are:
+
+- set `FUNCX_LOCAL_ENDPOINT_ID` (higher precedence than `~/.funcx/` dir)
+
+- pass the `--endpoint <UUID>` option to `pytest` (highest precedence)
+
+All tests should pass when run locally. Tests which cannot work on a local
+stack are marked with `pytest.skip` and will be skipped.

--- a/funcx_endpoint/tests/stress_tests/conftest.py
+++ b/funcx_endpoint/tests/stress_tests/conftest.py
@@ -83,6 +83,11 @@ def pytest_addoption(parser):
         "--endpoint", metavar="endpoint", help="Specify an active endpoint UUID"
     )
     parser.addoption(
+        "--endpoints",
+        metavar="endpoints",
+        help="Specify a comma separated list of active endpoint UUIDs",
+    )
+    parser.addoption(
         "--service-address",
         metavar="service-address",
         help="Specify a funcX service address",
@@ -117,8 +122,12 @@ def funcx_test_config(pytestconfig, funcx_test_config_name):
     # if `--endpoint` was passed or `endpoint_uuid` is present in config,
     # handle those cases
     endpoint = pytestconfig.getoption("--endpoint")
+    endpoints = pytestconfig.getoption("--endpoints")
+
     if endpoint:
         config["endpoint_uuid"] = endpoint
+    elif endpoints:
+        config["endpoint_uuids"] = endpoints.split(",")
     elif config["endpoint_uuid"] is None:
         config["endpoint_uuid"] = _get_local_endpoint_id()
     if not config["endpoint_uuid"]:
@@ -189,6 +198,11 @@ def fx(fxc):
 @pytest.fixture
 def endpoint(funcx_test_config):
     return funcx_test_config["endpoint_uuid"]
+
+
+@pytest.fixture
+def endpoints(funcx_test_config):
+    return funcx_test_config["endpoint_uuids"]
 
 
 @pytest.fixture

--- a/funcx_endpoint/tests/stress_tests/conftest.py
+++ b/funcx_endpoint/tests/stress_tests/conftest.py
@@ -1,0 +1,208 @@
+import json
+import os
+import time
+
+import pytest
+from globus_sdk import AccessTokenAuthorizer, ConfidentialAppAuthClient
+
+from funcx import FuncXClient
+from funcx.sdk.executor import FuncXExecutor
+
+# the non-tutorial endpoint will be required, with the following priority order for
+# finding the ID:
+#
+#  1. `--endpoint` opt
+#  2. FUNX_LOCAL_ENDPOINT_ID (seen here)
+#  3. FUNX_LOCAL_ENDPOINT_NAME (the name of a dir in `~/.funcx/`)
+#  4. An endpoint ID found in ~/.funcx/default/endpoint.json
+#
+#  this var starts with the ID env var load
+_LOCAL_ENDPOINT_ID = os.getenv("FUNCX_LOCAL_ENDPOINT_ID")
+
+_CONFIGS = {
+    "dev": {
+        "client_args": {
+            "funcx_service_address": "https://api.dev.funcx.org/v2",
+            "results_ws_uri": "wss://api.dev.funcx.org/ws/v2/",
+        },
+        # assert versions are as expected on dev
+        "forwarder_min_version": "0.3.5",
+        "api_min_version": "0.3.5",
+        # This fn is public and searchable
+        "public_hello_fn_uuid": "f84351f9-6f82-45d8-8eca-80d8f73645be",
+        "endpoint_uuid": _LOCAL_ENDPOINT_ID,
+    },
+    "prod": {
+        # By default tests are against production, which means we do not need to pass
+        # any arguments to the client object (default will point at prod stack)
+        "client_args": {},
+        # assert versions are as expected on prod
+        "forwarder_min_version": "0.3.5",
+        "api_min_version": "0.3.5",
+        # This fn is public and searchable
+        "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
+        # For production tests, the target endpoint should be the tutorial_endpoint
+        "endpoint_uuid": "4b116d3c-1703-4f8f-9f6f-39921e5864df",
+    },
+    "local": {
+        # localhost; typical defaults for a helm deploy
+        "client_args": {
+            "funcx_service_address": "http://localhost:5000/v2",
+            "results_ws_uri": "ws://localhost:6000/ws/v2/",
+        },
+        "endpoint_uuid": _LOCAL_ENDPOINT_ID,
+    },
+}
+
+
+def _get_local_endpoint_id():
+    # get the ID of a local endpoint, by name
+    # this is only called if
+    #  - there is no endpoint in the config (e.g. config via env var)
+    #  - `--endpoint` is not passed
+    local_endpoint_name = os.getenv("FUNCX_LOCAL_ENDPOINT_NAME", "default")
+    data_path = os.path.join(
+        os.path.expanduser("~"), ".funcx", local_endpoint_name, "endpoint.json"
+    )
+
+    try:
+        with open(data_path) as fp:
+            data = json.load(fp)
+    except Exception:
+        return None
+    else:
+        return data["endpoint_id"]
+
+
+def pytest_addoption(parser):
+    """Add funcx-specific command-line options to pytest."""
+    parser.addoption(
+        "--funcx-config", default="prod", help="Name of testing config to use"
+    )
+    parser.addoption(
+        "--endpoint", metavar="endpoint", help="Specify an active endpoint UUID"
+    )
+    parser.addoption(
+        "--service-address",
+        metavar="service-address",
+        help="Specify a funcX service address",
+    )
+    parser.addoption(
+        "--ws-uri", metavar="ws-uri", help="WebSocket URI to get task results"
+    )
+    parser.addoption(
+        "--api-client-id",
+        metavar="api-client-id",
+        default=None,
+        help="The API Client ID. Used for github actions testing",
+    )
+    parser.addoption(
+        "--api-client-secret",
+        metavar="api-client-secret",
+        default=None,
+        help="The API Client Secret. Used for github actions testing",
+    )
+
+
+@pytest.fixture(scope="session")
+def funcx_test_config_name(pytestconfig):
+    return pytestconfig.getoption("--funcx-config")
+
+
+@pytest.fixture(scope="session")
+def funcx_test_config(pytestconfig, funcx_test_config_name):
+    # start with basic config load
+    config = _CONFIGS[funcx_test_config_name]
+
+    # if `--endpoint` was passed or `endpoint_uuid` is present in config,
+    # handle those cases
+    endpoint = pytestconfig.getoption("--endpoint")
+    if endpoint:
+        config["endpoint_uuid"] = endpoint
+    elif config["endpoint_uuid"] is None:
+        config["endpoint_uuid"] = _get_local_endpoint_id()
+    if not config["endpoint_uuid"]:
+        # If there's no endpoint_uuid available, the smoke tests won't work
+        raise Exception("No target endpoint_uuid available to test against")
+
+    # set URIs if passed
+    client_args = config["client_args"]
+    ws_uri = pytestconfig.getoption("--ws-uri")
+    api_uri = pytestconfig.getoption("--service-address")
+    api_client_id = pytestconfig.getoption("--api-client-id")
+    api_client_secret = pytestconfig.getoption("--api-client-secret")
+    if ws_uri:
+        client_args["results_ws_uri"] = ws_uri
+    if api_uri:
+        client_args["funcx_service_address"] = api_uri
+
+    if api_client_id and api_client_secret:
+        client = ConfidentialAppAuthClient(api_client_id, api_client_secret)
+        scopes = [
+            "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+            "urn:globus:auth:scope:search.api.globus.org:all",
+            "openid",
+        ]
+
+        token_response = client.oauth2_client_credentials_tokens(
+            requested_scopes=scopes
+        )
+        fx_token = token_response.by_resource_server["funcx_service"]["access_token"]
+        search_token = token_response.by_resource_server["search.api.globus.org"][
+            "access_token"
+        ]
+        openid_token = token_response.by_resource_server["auth.globus.org"][
+            "access_token"
+        ]
+
+        fx_auth = AccessTokenAuthorizer(fx_token)
+        search_auth = AccessTokenAuthorizer(search_token)
+        openid_auth = AccessTokenAuthorizer(openid_token)
+
+        client_args["fx_authorizer"] = fx_auth
+        client_args["search_authorizer"] = search_auth
+        client_args["openid_authorizer"] = openid_auth
+
+    return config
+
+
+@pytest.fixture(scope="session")
+def fxc(funcx_test_config):
+    client_args = funcx_test_config["client_args"]
+    fxc = FuncXClient(**client_args)
+    return fxc
+
+
+@pytest.fixture(scope="session")
+def async_fxc(funcx_test_config):
+    client_args = funcx_test_config["client_args"]
+    fxc = FuncXClient(**client_args, asynchronous=True)
+    return fxc
+
+
+@pytest.fixture(scope="session")
+def fx(fxc):
+    fx = FuncXExecutor(fxc)
+    return fx
+
+
+@pytest.fixture
+def endpoint(funcx_test_config):
+    return funcx_test_config["endpoint_uuid"]
+
+
+@pytest.fixture
+def tutorial_funcion_id(funcx_test_config):
+    funcid = funcx_test_config.get("public_hello_fn_uuid")
+    if not funcid:
+        pytest.skip("test requires a pre-defined public hello function")
+    return funcid
+
+
+@pytest.fixture(autouse=True)
+def sleep_before_test():
+    """WARNING: This will make all tests sleep for 5s just to make
+    sure that tests do not interfere with each other via throttle limits
+    """
+    time.sleep(5)
+    return

--- a/funcx_endpoint/tests/stress_tests/shared.py
+++ b/funcx_endpoint/tests/stress_tests/shared.py
@@ -3,3 +3,19 @@ def simple_function(*, input_data: bytes, output_size: int, sleep_dur: int):
 
     time.sleep(sleep_dur)
     return (len(input_data), bytearray(output_size))
+
+
+def wait_for_task(fxc, task_id, walltime: int = 2):
+    import time
+
+    start = time.time()
+    while True:
+        if time.time() > start + walltime:
+            raise Exception("Timeout")
+        try:
+            r = fxc.get_result(task_id)
+        except Exception:
+            print("Not available yet")
+            time.sleep(1)
+        else:
+            return r

--- a/funcx_endpoint/tests/stress_tests/shared.py
+++ b/funcx_endpoint/tests/stress_tests/shared.py
@@ -1,0 +1,5 @@
+def simple_function(*, input_data: bytes, output_size: int, sleep_dur: int):
+    import time
+
+    time.sleep(sleep_dur)
+    return (len(input_data), bytearray(output_size))

--- a/funcx_endpoint/tests/stress_tests/test_batch.py
+++ b/funcx_endpoint/tests/stress_tests/test_batch.py
@@ -1,0 +1,55 @@
+import time
+
+import pytest
+from shared import simple_function
+
+
+def wait_for_task(fxc, task_id, walltime: int = 2):
+
+    start = time.time()
+    while True:
+        if time.time() > start + walltime:
+            raise Exception("Timeout")
+        try:
+            r = fxc.get_result(task_id)
+        except Exception:
+            print("Not available yet")
+            time.sleep(1)
+        else:
+            return r
+
+
+@pytest.mark.parametrize("task_count", [100])
+@pytest.mark.skip
+def test_bag_of_tasks_batch(fxc, endpoint, task_count, batch_size=100):
+    """Launches a parametrized bag of tasks using the REST interface.
+    Minimal data IO.
+    """
+    task_ids = []
+    fn_uuid = fxc.register_function(simple_function, endpoint)
+
+    batch = None
+    batch_ids = []
+    for i in range(task_count):
+        if i % 100:
+            # if a batch exists launch, and then create new batch
+            if batch:
+                b_id = fxc.batch_run(batch)
+                batch_ids.append(b_id)
+            batch = fxc.create_batch()
+
+    batch = fxc.create_batch()
+
+    for _i in range(task_count):
+        tid = fxc.run(
+            input_data=bytearray(10),
+            output_size=10,
+            sleep_dur=0,
+            function_id=fn_uuid,
+            endpoint_id=endpoint,
+        )
+        task_ids.append(tid)
+
+    for tid in task_ids:
+        x = wait_for_task(fxc, tid, walltime=30)
+        assert x == (10, bytearray(10)), f"Result does not match, got: {x}"

--- a/funcx_endpoint/tests/stress_tests/test_batch.py
+++ b/funcx_endpoint/tests/stress_tests/test_batch.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_batch.py
+++ b/funcx_endpoint/tests/stress_tests/test_batch.py
@@ -1,7 +1,6 @@
 import time
 
 import pytest
-
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_executor.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor.py
@@ -1,5 +1,4 @@
 import pytest
-
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_executor.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor.py
@@ -1,4 +1,5 @@
 import pytest
+
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_executor.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor.py
@@ -1,0 +1,23 @@
+import pytest
+from shared import simple_function
+
+
+@pytest.mark.parametrize("task_count", [100, 1000])
+def test_bag_of_tasks_executor(fx, endpoint, task_count):
+    """Launches a parametrized bag of tasks using the executor interface.
+    Minimal data IO.
+    """
+    futures = []
+    for _i in range(task_count):
+        future = fx.submit(
+            simple_function,
+            input_data=bytearray(10),
+            output_size=10,
+            sleep_dur=0,
+            endpoint_id=endpoint,
+        )
+        futures.append(future)
+
+    for future in futures:
+        x = future.result()
+        assert x == (10, bytearray(10)), f"Result does not match, got: {x}"

--- a/funcx_endpoint/tests/stress_tests/test_executor_io.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor_io.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_executor_io.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor_io.py
@@ -4,7 +4,7 @@ import pytest
 from shared import simple_function
 
 
-@pytest.mark.parametrize("task_count", [100, 1000])
+@pytest.mark.parametrize("task_count", [5000])
 def test_bag_of_IO_tasks_executor(fx, endpoint, task_count):
     """Launches a parametrized bag of tasks using the executor interface."""
     data_sizes = [2000, 20000, 200000]

--- a/funcx_endpoint/tests/stress_tests/test_executor_io.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor_io.py
@@ -1,0 +1,28 @@
+import random
+
+import pytest
+from shared import simple_function
+
+
+@pytest.mark.parametrize("task_count", [100, 1000])
+def test_bag_of_IO_tasks_executor(fx, endpoint, task_count):
+    """Launches a parametrized bag of tasks using the executor interface."""
+    data_sizes = [2000, 20000, 200000]
+    futures = {}
+    for _i in range(task_count):
+        kwargs = {
+            "input_data": bytearray(random.choice(data_sizes)),
+            "output_size": random.choice(data_sizes),
+        }
+        future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
+        futures[future] = kwargs
+
+    print(futures)
+    for future in futures:
+        print("Trying future: ", future)
+        x = future.result()
+        expected_result = (
+            len(futures[future]["input_data"]),
+            bytearray(futures[future]["output_size"]),
+        )
+        assert x == expected_result, f"Result does not match, got: {x}"

--- a/funcx_endpoint/tests/stress_tests/test_executor_io.py
+++ b/funcx_endpoint/tests/stress_tests/test_executor_io.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-
 from shared import simple_function
 
 

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -1,12 +1,12 @@
 import logging
-
+import time
 import pytest
 from shared import simple_function
 
 logger = logging.getLogger("test")
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=100000):
     """Launches N tasks that return ~1MB results per task."""
@@ -26,6 +26,7 @@ def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=1000
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""
@@ -81,3 +82,37 @@ def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=700):
             bytearray(futures[future]["output_size"]),
         )
         assert x == expected_result, f"Result does not match, got: {x}"
+
+
+# @pytest.mark.parametrize("io_size", [1, 10, 100, 1000, 10000, 100000, 1000000])
+@pytest.mark.parametrize("io_size", [1000000])
+def test_IO_latency(fx, endpoint, io_size, task_count=10):
+    """Launches N tasks that return ~1MB results per task."""
+    futures = {}
+
+
+    s_times = []
+    ttc_times = []
+    for _i in range(task_count):
+        kwargs = {"input_data": bytearray(io_size),
+                  "output_size": io_size}
+        s = time.time()
+        future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
+        submit = time.time() - s
+        x = future.result(timeout=60)
+        done = time.time() - s
+        logger.warning(f"Run {_i}/{task_count} done")
+        """
+        expected_result = (
+            len(futures[future]["input_data"]),
+            bytearray(futures[future]["output_size"]),
+        )
+        assert x == expected_result, f"Result does not match, got: {x}"
+        """
+        s_times.append(submit)
+        ttc_times.append(done)
+
+    avg_submit_time = sum(s_times) / len(s_times)
+    avg_ttc_time = sum(ttc_times) / len(ttc_times)
+    logger.warning(f"Submit latency over {task_count} iterations with IO of {io_size}: min={min(s_times):.3f}s max={max(s_times):.3f}s avg:{avg_submit_time:.3f}s")
+    logger.warning(f"TTC over {task_count} iterations with IO of {io_size}: min={min(ttc_times):.3f}s max={max(ttc_times):.3f}s avg:{avg_ttc_time:.3f}s")

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -6,6 +6,7 @@ from shared import simple_function
 logger = logging.getLogger("test")
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=100000):
     """Launches N tasks that return ~1MB results per task."""
@@ -25,6 +26,7 @@ def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=1000
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""
@@ -83,31 +85,26 @@ def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
 @pytest.mark.parametrize("io_size", [1, 10, 100, 1000, 10000, 100000, 1000000])
 def test_IO_latency(fx, endpoint, io_size, task_count=10):
     """Launches N tasks that return ~1MB results per task."""
-    futures = {}
-
 
     s_times = []
     ttc_times = []
     for _i in range(task_count):
-        kwargs = {"input_data": bytearray(io_size),
-                  "output_size": io_size}
+        kwargs = {"input_data": bytearray(io_size), "output_size": io_size}
         s = time.time()
         future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
         submit = time.time() - s
-        x = future.result(timeout=60)
+        future.result(timeout=60)
         done = time.time() - s
-        # logger.warning(f"Run {_i}/{task_count} done")
-        """
-        expected_result = (
-            len(futures[future]["input_data"]),
-            bytearray(futures[future]["output_size"]),
-        )
-        assert x == expected_result, f"Result does not match, got: {x}"
-        """
         s_times.append(submit)
         ttc_times.append(done)
 
     avg_submit_time = sum(s_times) / len(s_times)
     avg_ttc_time = sum(ttc_times) / len(ttc_times)
-    logger.warning(f"Submit latency over {task_count} iterations with IO of {io_size}: min={min(s_times):.3f}s max={max(s_times):.3f}s avg:{avg_submit_time:.3f}s")
-    logger.warning(f"TTC over {task_count} iterations with IO of {io_size}: min={min(ttc_times):.3f}s max={max(ttc_times):.3f}s avg:{avg_ttc_time:.3f}s")
+    logger.warning(
+        f"Submit latency over {task_count} iterations with IO of {io_size}:"
+        f" min={min(s_times):.3f}s max={max(s_times):.3f}s avg:{avg_submit_time:.3f}s"
+    )
+    logger.warning(
+        f"TTC over {task_count} iterations with IO of {io_size}: "
+        f"min={min(ttc_times):.3f}s max={max(ttc_times):.3f}s avg:{avg_ttc_time:.3f}s"
+    )

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -3,7 +3,7 @@ from shared import simple_function
 
 
 # @pytest.mark.parametrize("task_count", [100, 1000, 10000])
-@pytest.mark.parametrize("task_count", [1000])
+@pytest.mark.parametrize("task_count", [1000, 2000])
 def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
     """Launches N tasks that return ~500KB results per task."""
     futures = {}
@@ -22,7 +22,7 @@ def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-@pytest.mark.parametrize("task_count", [1000])
+@pytest.mark.parametrize("task_count", [1000, 10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""
     futures = {}

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -1,6 +1,8 @@
 import logging
 import time
+
 import pytest
+
 from shared import simple_function
 
 logger = logging.getLogger("test")

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -1,8 +1,11 @@
+import logging
+
 import pytest
 from shared import simple_function
 
+logger = logging.getLogger("test")
 
-# @pytest.mark.parametrize("task_count", [100, 1000, 10000])
+
 @pytest.mark.parametrize("task_count", [1000])
 def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
     """Launches N tasks that return ~500KB results per task."""
@@ -30,10 +33,46 @@ def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
         kwargs = {"input_data": bytearray(1), "output_size": result_size}
         future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
         futures[future] = kwargs
+        # logger.warning(f"Launching futures with {future.task_id}")
 
     for future in futures:
         print("Trying future: ", future)
-        x = future.result()
+        try:
+            x = future.result(timeout=600)
+        except TimeoutError:
+            logger.warning(f"Failed to get results for task_id:{future.task_id}")
+            raise
+        expected_result = (
+            len(futures[future]["input_data"]),
+            bytearray(futures[future]["output_size"]),
+        )
+        assert x == expected_result, f"Result does not match, got: {x}"
+
+
+@pytest.mark.parametrize("task_count", [1000])
+def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
+    """Launches N tasks that return ~7MB results per task that would use redis"""
+    futures = {}
+    count = 0
+    for _i in range(task_count):
+        kwargs = {"input_data": bytearray(1), "output_size": result_size}
+        future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
+        futures[future] = kwargs
+        count += 1
+        if count % 1000 is True:
+            logger.warning(f"Task {count}/{task_count} launched")
+        # logger.warning(f"Launching futures with {future.task_id}")
+
+    count = 0
+    for future in futures:
+        print("Trying future: ", future)
+        try:
+            x = future.result(timeout=600)
+            count += 1
+        except TimeoutError:
+            logger.warning(f"Failed to get results for task_id:{future.task_id}")
+            raise
+        logger.warning(f"Task {count}/{task_count} completed")
         expected_result = (
             len(futures[future]["input_data"]),
             bytearray(futures[future]["output_size"]),

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -6,9 +6,10 @@ from shared import simple_function
 logger = logging.getLogger("test")
 
 
-@pytest.mark.parametrize("task_count", [1000])
-def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
-    """Launches N tasks that return ~500KB results per task."""
+# @pytest.mark.skip
+@pytest.mark.parametrize("task_count", [10000])
+def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=100000):
+    """Launches N tasks that return ~1MB results per task."""
     futures = {}
     for _i in range(task_count):
         kwargs = {"input_data": bytearray(1), "output_size": result_size}
@@ -49,8 +50,10 @@ def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [1000])
-def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
+# def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
+def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=700):
     """Launches N tasks that return ~7MB results per task that would use redis"""
     futures = {}
     count = 0

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -2,13 +2,11 @@ import logging
 import time
 
 import pytest
-
 from shared import simple_function
 
 logger = logging.getLogger("test")
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=100000):
     """Launches N tasks that return ~1MB results per task."""
@@ -28,7 +26,6 @@ def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=1000
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -6,7 +6,6 @@ from shared import simple_function
 logger = logging.getLogger("test")
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=100000):
     """Launches N tasks that return ~1MB results per task."""
@@ -26,7 +25,6 @@ def test_small_IO_through_s3_executor(fx, endpoint, task_count, result_size=1000
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("task_count", [10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""
@@ -51,15 +49,13 @@ def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize("task_count", [1000])
-# def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
-def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=700):
+@pytest.mark.parametrize("task_count", [10])
+def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=7000000):
     """Launches N tasks that return ~7MB results per task that would use redis"""
     futures = {}
     count = 0
     for _i in range(task_count):
-        kwargs = {"input_data": bytearray(1), "output_size": result_size}
+        kwargs = {"input_data": bytearray(result_size), "output_size": result_size}
         future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
         futures[future] = kwargs
         count += 1
@@ -78,14 +74,13 @@ def test_IO_through_S3_executor(fx, endpoint, task_count, result_size=700):
             raise
         logger.warning(f"Task {count}/{task_count} completed")
         expected_result = (
-            len(futures[future]["input_data"]),
-            bytearray(futures[future]["output_size"]),
+            result_size,
+            bytearray(result_size),
         )
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-# @pytest.mark.parametrize("io_size", [1, 10, 100, 1000, 10000, 100000, 1000000])
-@pytest.mark.parametrize("io_size", [1000000])
+@pytest.mark.parametrize("io_size", [1, 10, 100, 1000, 10000, 100000, 1000000])
 def test_IO_latency(fx, endpoint, io_size, task_count=10):
     """Launches N tasks that return ~1MB results per task."""
     futures = {}
@@ -101,7 +96,7 @@ def test_IO_latency(fx, endpoint, io_size, task_count=10):
         submit = time.time() - s
         x = future.result(timeout=60)
         done = time.time() - s
-        logger.warning(f"Run {_i}/{task_count} done")
+        # logger.warning(f"Run {_i}/{task_count} done")
         """
         expected_result = (
             len(futures[future]["input_data"]),

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -3,7 +3,7 @@ from shared import simple_function
 
 
 # @pytest.mark.parametrize("task_count", [100, 1000, 10000])
-@pytest.mark.parametrize("task_count", [1000, 2000])
+@pytest.mark.parametrize("task_count", [1000])
 def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
     """Launches N tasks that return ~500KB results per task."""
     futures = {}
@@ -22,7 +22,7 @@ def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
         assert x == expected_result, f"Result does not match, got: {x}"
 
 
-@pytest.mark.parametrize("task_count", [1000, 10000])
+@pytest.mark.parametrize("task_count", [10000])
 def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
     """Launches N tasks that return ~10KB results per task that would use redis"""
     futures = {}

--- a/funcx_endpoint/tests/stress_tests/test_io_volume.py
+++ b/funcx_endpoint/tests/stress_tests/test_io_volume.py
@@ -1,0 +1,41 @@
+import pytest
+from shared import simple_function
+
+
+# @pytest.mark.parametrize("task_count", [100, 1000, 10000])
+@pytest.mark.parametrize("task_count", [1000])
+def test_IO_through_s3_executor(fx, endpoint, task_count, result_size=350000):
+    """Launches N tasks that return ~500KB results per task."""
+    futures = {}
+    for _i in range(task_count):
+        kwargs = {"input_data": bytearray(1), "output_size": result_size}
+        future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
+        futures[future] = kwargs
+
+    for future in futures:
+        print("Trying future: ", future)
+        x = future.result()
+        expected_result = (
+            len(futures[future]["input_data"]),
+            bytearray(futures[future]["output_size"]),
+        )
+        assert x == expected_result, f"Result does not match, got: {x}"
+
+
+@pytest.mark.parametrize("task_count", [1000])
+def test_IO_through_redis_executor(fx, endpoint, task_count, result_size=10000):
+    """Launches N tasks that return ~10KB results per task that would use redis"""
+    futures = {}
+    for _i in range(task_count):
+        kwargs = {"input_data": bytearray(1), "output_size": result_size}
+        future = fx.submit(simple_function, sleep_dur=0, **kwargs, endpoint_id=endpoint)
+        futures[future] = kwargs
+
+    for future in futures:
+        print("Trying future: ", future)
+        x = future.result()
+        expected_result = (
+            len(futures[future]["input_data"]),
+            bytearray(futures[future]["output_size"]),
+        )
+        assert x == expected_result, f"Result does not match, got: {x}"

--- a/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
+++ b/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
@@ -4,10 +4,10 @@ from functools import partial
 from multiprocessing import Pool
 
 import pytest
+from shared import simple_function
 
 from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
-from shared import simple_function
 
 logger = logging.getLogger("test")
 

--- a/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
+++ b/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
@@ -4,10 +4,10 @@ from functools import partial
 from multiprocessing import Pool
 
 import pytest
-from shared import simple_function
 
 from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
+from shared import simple_function
 
 logger = logging.getLogger("test")
 

--- a/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
+++ b/funcx_endpoint/tests/stress_tests/test_multi_client_ep.py
@@ -1,0 +1,66 @@
+import logging
+import os
+from functools import partial
+from multiprocessing import Pool
+
+import pytest
+from shared import simple_function
+
+from funcx import FuncXClient
+from funcx.sdk.executor import FuncXExecutor
+
+logger = logging.getLogger("test")
+
+
+def double(x):
+    return x * 2
+
+
+def run_tasks_with_fresh_client(
+    funcx_test_config, endpoint, task_count=10, io_size=100
+):
+    """Create a fresh executor and run tests that will hit only redis"""
+    pid = os.getpid()
+    logger.warning(f"Creating client on pid:{pid} against endpoint:{endpoint}")
+
+    client_args = funcx_test_config["client_args"]
+    fxc = FuncXClient(**client_args)
+    fx = FuncXExecutor(fxc)
+
+    futures = {}
+    for t in range(task_count):
+        futures[t] = fx.submit(
+            simple_function,
+            sleep_dur=0,
+            input_data=bytearray(io_size),
+            output_size=io_size,
+            endpoint_id=endpoint,
+        )
+
+    for t in futures:
+        x = futures[t].result(timeout=300)
+        expected_result = (io_size, bytearray(io_size))
+        assert x == expected_result
+    return
+
+
+@pytest.mark.parametrize("task_count", [1000])
+def test_multi_client_small_data(funcx_test_config, endpoints, task_count, io_size=100):
+
+    fn = partial(
+        run_tasks_with_fresh_client, funcx_test_config, task_count=10, io_size=100
+    )
+    with Pool(len(endpoints)) as p:
+        p.map(fn, endpoints)
+
+
+@pytest.mark.parametrize("task_count", [100])
+def test_multi_client_large_data(
+    funcx_test_config, endpoints, task_count, io_size=100000
+):
+
+    fn = partial(
+        run_tasks_with_fresh_client, funcx_test_config, task_count=10, io_size=100
+    )
+    with Pool(len(endpoints)) as p:
+        p.map(fn, endpoints)

--- a/funcx_endpoint/tests/stress_tests/test_raw.py
+++ b/funcx_endpoint/tests/stress_tests/test_raw.py
@@ -1,25 +1,9 @@
 import time
 
 import pytest
-from shared import simple_function
+from shared import simple_function, wait_for_task
 
 from funcx.sdk.utils.throttling import MaxRequestsExceeded
-
-
-def wait_for_task(fxc, task_id, walltime: int = 2):
-    import time
-
-    start = time.time()
-    while True:
-        if time.time() > start + walltime:
-            raise Exception("Timeout")
-        try:
-            r = fxc.get_result(task_id)
-        except Exception:
-            print("Not available yet")
-            time.sleep(1)
-        else:
-            return r
 
 
 @pytest.mark.parametrize("task_count", [100])

--- a/funcx_endpoint/tests/stress_tests/test_raw.py
+++ b/funcx_endpoint/tests/stress_tests/test_raw.py
@@ -1,0 +1,71 @@
+import time
+
+import pytest
+from shared import simple_function
+
+from funcx.sdk.utils.throttling import MaxRequestsExceeded
+
+
+def wait_for_task(fxc, task_id, walltime: int = 2):
+    import time
+
+    start = time.time()
+    while True:
+        if time.time() > start + walltime:
+            raise Exception("Timeout")
+        try:
+            r = fxc.get_result(task_id)
+        except Exception:
+            print("Not available yet")
+            time.sleep(1)
+        else:
+            return r
+
+
+@pytest.mark.parametrize("task_count", [100])
+def test_bag_of_tasks_fail_REST(fxc, endpoint, task_count):
+    """Launches a parametrized bag of tasks using the REST interface.
+    This tests for the MaxRequestsExceeded error
+    """
+
+    task_ids = []
+    fn_uuid = fxc.register_function(simple_function, endpoint)
+
+    with pytest.raises(MaxRequestsExceeded):
+        for _i in range(task_count):
+            task_id = fxc.run(
+                input_data=bytearray(10),
+                output_size=10,
+                sleep_dur=0,
+                function_id=fn_uuid,
+                endpoint_id=endpoint,
+            )
+            task_ids.append(task_id)
+
+    for tid in task_ids:
+        x = wait_for_task(fxc, tid, walltime=10)
+        assert x == (10, bytearray(10)), f"Result does not match, got: {x}"
+
+
+@pytest.mark.parametrize("task_count", [100])
+def test_bag_of_tasks_REST(fxc, endpoint, task_count):
+    """Launches a parametrized bag of tasks using the REST interface.
+    Minimal data IO.
+    """
+    task_ids = []
+    fn_uuid = fxc.register_function(simple_function, endpoint)
+
+    for _i in range(task_count):
+        task_id = fxc.run(
+            input_data=bytearray(10),
+            output_size=10,
+            sleep_dur=0,
+            function_id=fn_uuid,
+            endpoint_id=endpoint,
+        )
+        task_ids.append(task_id)
+        time.sleep(1)
+
+    for tid in task_ids:
+        x = wait_for_task(fxc, tid, walltime=10)
+        assert x == (10, bytearray(10)), f"Result does not match, got: {x}"

--- a/funcx_endpoint/tests/stress_tests/test_raw.py
+++ b/funcx_endpoint/tests/stress_tests/test_raw.py
@@ -1,9 +1,9 @@
 import time
 
 import pytest
-from shared import simple_function, wait_for_task
 
 from funcx.sdk.utils.throttling import MaxRequestsExceeded
+from shared import simple_function, wait_for_task
 
 
 @pytest.mark.parametrize("task_count", [100])

--- a/funcx_endpoint/tests/stress_tests/test_raw.py
+++ b/funcx_endpoint/tests/stress_tests/test_raw.py
@@ -1,9 +1,9 @@
 import time
 
 import pytest
+from shared import simple_function, wait_for_task
 
 from funcx.sdk.utils.throttling import MaxRequestsExceeded
-from shared import simple_function, wait_for_task
 
 
 @pytest.mark.parametrize("task_count", [100])


### PR DESCRIPTION
# Description

This PR adds a few stress tests that test the following:

* Run ~1000 to ~10000 no-op tasks 
* Run ~10000 tasks with minimal IO for both input and output so as to only hit Redis
* Run ~1000 tasks with larger IO ~1MB for input/output to stress test S3 storage
* Use multiple endpoint and client pairs to simulate multi-user load

Please note that there's some duplication between tests.

Fixes  [sc-12026] 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)

Since this is not a feature that needs to user-visibility, I'm skipping a changelog update.