### PR TITLE
Document post-parsl changes to strategy/provider status interface

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -1210,7 +1210,9 @@ class Interchange:
         return r
 
     def provider_status(self):
-        """Get status of all blocks from the provider"""
+        """Get status of all blocks from the provider. The return type is
+        defined by the particular provider in use.
+        """
         status = []
         if self.provider:
             log.debug(

--- a/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
+++ b/funcx_endpoint/funcx_endpoint/providers/kubernetes/kube.py
@@ -192,15 +192,14 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         return pod_name
 
     def status(self, job_ids):
-        """Get the status of a list of jobs identified by the job identifiers
+        """Get the status of a list of pods identified by the job identifiers
         returned from the submit request.
         Args:
              - job_ids (list) : A list of job identifiers
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
-        Raises:
-             - ExecutionProviderExceptions or its subclasses
+             - A dictionary keyed by task_types, containing the count of
+               known pods known with that task type.
+               For example: {"RAW": 16}
         """
         # This is a hack
         log.debug("Getting Kubernetes provider status")


### PR DESCRIPTION
The interface is descended from parsl's strategy/provider status
interactions but is substantially looser, allowing more flexibility
in kubernetes strategy/provider interactions.

## Type of change

- Documentation update
