### PR TITLE
Fix stress tests

### DIFF
--- a/funcx_endpoint/tests/stress_tests/test_batch.py
+++ b/funcx_endpoint/tests/stress_tests/test_batch.py
@@ -19,36 +19,26 @@ def wait_for_task(fxc, task_id, walltime: int = 2):
             return r
 
 
-@pytest.mark.parametrize("task_count", [100])
-@pytest.mark.skip
-def test_bag_of_tasks_batch(fxc, endpoint, task_count, batch_size=100):
+@pytest.mark.parametrize("task_count", [10])
+def test_bag_of_tasks_batch(fxc, endpoint, task_count, batch_size=10):
     """Launches a parametrized bag of tasks using the REST interface.
     Minimal data IO.
     """
     task_ids = []
     fn_uuid = fxc.register_function(simple_function, endpoint)
 
-    batch = None
-    batch_ids = []
-    for i in range(task_count):
-        if i % 100:
-            # if a batch exists launch, and then create new batch
-            if batch:
-                b_id = fxc.batch_run(batch)
-                batch_ids.append(b_id)
-            batch = fxc.create_batch()
-
-    batch = fxc.create_batch()
-
-    for _i in range(task_count):
-        tid = fxc.run(
-            input_data=bytearray(10),
-            output_size=10,
-            sleep_dur=0,
-            function_id=fn_uuid,
-            endpoint_id=endpoint,
-        )
-        task_ids.append(tid)
+    for _ in range(task_count):
+        batch = fxc.create_batch()
+        for _ in range(batch_size):
+            batch.add(
+                input_data=bytearray(10),
+                output_size=10,
+                sleep_dur=0,
+                function_id=fn_uuid,
+                endpoint_id=endpoint,
+            )
+        batch_task_ids = fxc.batch_run(batch)
+        task_ids.extend(batch_task_ids)
 
     for tid in task_ids:
         x = wait_for_task(fxc, tid, walltime=30)

--- a/funcx_endpoint/tests/stress_tests/test_raw.py
+++ b/funcx_endpoint/tests/stress_tests/test_raw.py
@@ -1,34 +1,5 @@
-import time
-
 import pytest
 from shared import simple_function, wait_for_task
-
-from funcx.sdk.utils.throttling import MaxRequestsExceeded
-
-
-@pytest.mark.parametrize("task_count", [100])
-def test_bag_of_tasks_fail_REST(fxc, endpoint, task_count):
-    """Launches a parametrized bag of tasks using the REST interface.
-    This tests for the MaxRequestsExceeded error
-    """
-
-    task_ids = []
-    fn_uuid = fxc.register_function(simple_function, endpoint)
-
-    with pytest.raises(MaxRequestsExceeded):
-        for _i in range(task_count):
-            task_id = fxc.run(
-                input_data=bytearray(10),
-                output_size=10,
-                sleep_dur=0,
-                function_id=fn_uuid,
-                endpoint_id=endpoint,
-            )
-            task_ids.append(task_id)
-
-    for tid in task_ids:
-        x = wait_for_task(fxc, tid, walltime=10)
-        assert x == (10, bytearray(10)), f"Result does not match, got: {x}"
 
 
 @pytest.mark.parametrize("task_count", [100])
@@ -48,7 +19,6 @@ def test_bag_of_tasks_REST(fxc, endpoint, task_count):
             endpoint_id=endpoint,
         )
         task_ids.append(task_id)
-        time.sleep(1)
 
     for tid in task_ids:
         x = wait_for_task(fxc, tid, walltime=10)


### PR DESCRIPTION
# Description

Add working batch stress test, and remove old stress test that relies on removed `MaxRequestsExceeded` (If we add some form of rate limiting on the web service we will need to revisit these stress tests)

## Type of change

- Code maintentance/cleanup
