### PR TITLE
add endpoint tox file and update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,14 +50,13 @@ jobs:
           python-version: 3.7
       - name: install requirements
         run: |
-          python -m pip install -U pip setuptools wheel
-          python -m pip install './funcx_endpoint[test]'
           pip install safety
       - name: run safety check
         run: safety check
-      - name: run pytest
+      - name: run tests
         run: |
-          PYTHONPATH=funcx_endpoint python -m coverage run -m pytest funcx_endpoint/tests/funcx_endpoint
+          cd funcx_endpoint
+          tox -e py
 
   publish:
     # only trigger on pushes to the main repo (not forks, and not PRs)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,7 @@ jobs:
           python-version: 3.7
       - name: install requirements
         run: |
-          pip install safety
-      - name: run safety check
-        run: safety check
+          python -m pip install tox
       - name: run tests
         run: |
           cd funcx_endpoint

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -48,6 +48,7 @@ TEST_REQUIRES = [
     "codecov==2.1.8",
     "pytest-mock==3.2.0",
     "flake8>=3.8",
+    "safety>=1.10.3",
 ]
 
 

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -5,4 +5,6 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 extras = test
-commands = python -m coverage run -m pytest tests/funcx_endpoint {posargs}
+commands =
+    safety check
+    python -m coverage run -m pytest tests/funcx_endpoint {posargs}

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{310,39,38,37,36}
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+extras = test
+commands = python -m coverage run -m pytest tests/funcx_endpoint {posargs}


### PR DESCRIPTION
# Description

Add a tox file for endpoint tests that are runnable in CI, and adjust CI accordingly

TODO: I see endpoint CI run includes `safety check` but the SDK does not, should we add that for SDK? (numpy has a vulnerability in safety with python 3.7 - one of our test deps, so this will not be super clean to do)

## Type of change

- Code maintentance/cleanup
