### PR TITLE
Make kubernetes worker pods describe themselves as funcx-worker-*

### DIFF
--- a/changelog.d/20220201_134414_benc_kubernetes_pod_names.rst
+++ b/changelog.d/20220201_134414_benc_kubernetes_pod_names.rst
@@ -1,0 +1,36 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- Kubernetes worker pods will now be named funcx-worker-*
+  instead of funcx-* to clarify what these pods are to
+  observers of 'kubectl get pods'
+
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -142,7 +142,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Dictionary that keeps track of jobs, keyed on task_type
         self.resources_by_task_type = {}
 
-    def submit(self, cmd_string, tasks_per_node, task_type, job_name="funcx"):
+    def submit(self, cmd_string, tasks_per_node, task_type, job_name="funcx-worker"):
         """Submit a job
         Args:
              - cmd_string  :(String) - Name of the container to initiate


### PR DESCRIPTION
This is in line with funcx-COMPONENT naming used for other funcx pods

## Type of change

- Code maintentance/cleanup
