### PR TITLE
Add a tox config to test funcx-endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,18 @@ jobs:
       - name: build docs
         run: make docs
 
+  safety-check-endpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - name: install requirements
+        run: |
+          python -m pip install './funcx_endpoint'
+          python -m pip install safety
+      - name: run safety check
+        run: safety check
+
   test-sdk:
     strategy:
       matrix:
@@ -44,31 +56,31 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install requirements
-        run: |
-          python -m pip install tox
+      - name: install tox
+        run: python -m pip install tox
       - name: run tests
         run: |
           cd funcx_sdk
           tox -e py
 
   test-endpoint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.10"]
+    runs-on: ${{ matrix.os }}
+    name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
-      - name: install requirements
+          python-version: ${{ matrix.python-version }}
+      - name: install tox
+        run: python -m pip install tox
+      - name: run tests
         run: |
-          python -m pip install -U pip setuptools wheel
-          python -m pip install './funcx_endpoint[test]'
-          pip install safety
-      - name: run safety check
-        run: safety check
-      - name: run pytest
-        run: |
-          PYTHONPATH=funcx_endpoint python -m coverage run -m pytest funcx_endpoint/tests/funcx_endpoint
+          cd funcx_endpoint
+          tox -e py
 
   publish:
     # only trigger on pushes to the main repo (not forks, and not PRs)

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{37,310}
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+extras = test
+commands = python -m coverage run -m pytest tests/funcx_endpoint {posargs}


### PR DESCRIPTION
Simplifies testing by codifying what is being done by CI in something locally runnable.

Switch CI to using said config, and make sdk/endpoint jobs as uniform as possible. In order for the safety check to work, put it in a separate job that installs the funcx-endpoint directly. Put the tox run of the endpoint into a matrix config which tests the high and low python versions.

You can try this out with `cd funcx_endpoint; tox`.