### PR TITLE
`setup_logging` creates the logdir

### DIFF
--- a/changelog.d/20220201_153610_sirosen_ensure_logdir.rst
+++ b/changelog.d/20220201_153610_sirosen_ensure_logdir.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fixed an issue in which funcx-endpoint commands expected the ``~/.funcx/``
+  directory to exist, preventing the endpoint from starting on new installs

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -848,9 +848,7 @@ def cli_run():
     print("Starting HTEX Intechange")
     args = parser.parse_args()
 
-    logdir = os.path.abspath(args.logdir)
-    os.makedirs(logdir, exist_ok=True)
-    setup_logging(logfile=os.path.join(logdir, "endpoint.log"), debug=args.debug)
+    setup_logging(logfile=os.path.join(args.logdir, "endpoint.log"), debug=args.debug)
 
     optionals = {}
     optionals["suppress_failure"] = args.suppress_failure

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -826,7 +826,6 @@ def cli_run():
 
     args = parser.parse_args()
 
-    os.makedirs(os.path.join(args.logdir, args.uid), exist_ok=True)
     setup_logging(
         logfile=os.path.join(args.logdir, args.uid, "manager.log"), debug=args.debug
     )

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -219,7 +219,6 @@ def cli_run():
     )
     args = parser.parse_args()
 
-    os.makedirs(args.logdir, exist_ok=True)
     setup_logging(
         logfile=os.path.join(args.logdir, f"funcx_worker_{args.worker_id}.log"),
         debug=args.debug,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -1290,7 +1290,6 @@ def cli_run():
     if args.worker_port_range:
         args.worker_port_range = [int(i) for i in args.worker_port_range.split(",")]
 
-    os.makedirs(args.logdir, exist_ok=True)
     setup_logging(
         logfile=os.path.join(args.logdir, "interchange.log"),
         debug=args.debug,

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -5,6 +5,7 @@ This module contains logging configuration for the funcx-endpoint application.
 import logging
 import logging.config
 import logging.handlers
+import os
 import pathlib
 import typing as t
 
@@ -21,6 +22,10 @@ def setup_logging(
 ) -> None:
     if logfile is None:
         logfile = _DEFAULT_LOGFILE
+
+    # ensure that the logdir exists
+    logdir = os.path.dirname(logfile)
+    os.makedirs(logdir, exist_ok=True)
 
     default_config = {
         "version": 1,


### PR DESCRIPTION
- setup_logging now does a `makedirs` call on the parent of the configured logfile
- any calls to `makedirs` immediately preceding `setup_logging` are removed

This resolves the immediate problem cited in #681 , although I might not close that until we're _not_ doing file logging early in the process. That will be another fix.

I tested by removing my `~/.funcx/` dir and running `funcx-endpoint start`, confirming that it fixes that issue.
I'm not sure if we need more testing than that + CI?