### PR TITLE
Helm endpoint updates

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -89,4 +89,5 @@ The deployment is configured via values.yaml file.
 | maxWorkersPerPod | How many workers will be scheduled in each pod | 1 |
 | detachEndpoint | Run the endpoint as a daemon inside the pod? | true |
 | endpointUUID   | Specify an existing UUID to this endpoint. Leave blank to generate a new one | |
-
+| maxIdleTime  | The maximum time to maintain an idle worker. After this time the SimpleStrategy will terminate the idle worker. | 3600 |
+| workerImageSecret | The K8s secret to use to deploy worker images. This can refer to an ECR secret. | |

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -34,6 +34,9 @@ data:
                     image="{{ .Values.workerImage }}",
                     worker_init='{{ .Values.workerInit }}',
                     namespace='{{ .Values.workerNamespace }}',
+                    {{- if .Values.workerImageSecret }}
+                    secret: '{{ .Values.workerImageSecret }}',
+                    {{- end }}
                     incluster_config=True
                 ),
             )

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -20,7 +20,7 @@ data:
             HighThroughputExecutor(
                 max_workers_per_node={{ .Values.maxWorkersPerPod }},
                 address=address_by_route(),
-                strategy=KubeSimpleStrategy(max_idletime=3600),
+                strategy=KubeSimpleStrategy(max_idletime={{ .Values.maxIdleTime | default 3600 }}),
                 container_type='docker',
                 scheduler_mode='hard',
                 provider=KubernetesProvider(
@@ -35,7 +35,7 @@ data:
                     worker_init='{{ .Values.workerInit }}',
                     namespace='{{ .Values.workerNamespace }}',
                     {{- if .Values.workerImageSecret }}
-                    secret: '{{ .Values.workerImageSecret }}',
+                    secret='{{ .Values.workerImageSecret }}',
                     {{- end }}
                     incluster_config=True
                 ),


### PR DESCRIPTION
# Description

This PR adds two options to the funcx_endpoint helm chart. Firstly, it allows you to specify an option `workerImageSecret` value which is passed into the KubernetesProvider as secret=... This was not previously configurable and was limiting to DLHub being able to use the standard helm chart. Secondly, it provides an optional argument for maxIdleTime which is passed into a SimpleStrategy to determine the period of time before an idle resource is released. The default is 1 hour (3600 seconds).

Fixes # [sc-13051]

## Type of change

- New feature (non-breaking change that adds functionality)
