### PR TITLE
Upping the websocket message size limit of from 1MB to 11MB.

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -15,6 +15,10 @@ from funcx.sdk.asynchronous.funcx_task import FuncXTask
 
 log = logging.getLogger(__name__)
 
+# Add extra allowance for result wrappers
+DEFAULT_RESULT_SIZE_LIMIT_MB = 10
+DEFAULT_RESULT_SIZE_LIMIT_B = (DEFAULT_RESULT_SIZE_LIMIT_MB + 1) * 1024 * 1024
+
 
 class WebSocketPollingTask:
     """The WebSocketPollingTask is used by the FuncXExecutor and the FuncXClient
@@ -90,7 +94,9 @@ class WebSocketPollingTask:
         headers = [self.get_auth_header()]
         try:
             self.ws = await websockets.connect(
-                self.results_ws_uri, extra_headers=headers
+                self.results_ws_uri,
+                extra_headers=headers,
+                max_size=DEFAULT_RESULT_SIZE_LIMIT_B,
             )
         # initial Globus authentication happens during the HTTP portion of the
         # handshake, so an invalid handshake means that the user was not authenticated


### PR DESCRIPTION
# Description

Size updated from 1048576 -> 11534336, 1MB allowance for wrappers and such.
With the existing limits larger results are dropped by the websockets with
exception: `websockets.exceptions.PayloadTooBig`

Complete traceback:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/legacy/protocol.py", line 750, in transfer_data
    message = await self.read_message()
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/legacy/protocol.py", line 819, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/legacy/protocol.py", line 895, in read_data_frame
    frame = await self.read_frame(max_size)
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/legacy/protocol.py", line 975, in read_frame
    extensions=self.extensions,
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/legacy/framing.py", line 94, in read
    frame = cls(*extension.decode(frame, max_size=max_size))
  File "/home/yadu/anaconda3/envs/funcx_py3.7/lib/python3.7/site-packages/websockets/extensions/permessage_deflate.py", line 135, in decode
    raise PayloadTooBig(f"over size limit (? > {max_size} bytes)")
websockets.exceptions.PayloadTooBig: over size limit (? > 1048576 bytes)
```

## Fixes: #677 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
