### PR TITLE
Add RabbitMQ plumbing [RMQ Series 2]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    services:
-      rabbitmq:
-        image: rabbitmq
-        env:
-          RABBITMQ_DEFAULT_USER: guest
-          RABBITMQ_DEFAULT_PASS: guest
-        ports:
-          - 5672:5672
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -51,6 +43,13 @@ jobs:
 
   test-endpoint:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq
+        ports:
+          - 5672:5672
+        # needed because the rabbitmq container does not provide a healthcheck
+        options: --health-cmd "rabbitmqctl node_health_check" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,14 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq
+        env:
+          RABBITMQ_DEFAULT_USER: guest
+          RABBITMQ_DEFAULT_PASS: guest
+        ports:
+          - 5672:5672
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -58,7 +66,7 @@ jobs:
       - name: run pytest
         run: |
           PYTHONPATH=funcx_endpoint python -m coverage run -m pytest funcx_endpoint/tests/funcx_endpoint
-
+          PYTHONPATH=funcx_endpoint python -m coverage run -m pytest funcx_endpoint/tests/test_rabbit_mq
   publish:
     # only trigger on pushes to the main repo (not forks, and not PRs)
     if: ${{ github.repository == 'funcx-faas/funcX' && github.event_name == 'push' }}

--- a/changelog.d/20220225_175608_yadudoc1729_add_rabbitmq_plumbing.rst
+++ b/changelog.d/20220225_175608_yadudoc1729_add_rabbitmq_plumbing.rst
@@ -1,0 +1,34 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+* `TaskQueueSubscriber` class added that allows receiving tasks over RabbitMQ
+* `ResultQueuePublisher` class added that allows publishing results and status over RabbitMQ
+* `TaskQueuePublisher` class added for testing
+* `ResultQueueSubscriber` class added for testing
+* A bunch of tests are added that test the above classes described above
+
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/README.rst
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/README.rst
@@ -1,0 +1,120 @@
+Design notes
+============
+
+Since we are interfacing with a queue like interface, a `get`, `put` interface first comes to mind.
+However, in the case of the subscriber, we have the added responsibility to split the get behavior to
+
+* waitFor a message
+* hand-off to application
+* if success -> ack
+  else -> nack
+
+This means that we either need:
+* A callback that upon successful handoff raises no error
+* Or pass the message to a robust queue that's guaranteed to not lose the message
+  - We can simulate this behavior with mp.Queue to start with and perhaps add a sqlite db to back it up
+    doing the commit to disk in the critical path is hard, so we have to consider some alt mechanism
+    that sends acks in an async fashion.
+
+Note : Following a dev discussion the callback option is dropped. The idea is to extend
+the multiprocessing Queue to write messages to disk to guarantee no message is lost.
+
+Results Queue
+-------------
+
+The ResultsQueuePublisher is left intentionally simple since the main behavior that we
+care about initially is covered, i.e:
+* A published message is never lost, so the ACK handler is rather simple.
+  If message could not be sent we immediately get an error message.
+* Need to determine what the retry behavior here ought to be before, if any.
+
+[TODO] Identify what AUTHZ rules can be enforced on topics against which an endpoint can publish.
+
+* On reconnect, it is safe for multiple endpoints to potentially push results over, since
+  we expect result updates to be idempotent.
+
+
+
+TaskQueueSubscriber Call chain
+------------------------------
+
+connect() --- _on_connection_open() ---> open_channel() ---_on_open_channel() --> setup_exchange
+                                                                                       |
+queue_bind()<-- _on_queue_declare_ok() -- setup_queue() <--- _on_exchange_declare_ok --+
+    |
+    +-- _on_bind_ok() --> start_consuming()
+
+
+Disconnect behavior
+-------------------
+
+Who can configure:
+^^^^^^^^^^^^^^^^^^
+For both task_q and result_q, the expected disconnect behavior is to raise an error,
+and disengage so that the endpoint can determine the reconnect procedure. Usually
+the creator of the queue sets the HEARTBEAT and BLOCKED_CONNECTION_TIMEOUT, with the
+subscriber only following.
+* Service side is responsible for creating a direct queue named: `<ENDPOINT_ID>.queue`
+* Service side is responsible for creating a queue named `results` and binding it to
+  the routing_key: `*.results` where each endpoint should publish only with the
+  routing_key = `<ENDPOINT_ID>.results`.
+
+This allows the setting of the heartbeats and timeout_period *only* from the service
+side. This probably needs more testing, because ATM we don't have an easy way to
+trigger connection loss in the middle of testing.
+
+Disconnect error propagation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `ResultQueuePublisher` is synchronous, so a publish failure is immediately raised.
+
+The `TaskQueueSubscriber` is asynchronous, and most likely on a separate python process.
+To communicate a disconnect/failure, we need an event that allows the parent i.e the
+endpoint main loop to detect a fault.
+
+When either of the above components fail, we should go through the following steps:
+1. Persist results in the pipes to disk
+2. Disconnect from the service
+3. Executors continue -- think of this as a clutch disengaging -- the engine continues
+4. Attempt endpoint register and reconnect logic
+5. Propagate pending results
+
+Failover behavior
+^^^^^^^^^^^^^^^^^
+
+Failover is when the endpoint fails/disconnects and connects back to the service.
+Essentially, the service side, couldn't know if the newly connecting endpoint is
+a duplicate or a remote side reconnecting after a disconnect.
+
+* If a duplicate endpoint or a reconnecting ep publishes results we don't mind
+* If a duplicate endpoint connects and starts draining tasks, that's a problem.
+   * we use "exclusive" subscriber mode on the task_queue: `<ENDPOINT_ID>.tasks`
+     ensuring that only 1 endpoint can be fetching tasks. As a result an older
+     connection has to be disconnected before a new connection can be created.
+
+
+Performance Eval
+----------------
+
+Throughput on the tasks pipe:
+
+    .. code-block::
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 1B = 7517.50messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 2B = 8482.18messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 4B = 8630.61messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 8B = 8706.41messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 16B = 8095.67messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 32B = 8598.09messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 64B = 8591.80messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 128B = 8503.42messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 256B = 8543.69messages/s
+        WARNING  test_task_q:test_task_q.py:280 TTC throughput for 1000 messages at 512B = 8057.96messages/s
+
+Basic latency on tasks pipe:
+
+    .. code-block::
+        test_task_q:test_task_q.py:246 Message latencies in milliseconds, min:0.70, max:17.70, avg:2.48
+
+
+
+

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/__init__.py
@@ -1,0 +1,11 @@
+from .result_queue_publisher import ResultQueuePublisher
+from .result_queue_subscriber import ResultQueueSubscriber
+from .task_queue_publisher import TaskQueuePublisher
+from .task_queue_subscriber import TaskQueueSubscriber
+
+__all__ = (
+    "TaskQueueSubscriber",
+    "TaskQueuePublisher",
+    "ResultQueuePublisher",
+    "ResultQueueSubscriber",
+)

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -1,0 +1,108 @@
+import logging
+import time
+
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+class ResultQueuePublisher:
+    """ResultPublisher publishes results to a topic exchange, with the {endpoint_id}.results
+    as a routing key.
+    """
+
+    def __init__(
+        self,
+        endpoint_id: str,
+        pika_conn_params: pika.ConnectionParameters,
+        exchange="results",
+    ):
+        self.endpoint_id = endpoint_id
+        self.routing_key = f"{self.endpoint_id}.results"
+        self.params = pika_conn_params
+        self.params.heartbeat = 30
+        self.params.blocked_connection_timeout = 60
+        self.exchange = exchange
+        self.exchange_type = "topic"
+        self._is_connected = False
+        self._deliveries = None
+        self._channel = None
+        self._stopping = False
+
+    def connect(self) -> pika.BlockingConnection:
+        """Connect
+
+        :rtype: pika.BlockingConnection
+        """
+        logger.info(f"Connecting to {self.params}")
+        self._conn = pika.BlockingConnection(self.params)
+        self._channel = self._conn.channel()
+        self._channel.confirm_delivery()
+        self._channel.exchange_declare(
+            exchange=self.exchange, exchange_type=self.exchange_type
+        )
+        # TO-DO: This shouldn't be done on the endpoint side
+        self._channel.queue_declare(queue="results")
+        self._channel.queue_bind(
+            queue="results", exchange=self.exchange, routing_key="*.results"
+        )
+        self._is_connected = True
+
+        return self._conn
+
+    def publish_message_retryable(self, message: bytes, retry_count=0, max_retries=3):
+        """Publish message to RabbitMQ with the routing key to identify the message source
+        The channel specifies confirm_delivery and with `mandatory=True` this call
+        will *block* until a delivery confirmation is received.
+
+        """
+        try:
+            self._channel.basic_publish(
+                self.exchange, self.routing_key, message, mandatory=True
+            )
+        except pika.exceptions.UnroutableError:
+            logger.exception("Message could not be delivered.")
+            raise
+        except (
+            pika.exceptions.ConnectionClosedByBroker,
+            pika.exceptions.ConnectionClosed,
+            pika.exceptions.ConnectionBlockedTimeout,
+        ):
+            logger.exception("Disconnected from the broker, attempting reconnect")
+            if retry_count < max_retries:
+                time.sleep(3 ** retry_count)  # Hacky exponential back-off
+                try:
+                    self.connect()
+                except Exception:
+                    logger.warning(
+                        f"Failed to reconnect, attempt {retry_count}/{max_retries}"
+                    )
+                    return self.publish(message, retry_count=retry_count + 1)
+            else:
+                raise
+
+    def publish(self, message: bytes) -> None:
+        """Publish message to RabbitMQ with the routing key to identify the message source
+        The channel specifies confirm_delivery and with `mandatory=True` this call
+        will *block* until a delivery confirmation is received.
+
+        Raises: Exception from pika if the message could not be delivered
+
+        """
+        try:
+            self._channel.basic_publish(
+                self.exchange, self.routing_key, message, mandatory=True
+            )
+        except Exception:
+            logger.exception("Message could not be delivered")
+            raise
+
+    def close(self):
+        self._channel.close()
+        self._conn.close()
+        self._is_connected = False
+
+    def _queue_purge(self):
+        """This method is *ONLY* for testing. This should not work in production"""
+        self._channel.queue_declare(queue="results")
+        self._channel.queue_purge("results")

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -47,7 +47,7 @@ class ResultQueuePublisher:
             exchange=self.exchange_name, exchange_type=self.exchange_type
         )
 
-        self._channel.queue_declare(queue=self.queue_name, passive=True)
+        self._channel.queue_declare(queue=self.queue_name)
         self._channel.queue_bind(
             queue=self.queue_name,
             exchange=self.exchange_name,

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -79,8 +79,3 @@ class ResultQueuePublisher:
     def close(self):
         self._channel.close()
         self._connection.close()
-
-    def _queue_purge(self):
-        """This method is *ONLY* for testing. This should not work in production"""
-        self._channel.queue_declare(queue=self.QUEUE_NAME)
-        self._channel.queue_purge("results")

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -14,7 +14,7 @@ class ResultQueuePublisher:
     def __init__(
         self,
         endpoint_id: str,
-        pika_conn_params: pika.ConnectionParameters,
+        pika_conn_params: pika.connection.Parameters,
         exchange="results",
     ):
         self.endpoint_id = endpoint_id

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -25,6 +25,9 @@ class ResultQueuePublisher:
         """
         self.endpoint_id = endpoint_id
         self.params = pika_conn_params
+        if self.params._heartbeat is None:
+            self.params._heartbeat = 0
+
         self._channel = None
         self._connection = None
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -30,8 +30,9 @@ class ResultQueuePublisher:
         """
         self.endpoint_id = endpoint_id
         self.params = pika_conn_params
-        if self.params._heartbeat is None:
-            self.params._heartbeat = 0
+        if self.params.heartbeat is None:
+            # result_q is blocking, and shouldn't use heartbeats
+            self.params.heartbeat = 0
 
         self._channel = None
         self._connection = None

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -51,7 +51,7 @@ class ResultQueuePublisher:
             exchange=self.EXCHANGE_NAME, exchange_type=self.EXCHANGE_TYPE
         )
 
-        self._channel.queue_declare(queue=self.QUEUE_NAME)
+        self._channel.queue_declare(queue=self.QUEUE_NAME, passive=True)
         self._channel.queue_bind(
             queue=self.QUEUE_NAME,
             exchange=self.EXCHANGE_NAME,

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
@@ -50,10 +50,9 @@ class ResultQueueSubscriber(multiprocessing.Process):
 
         self.exchange = exchange
         self.exchange_type = exchange_type
-        self._is_connected = False
         self._connection = None
         self._channel = None
-        self._closed = False
+
         self._closing = False
         logger.debug("Init done")
 
@@ -235,7 +234,7 @@ class ResultQueueSubscriber(multiprocessing.Process):
         """
         self.add_on_cancel_callback()
         logger.debug("Waiting for basic_consume")
-        self._consumer_tag = self._channel.basic_consume(
+        self._channel.basic_consume(
             self.queue_name, on_message_callback=self.on_message, exclusive=True
         )
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
@@ -1,0 +1,316 @@
+import logging
+import multiprocessing
+from typing import Tuple
+
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+class ResultQueueSubscriber:
+    """The ResultQueueSubscriber is a direct rabbitMQ pipe subscriber that uses
+    the SelectConnection adaptor to enable performance consumption of messages
+    from the service
+
+    """
+
+    def __init__(
+        self,
+        pika_conn_params,
+        exchange="results",
+        exchange_type="topic",
+    ):
+
+        self.queue_name = "results"
+        self.routing_key = "*.results"
+        self.params = pika_conn_params
+        self.exchange = exchange
+        self.exchange_type = exchange_type
+        self._is_connected = False
+        logger.debug("Init done")
+
+    def connect(self):
+        logger.info("Connecting to %s", self.params)
+        return pika.SelectConnection(
+            pika.URLParameters("amqp://guest:guest@localhost:5672/%2F"),  # self.params,
+            on_open_callback=self._on_connection_open,
+            on_close_callback=self._on_connection_closed,
+            on_open_error_callback=self._on_open_failed,
+        )
+
+    def _on_connection_open(self, unused_connection):
+        logger.debug("Connection opened")
+        self.open_channel()
+
+    def _on_open_failed(self, *args):
+        logger.warning(f"Connection failed to open : {args}")
+
+    def _on_connection_closed(self, connection, exception):
+        """This method is invoked by pika when the connection to RabbitMQ is
+        closed unexpectedly. Since it is unexpected, we will reconnect to
+        RabbitMQ if it disconnects.
+
+        :param pika.connection.Connection connection: The closed connection obj
+        :param int reply_code: The server provided reply_code if given
+        :param str reply_text: The server provided reply_text if given
+
+        """
+        logger.warning("Closing... something broke")
+        self._channel = None
+        if self._closing:
+            self._connection.ioloop.stop()
+        else:
+            logger.warning("Connection closed, reopening in 5 seconds: (%s)", exception)
+            self._connection.add_timeout(5, self.reconnect)
+
+    def reconnect(self):
+        """Will be invoked by the IOLoop timer if the connection is
+        closed. See the on_connection_closed method.
+
+        """
+        # This is the old connection IOLoop instance, stop its ioloop
+        self._connection.ioloop.stop()
+
+        if not self._closing:
+
+            # Create a new connection
+            self._connection = self.connect()
+
+            # There is now a new connection, needs a new ioloop to run
+            self._connection.ioloop.start()
+
+    def open_channel(self):
+        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
+        command. When RabbitMQ responds that the channel is open, the
+        on_channel_open callback will be invoked by pika.
+
+        """
+        logger.debug("Creating a new channel")
+        self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, channel):
+        """This method is invoked by pika when the channel has been opened.
+        The channel object is passed in so we can make use of it.
+
+        Since the channel is now open, we'll declare the exchange to use.
+
+        :param pika.channel.Channel channel: The channel object
+
+        """
+        logger.debug(f"Channel opened: {channel}")
+        self._channel = channel
+        self.add_on_channel_close_callback()
+        self.setup_exchange(self.exchange)
+
+    def add_on_channel_close_callback(self):
+        """This method tells pika to call the on_channel_closed method if
+        RabbitMQ unexpectedly closes the channel.
+
+        """
+        logger.info("Adding channel close callback")
+        self._channel.add_on_close_callback(self._on_channel_closed)
+
+    def _on_channel_closed(self, channel, exception):
+        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
+        Channels are usually closed if you attempt to do something that
+        violates the protocol, such as re-declare an exchange or queue with
+        different parameters. In this case, we'll close the connection
+        to shutdown the object.
+
+        :param pika.channel.Channel: The closed channel
+        :param int reply_code: The numeric reason the channel was closed
+        :param str reply_text: The text reason the channel was closed
+
+        """
+        logger.warning(
+            f"Channel:{channel} was closed: {exception.reply_code}:"
+            " {exception.reply_text}"
+        )
+        self._connection.close()
+
+    def setup_exchange(self, exchange_name):
+        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
+        command. When it is complete, the on_exchange_declareok method will
+        be invoked by pika.
+
+        :param str|unicode exchange_name: The name of the exchange to declare
+
+        """
+        logger.info(f"Declaring exchange {exchange_name}")
+        self._channel.exchange_declare(
+            exchange=exchange_name,
+            exchange_type=self.exchange_type,
+            callback=self._on_exchange_declareok,
+        )
+
+    def _on_exchange_declareok(self, unused_frame):
+        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
+        command.
+
+        :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
+
+        """
+        logger.info("Exchange declared")
+        self.setup_queue(self.queue_name)
+
+    def setup_queue(self, queue_name):
+        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
+        command. When it is complete, the on_queue_declareok method will
+        be invoked by pika.
+
+        :param str|unicode queue_name: The name of the queue to declare.
+
+        """
+        logger.info("Declaring queue %s", queue_name)
+        self._channel.queue_declare(queue_name, callback=self._on_queue_declareok)
+
+    def _on_queue_declareok(self, method_frame):
+        """Method invoked by pika when the Queue.Declare RPC call made in
+        setup_queue has completed. In this method we will bind the queue
+        and exchange together with the routing key by issuing the Queue.Bind
+        RPC command. When this command is complete, the on_bindok method will
+        be invoked by pika.
+
+        :param pika.frame.Method method_frame: The Queue.DeclareOk frame
+
+        """
+        logger.info(f"Binding exchange:{self.exchange} to {self.queue_name}")
+
+        # No routing key since we are doing a direct exchange
+        self._channel.queue_bind(
+            queue=self.queue_name,
+            exchange=self.exchange,
+            routing_key=self.routing_key,
+            callback=self._on_bindok,
+        )
+
+    def _on_bindok(self, unused_frame):
+        """Invoked by pika when the Queue.Bind method has completed. At this
+        point we will start consuming messages by calling start_consuming
+        which will invoke the needed RPC commands to start the process.
+
+        :param pika.frame.Method unused_frame: The Queue.BindOk response frame
+
+        """
+        logger.info("Queue bound")
+        self.start_consuming()
+
+    def start_consuming(self):
+        """This method sets up the consumer by first calling
+        add_on_cancel_callback so that the object is notified if RabbitMQ
+        cancels the consumer. It then issues the Basic.Consume RPC command
+        which returns the consumer tag that is used to uniquely identify the
+        consumer with RabbitMQ. We keep the value to use it when we want to
+        cancel consuming. The on_message method is passed in as a callback pika
+        will invoke when a message is fully received.
+
+        """
+        self.add_on_cancel_callback()
+        logger.debug("Waiting for basic_consume")
+        self._consumer_tag = self._channel.basic_consume(
+            self.queue_name, on_message_callback=self.on_message, exclusive=True
+        )
+
+    def add_on_cancel_callback(self):
+        """Add a callback that will be invoked if RabbitMQ cancels the consumer
+        for some reason. If RabbitMQ does cancel the consumer,
+        on_consumer_cancelled will be invoked by pika.
+
+        """
+        logger.info("Adding consumer cancellation callback")
+        self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
+
+    def on_consumer_cancelled(self, method_frame):
+        """Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer
+        receiving messages.
+
+        :param pika.frame.Method method_frame: The Basic.Cancel frame
+
+        """
+        logger.info("Consumer was cancelled remotely, shutting down: %r", method_frame)
+        if self._channel:
+            self._channel.close()
+
+    def on_message(self, _unused_channel, basic_deliver, _properties, body):
+        """on_message pushes a message upon receipt into the external_queue
+        for async consumption. The message pushed to the external_queue
+        is of the following type : Tuple[str, bytes]
+
+        :param pika.channel.Channel unused_channel: The channel object
+        :param pika.Spec.Basic.Deliver: basic_deliver method
+        :param pika.Spec.BasicProperties: properties
+        :param str|unicode body: The message body
+
+        """
+
+        routing_key = basic_deliver.routing_key
+
+        if self.external_queue:
+            try:
+                response: Tuple[str, bytes] = (routing_key.split(".")[0], body)
+                self.external_queue.put(response)
+            except Exception:
+                logger.exception("Failed to forward message to external_queue")
+                self._channel.basic_nack(basic_deliver.delivery_tag, requeue=True)
+            else:
+                self._channel.basic_ack(delivery_tag=basic_deliver.delivery_tag)
+
+    def stop_consuming(self):
+        """Tell RabbitMQ that you would like to stop consuming by sending the
+        Basic.Cancel RPC command.
+
+        """
+        if self._channel:
+            logger.info("Sending a Basic.Cancel RPC command to RabbitMQ")
+            self._channel.basic_cancel(self.on_cancelok, self._consumer_tag)
+
+    def on_cancelok(self, unused_frame):
+        """This method is invoked by pika when RabbitMQ acknowledges the
+        cancellation of a consumer. At this point we will close the channel.
+        This will invoke the on_channel_closed method once the channel has been
+        closed, which will in-turn close the connection.
+
+        :param pika.frame.Method unused_frame: The Basic.CancelOk frame
+
+        """
+        logger.info("RabbitMQ acknowledged the cancellation of the consumer")
+        self.close_channel()
+
+    def close_channel(self):
+        """Call to close the channel with RabbitMQ cleanly by issuing the
+        Channel.Close RPC command.
+
+        """
+        logger.info("Closing the channel")
+        self._channel.close()
+
+    def run(self, queue: multiprocessing.Queue):
+        """Run the example consumer by connecting to RabbitMQ and then
+        starting the IOLoop to block and allow the SelectConnection to operate.
+
+        """
+        self.external_queue = queue
+        self._connection = self.connect()
+        self._connection.ioloop.start()
+
+    def stop(self):
+        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
+        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
+        will be invoked by pika, which will then closing the channel and
+        connection. The IOLoop is started again because this method is invoked
+        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
+        exception stops the IOLoop which needs to be running for pika to
+        communicate with RabbitMQ. All of the commands issued prior to starting
+        the IOLoop will be buffered but not processed.
+
+        """
+        logger.info("Stopping")
+        self._closing = True
+        self.stop_consuming()
+        self._connection.ioloop.start()
+        logger.info("Stopped")
+
+    def close_connection(self):
+        """This method closes the connection to RabbitMQ."""
+        logger.info("Closing connection")
+        self._connection.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_subscriber.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import logging
 import multiprocessing
 import queue
-from typing import Tuple
 
 import pika
 
@@ -212,13 +213,15 @@ class ResultQueueSubscriber(multiprocessing.Process):
         :param pika.Spec.BasicProperties: properties
         :param str|unicode body: The message body
 
+        Pops items into the external_queue of the form:
+        tuple(str: Endpoint_UUID, bytes: message)
         """
 
         routing_key = basic_deliver.routing_key
 
         if self.external_queue:
             try:
-                response: Tuple[str, bytes] = (routing_key.rsplit(".", 1)[0], body)
+                response: tuple[str, bytes] = (routing_key.rsplit(".", 1)[0], body)
                 self.external_queue.put(response)
             except queue.Full:
                 logger.exception("Failed to forward message to external_queue")
@@ -264,8 +267,3 @@ class ResultQueueSubscriber(multiprocessing.Process):
         self.join()
         super().close()
         logger.info("Connection closed")
-
-    def close_connection(self):
-        """This method closes the connection to RabbitMQ."""
-        logger.info("Closing connection")
-        self._connection.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -33,13 +33,13 @@ class TaskQueuePublisher:
         self.exchange = "tasks"
         self.exchange_type = "direct"
 
-        self._conn = None
+        self._connection = None
         self._channel = None
 
     def connect(self):
         logger.debug("Connecting as server")
-        self._conn = pika.BlockingConnection(self.params)
-        self._channel = self._conn.channel()
+        self._connection = pika.BlockingConnection(self.params)
+        self._channel = self._connection.channel()
         self._channel.exchange_declare(
             exchange=self.exchange, exchange_type=self.exchange_type
         )
@@ -68,4 +68,4 @@ class TaskQueuePublisher:
 
     def close(self):
         """Close the connection and channels"""
-        self._conn.close()
+        self._connection.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -16,7 +16,6 @@ class TaskQueuePublisher:
         self,
         endpoint_uuid: str,
         pika_conn_params: pika.connection.Parameters,
-        exchange: str = "tasks",
     ):
         """
         Parameters
@@ -25,15 +24,13 @@ class TaskQueuePublisher:
              Endpoint UUID string used to identify the endpoint
         pika_conn_params: pika.connection.Parameters
              Pika connection parameters to connect to RabbitMQ
-        exchange: str
-             Exchange name. Default: "tasks"
         """
         self.endpoint_uuid = endpoint_uuid
         self.queue_name = f"{self.endpoint_uuid}.tasks"
         self.routing_key = f"{self.endpoint_uuid}.tasks"
         self.params = pika_conn_params
 
-        self.exchange = exchange
+        self.exchange = "tasks"
         self.exchange_type = "direct"
 
         self._conn = None
@@ -70,6 +67,5 @@ class TaskQueuePublisher:
         self._channel.queue_purge(self.queue_name)
 
     def close(self):
-        """Close channel"""
-        self._channel.close()
+        """Close the connection and channels"""
         self._conn.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -1,0 +1,70 @@
+import logging
+
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+class TaskQueuePublisher:
+    """The TaskQueue is a direct rabbitMQ pipe that runs from the service
+    to the endpoint.
+    Multiple subscribers are disabled, with endpoints using exclusive consume
+    Publish side will set heartbeats
+    """
+
+    def __init__(
+        self,
+        endpoint_name: str,
+        pika_conn_params: pika.ConnectionParameters,
+        exchange="tasks",
+    ):
+        self.endpoint_name = endpoint_name
+        self.queue_name = f"{self.endpoint_name}.tasks"
+        self.routing_key = f"{self.endpoint_name}.tasks"
+        self.params = pika_conn_params
+        self.params._heartbeat = 60
+        self.params._blocked_connection_timeout = 120
+
+        self.exchange = exchange
+        self.exchange_type = "direct"
+        self._is_connected = False
+
+    def connect(self):
+        logger.debug("Connecting as server")
+        self._conn = pika.BlockingConnection(self.params)
+        self._channel = self._conn.channel()
+        self._channel.exchange_declare(
+            exchange=self.exchange, exchange_type=self.exchange_type
+        )
+        self._channel.queue_declare(queue=self.queue_name)
+        self._channel.queue_bind(self.queue_name, self.exchange)
+        self._is_connected = True
+
+    def publish(self, payload: bytes):
+        """Publish a message to the endpoint from the service
+
+        Parameters
+        ----------
+        payload: Payload string to be published
+
+        Returns
+        -------
+
+        """
+        assert self._is_connected, "Cannot publish, not connected"
+        return self._channel.basic_publish(
+            self.exchange,
+            routing_key=self.routing_key,
+            body=payload,
+            mandatory=True,  # Raise error if message cannot be routed
+        )
+
+    def queue_purge(self):
+        """Purge all messages in the queue. Either service/endpoint can
+        call this method"""
+        assert self._is_connected, "Not connected, cannot purge"
+        self._channel.queue_purge(self.queue_name)
+
+    def close(self):
+        self._channel.close()
+        self._conn.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -61,11 +61,6 @@ class TaskQueuePublisher:
             mandatory=True,  # Raise error if message cannot be routed
         )
 
-    def queue_purge(self):
-        """Purge all messages in the queue. Either service/endpoint can
-        call this method"""
-        self._channel.queue_purge(self.queue_name)
-
     def close(self):
         """Close the connection and channels"""
         self._connection.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -32,8 +32,6 @@ class TaskQueuePublisher:
         self.queue_name = f"{self.endpoint_uuid}.tasks"
         self.routing_key = f"{self.endpoint_uuid}.tasks"
         self.params = pika_conn_params
-        self.params._heartbeat = 60
-        self.params._blocked_connection_timeout = 120
 
         self.exchange = exchange
         self.exchange_type = "direct"

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -14,13 +14,13 @@ class TaskQueuePublisher:
 
     def __init__(
         self,
-        endpoint_name: str,
-        pika_conn_params: pika.ConnectionParameters,
-        exchange="tasks",
+        endpoint_uuid: str,
+        pika_conn_params: pika.connection.Parameters,
+        exchange: str = "tasks",
     ):
-        self.endpoint_name = endpoint_name
-        self.queue_name = f"{self.endpoint_name}.tasks"
-        self.routing_key = f"{self.endpoint_name}.tasks"
+        self.endpoint_uuid = endpoint_uuid
+        self.queue_name = f"{self.endpoint_uuid}.tasks"
+        self.routing_key = f"{self.endpoint_uuid}.tasks"
         self.params = pika_conn_params
         self.params._heartbeat = 60
         self.params._blocked_connection_timeout = 120

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -24,7 +24,6 @@ class TaskQueueSubscriber(multiprocessing.Process):
         kill_event: multiprocessing.Event,
         endpoint_uuid: str,
         _on_message_test_hook: Callable = None,
-        exchange: str = "tasks",
     ):
         """
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -1,0 +1,359 @@
+import logging
+import multiprocessing
+from typing import Callable
+
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+class TaskQueueSubscriber:
+    """The TaskQueueSubscriber is a direct rabbitMQ pipe subscriber that uses
+    the SelectConnection adaptor to enable performance consumption of messages
+    from the service
+
+    """
+
+    def __init__(
+        self,
+        pika_conn_params,
+        endpoint_name: str,
+        exchange="tasks",
+    ):
+
+        self.endpoint_name = endpoint_name
+        self.queue_name = f"{self.endpoint_name}.tasks"
+        self.routing_key = f"{self.endpoint_name}.tasks"
+        self.params = pika_conn_params
+        self.exchange = exchange
+        self.exchange_type = "direct"
+        self._is_connected = False
+        self._closing = False
+        logger.debug("Init done")
+
+    def connect(self):
+        logger.info("Connecting to %s", self.params)
+        return pika.SelectConnection(
+            pika.URLParameters("amqp://guest:guest@localhost:5672/%2F"),  # self.params,
+            on_open_callback=self._on_connection_open,
+            on_close_callback=self._on_connection_closed,
+            on_open_error_callback=self._on_open_failed,
+        )
+
+    def _on_connection_open(self, unused_connection):
+        logger.warning("Connection opened")
+        self.open_channel()
+
+    def _on_open_failed(self, *args):
+        logger.warning(f"Connection failed to open : {args}")
+
+    def _on_connection_closed(self, connection, exception):
+        """This method is invoked by pika when the connection to RabbitMQ is
+        closed unexpectedly. Since it is unexpected, we will reconnect to
+        RabbitMQ if it disconnects.
+
+        :param pika.connection.Connection connection: The closed connection obj
+        :param exception: Exception object
+        """
+        logger.warning(f"Connection closing: {exception}")
+        self._channel = None
+        if self._closing:
+            connection.ioloop.stop()
+        else:
+            logger.warning(f"Connection closed, reopening in 5 seconds: {exception}")
+            self._connection.ioloop.call_later(5, self.reconnect)
+            # self._connection.add_timeout(5, self.reconnect)
+
+    def reconnect(self):
+        """Will be invoked by the IOLoop timer if the connection is
+        closed. See the on_connection_closed method.
+
+        """
+        # This is the old connection IOLoop instance, stop its ioloop
+        self._connection.ioloop.stop()
+
+        if not self._closing:
+
+            # Create a new connection
+            self._connection = self.connect()
+
+            # There is now a new connection, needs a new ioloop to run
+            self._connection.ioloop.start()
+
+    def open_channel(self):
+        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
+        command. When RabbitMQ responds that the channel is open, the
+        on_channel_open callback will be invoked by pika.
+
+        """
+        logger.info("Creating a new channel")
+        self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, channel):
+        """This method is invoked by pika when the channel has been opened.
+        The channel object is passed in so we can make use of it.
+
+        Since the channel is now open, we'll declare the exchange to use.
+
+        :param pika.channel.Channel channel: The channel object
+
+        """
+        logger.info(f"Channel opened: {channel}")
+        self._channel = channel
+        self.add_on_channel_close_callback()
+        self.setup_exchange(self.exchange)
+
+    def add_on_channel_close_callback(self):
+        """This method tells pika to call the on_channel_closed method if
+        RabbitMQ unexpectedly closes the channel.
+
+        """
+        logger.info("Adding channel close callback")
+        self._channel.add_on_close_callback(self._on_channel_closed)
+
+    def _on_channel_closed(self, channel, exception):
+        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
+        Channels are usually closed if you attempt to do something that
+        violates the protocol, such as re-declare an exchange or queue with
+        different parameters. In this case, we'll close the connection
+        to shutdown the object.
+
+        :param pika.channel.Channel: The closed channel
+        :param Exception: exception from pika
+        """
+        logger.warning(f"Channel:{channel} was closed: ({exception}")
+        try:
+            logger.warning("Raising exception:")
+            raise exception
+        except pika.exceptions.ChannelClosedByBroker:
+            if "exclusive use" in exception.reply_text:
+                logger.exception(
+                    "Channel closed by RabbitMQ broker due to exclusive "
+                    "ownership by an active endpoint"
+                )
+                logger.warning("Channel will close without connection retry")
+                self._closing = True
+        except Exception as e:
+            logger.exception(
+                f"Channel closed with code:{e.reply_code}, error:{e.reply_text}"
+            )
+
+        self._connection.close()
+
+    def setup_exchange(self, exchange_name):
+        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
+        command. When it is complete, the on_exchange_declareok method will
+        be invoked by pika.
+
+        :param str|unicode exchange_name: The name of the exchange to declare
+        """
+        logger.info(f"Declaring exchange {exchange_name}")
+        self._channel.exchange_declare(
+            exchange=exchange_name,
+            exchange_type=self.exchange_type,
+            callback=self._on_exchange_declareok,
+        )
+
+    def _on_exchange_declareok(self, unused_frame):
+        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
+        command.
+
+        :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
+
+        """
+        logger.info("Exchange declared")
+        self.setup_queue(self.queue_name)
+
+    def setup_queue(self, queue_name):
+        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
+        command. When it is complete, the on_queue_declareok method will
+        be invoked by pika.
+
+        :param str|unicode queue_name: The name of the queue to declare.
+
+        """
+        logger.info("Declaring queue %s", queue_name)
+        self._channel.queue_declare(queue_name, callback=self._on_queue_declareok)
+
+    def _on_queue_declareok(self, method_frame):
+        """Method invoked by pika when the Queue.Declare RPC call made in
+        setup_queue has completed. In this method we will bind the queue
+        and exchange together with the routing key by issuing the Queue.Bind
+        RPC command. When this command is complete, the on_bindok method will
+        be invoked by pika.
+
+        :param pika.frame.Method method_frame: The Queue.DeclareOk frame
+
+        """
+        logger.info(f"Binding exchange:{self.exchange} to {self.queue_name}")
+
+        # No routing key since we are doing a direct exchange
+        self._channel.queue_bind(
+            self.queue_name, self.exchange, callback=self._on_bindok
+        )
+
+    def _on_bindok(self, unused_frame):
+        """Invoked by pika when the Queue.Bind method has completed. At this
+        point we will start consuming messages by calling start_consuming
+        which will invoke the needed RPC commands to start the process.
+
+        :param pika.frame.Method unused_frame: The Queue.BindOk response frame
+
+        """
+        logger.info("Queue bound")
+        self.start_consuming()
+
+    def start_consuming(self):
+        """This method sets up the consumer by first calling
+        add_on_cancel_callback so that the object is notified if RabbitMQ
+        cancels the consumer. It then issues the Basic.Consume RPC command
+        which returns the consumer tag that is used to uniquely identify the
+        consumer with RabbitMQ. We keep the value to use it when we want to
+        cancel consuming. The on_message method is passed in as a callback pika
+        will invoke when a message is fully received.
+
+        """
+        logger.info("Issuing consumer related RPC commands")
+        self.add_on_cancel_callback()
+        self._consumer_tag = self._channel.basic_consume(
+            self.queue_name, on_message_callback=self.on_message, exclusive=True
+        )
+
+    def add_on_cancel_callback(self):
+        """Add a callback that will be invoked if RabbitMQ cancels the consumer
+        for some reason. If RabbitMQ does cancel the consumer,
+        on_consumer_cancelled will be invoked by pika.
+
+        """
+        logger.info("Adding consumer cancellation callback")
+        self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
+
+    def on_consumer_cancelled(self, method_frame):
+        """Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer
+        receiving messages.
+
+        :param pika.frame.Method method_frame: The Basic.Cancel frame
+
+        """
+        logger.info("Consumer was cancelled remotely, shutting down: %r", method_frame)
+        if self._channel:
+            self._channel.close()
+
+    def on_message(self, unused_channel, basic_deliver, properties, body):
+        """Invoked by pika when a message is delivered from RabbitMQ. The
+        channel is passed for your convenience. The basic_deliver object that
+        is passed in carries the exchange, routing key, delivery tag and
+        a redelivered flag for the message. The properties passed in is an
+        instance of BasicProperties with the message properties and the body
+        is the message that was sent.
+
+        :param pika.channel.Channel unused_channel: The channel object
+        :param pika.Spec.Basic.Deliver: basic_deliver method
+        :param pika.Spec.BasicProperties: properties
+        :param str|unicode body: The message body
+
+        """
+        logger.info(
+            f"Received message # {basic_deliver.delivery_tag} "
+            "from {properties.app_id} {body}"
+        )
+        if self.external_queue:
+            self.external_queue.put(body)
+            self.acknowledge_message(basic_deliver.delivery_tag)
+        elif self.external_callback:
+            try:
+                self.external_callback(body)
+            except Exception:
+                # We only ack the message
+                logger.exception("External callback failed")
+                self._channel.basic_nack(basic_deliver.delivery_tag, requeue=True)
+            else:
+                self.acknowledge_message(basic_deliver.delivery_tag)
+
+    def acknowledge_message(self, delivery_tag):
+        """Acknowledge the message delivery from RabbitMQ by sending a
+        Basic.Ack RPC method for the delivery tag.
+
+        :param int delivery_tag: The delivery tag from the Basic.Deliver frame
+
+        """
+        logger.info(f"Acknowledging message {delivery_tag}")
+        self._channel.basic_ack(delivery_tag)
+
+    def stop_consuming(self):
+        """Tell RabbitMQ that you would like to stop consuming by sending the
+        Basic.Cancel RPC command.
+
+        """
+        if self._channel:
+            logger.info("Sending a Basic.Cancel RPC command to RabbitMQ")
+            self._channel.basic_cancel(self.on_cancelok, self._consumer_tag)
+
+    def on_cancelok(self, unused_frame):
+        """This method is invoked by pika when RabbitMQ acknowledges the
+        cancellation of a consumer. At this point we will close the channel.
+        This will invoke the on_channel_closed method once the channel has been
+        closed, which will in-turn close the connection.
+
+        :param pika.frame.Method unused_frame: The Basic.CancelOk frame
+
+        """
+        logger.info("RabbitMQ acknowledged the cancellation of the consumer")
+        self.close_channel()
+
+    def close_channel(self):
+        """Call to close the channel with RabbitMQ cleanly by issuing the
+        Channel.Close RPC command.
+
+        """
+        logger.info("Closing the channel")
+        self._channel.close()
+
+    def run(
+        self,
+        queue: multiprocessing.Queue,
+        disconnect_event: multiprocessing.Event,
+        test_hook: Callable = None,
+    ):
+        """Run the example consumer by connecting to RabbitMQ and then
+        starting the IOLoop to block and allow the SelectConnection to
+        operate.
+
+        Note: Only one of these options should be used.
+        queue: multiprocessing.Queue
+             if this option is provided, each incoming message will be
+             pushed to the queue
+        disconnect_event: multiprocessing.Event
+             This event is used to communicate a failure on the subscriber
+        test_hook: Callable
+             This is a test_hook used only for testing. This is invoked on
+             every message
+        """
+        logger.warning("Run method")
+        self.external_queue = queue
+        self.disconnect_event = disconnect_event
+        self.test_hook = test_hook
+        self._connection = self.connect()
+        self._connection.ioloop.start()
+
+    def stop(self):
+        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
+        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
+        will be invoked by pika, which will then closing the channel and
+        connection. The IOLoop is started again because this method is invoked
+        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
+        exception stops the IOLoop which needs to be running for pika to
+        communicate with RabbitMQ. All of the commands issued prior to starting
+        the IOLoop will be buffered but not processed.
+
+        """
+        logger.info("Stopping")
+        self._closing = True
+        self.stop_consuming()
+        self._connection.ioloop.start()
+        logger.info("Stopped")
+
+    def close_connection(self):
+        """This method closes the connection to RabbitMQ."""
+        logger.info("Closing connection")
+        self._connection.close()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -384,20 +384,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
             logger.exception("Failed to start subscriber")
 
     def close(self) -> None:
-        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
-        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
-        will be invoked by pika, which will then closing the channel and
-        connection. The IOLoop is started again because this method is invoked
-        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
-        exception stops the IOLoop which needs to be running for pika to
-        communicate with RabbitMQ. All of the commands issued prior to starting
-        the IOLoop will be buffered but not processed.
-
-        ^  This doc block is mostly all wrong, since the code has been rewritten
-        but some cases described here need to be tested more closely like handling
-        KeyboardInterrupts
-
-        This close method needs some rethinking since this whole thing is a separate
+        """This close method needs some rethinking since this whole thing is a separate
         process with the ioloop callbacks not setting the vars properly
         """
         logger.info("Stopping")

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -130,7 +130,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         """This method is invoked by pika when the channel has been opened.
         The channel object is passed in so we can make use of it.
 
-        Since the channel is now open, we'll declare the exchange to use.
+        Since the channel is now open, we'll declare the exchange_name to use.
 
         :param pika.channel.Channel channel: The channel object
 
@@ -151,7 +151,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def _on_channel_closed(self, channel, exception):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange or queue with
+        violates the protocol, such as re-declare an exchange_name or queue with
         different parameters. In this case, we'll close the connection
         to shutdown the object.
 
@@ -178,13 +178,13 @@ class TaskQueueSubscriber(multiprocessing.Process):
         self._connection.close()
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
+        """Setup the exchange_name on RabbitMQ by invoking the Exchange.Declare RPC
         command. When it is complete, the on_exchange_declareok method will
         be invoked by pika.
 
-        :param str|unicode exchange_name: The name of the exchange to declare
+        :param str|unicode exchange_name: The name of the exchange_name to declare
         """
-        logger.info(f"Declaring exchange {exchange_name}")
+        logger.info(f"Declaring exchange_name {exchange_name}")
         self._channel.exchange_declare(
             exchange=exchange_name,
             exchange_type=self.exchange_type,
@@ -215,16 +215,16 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def _on_queue_declareok(self, method_frame):
         """Method invoked by pika when the Queue.Declare RPC call made in
         setup_queue has completed. In this method we will bind the queue
-        and exchange together with the routing key by issuing the Queue.Bind
+        and exchange_name together with the routing key by issuing the Queue.Bind
         RPC command. When this command is complete, the on_bindok method will
         be invoked by pika.
 
         :param pika.frame.Method method_frame: The Queue.DeclareOk frame
 
         """
-        logger.info(f"Binding exchange:{self.exchange} to {self.queue_name}")
+        logger.info(f"Binding exchange_name:{self.exchange} to {self.queue_name}")
 
-        # No routing key since we are doing a direct exchange
+        # No routing key since we are doing a direct exchange_name
         self._channel.queue_bind(
             self.queue_name, self.exchange, callback=self._on_bindok
         )
@@ -279,7 +279,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def on_message(self, unused_channel, basic_deliver, properties, body):
         """Invoked by pika when a message is delivered from RabbitMQ. The
         channel is passed for your convenience. The basic_deliver object that
-        is passed in carries the exchange, routing key, delivery tag and
+        is passed in carries the exchange_name, routing key, delivery tag and
         a redelivered flag for the message. The properties passed in is an
         instance of BasicProperties with the message properties and the body
         is the message that was sent.

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -78,7 +78,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         )
 
     def _on_connection_open(self, _unused_connection):
-        logger.warning("Connection opened")
+        logger.info("Connection opened")
         self.open_channel()
 
     def _on_open_failed(self, *args):
@@ -130,7 +130,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         """This method is invoked by pika when the channel has been opened.
         The channel object is passed in so we can make use of it.
 
-        Since the channel is now open, we'll declare the exchange_name to use.
+        Since the channel is now open, we'll declare the EXCHANGE_NAME to use.
 
         :param pika.channel.Channel channel: The channel object
 
@@ -151,7 +151,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def _on_channel_closed(self, channel, exception):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange_name or queue with
+        violates the protocol, such as re-declare an EXCHANGE_NAME or queue with
         different parameters. In this case, we'll close the connection
         to shutdown the object.
 
@@ -178,13 +178,13 @@ class TaskQueueSubscriber(multiprocessing.Process):
         self._connection.close()
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange_name on RabbitMQ by invoking the Exchange.Declare RPC
+        """Setup the EXCHANGE_NAME on RabbitMQ by invoking the Exchange.Declare RPC
         command. When it is complete, the on_exchange_declareok method will
         be invoked by pika.
 
-        :param str|unicode exchange_name: The name of the exchange_name to declare
+        :param str|unicode exchange_name: The name of the EXCHANGE_NAME to declare
         """
-        logger.info(f"Declaring exchange_name {exchange_name}")
+        logger.info(f"Declaring EXCHANGE_NAME {exchange_name}")
         self._channel.exchange_declare(
             exchange=exchange_name,
             exchange_type=self.exchange_type,
@@ -215,16 +215,16 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def _on_queue_declareok(self, method_frame):
         """Method invoked by pika when the Queue.Declare RPC call made in
         setup_queue has completed. In this method we will bind the queue
-        and exchange_name together with the routing key by issuing the Queue.Bind
+        and EXCHANGE_NAME together with the routing key by issuing the Queue.Bind
         RPC command. When this command is complete, the on_bindok method will
         be invoked by pika.
 
         :param pika.frame.Method method_frame: The Queue.DeclareOk frame
 
         """
-        logger.info(f"Binding exchange_name:{self.exchange} to {self.queue_name}")
+        logger.info(f"Binding EXCHANGE_NAME:{self.exchange} to {self.queue_name}")
 
-        # No routing key since we are doing a direct exchange_name
+        # No routing key since we are doing a direct EXCHANGE_NAME
         self._channel.queue_bind(
             self.queue_name, self.exchange, callback=self._on_bindok
         )
@@ -279,7 +279,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
     def on_message(self, unused_channel, basic_deliver, properties, body):
         """Invoked by pika when a message is delivered from RabbitMQ. The
         channel is passed for your convenience. The basic_deliver object that
-        is passed in carries the exchange_name, routing key, delivery tag and
+        is passed in carries the EXCHANGE_NAME, routing key, delivery tag and
         a redelivered flag for the message. The properties passed in is an
         instance of BasicProperties with the message properties and the body
         is the message that was sent.
@@ -393,7 +393,6 @@ class TaskQueueSubscriber(multiprocessing.Process):
         logger.warning("Waiting for cleanup_complete")
         self.cleanup_complete.wait(2 * self._watcher_poll_period)
         logger.warning("Cleanup done")
-        logger.info("Stopped")
 
     def close_connection(self):
         """This method closes the connection to RabbitMQ."""

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -1,10 +1,22 @@
+import enum
 import logging
 import multiprocessing
-from typing import Callable
 
 import pika
 
 logger = logging.getLogger(__name__)
+
+
+# a status enum to describe the different states of the TaskQueueSubscriber
+class SubscriberProcessStatus(enum.Enum):
+    # the object is in the parent process, it has no notion of the process state other
+    # than that it is none of the other values
+    parent = enum.auto()
+    # the process is in the child proc and should try to start or continue to run
+    running = enum.auto()
+    # the process is in the child proc and is closing down, it should not try to
+    # reconnect or otherwise handle failures
+    closing = enum.auto()
 
 
 class TaskQueueSubscriber(multiprocessing.Process):
@@ -23,7 +35,6 @@ class TaskQueueSubscriber(multiprocessing.Process):
         external_queue: multiprocessing.Queue,
         kill_event: multiprocessing.Event,
         endpoint_uuid: str,
-        _on_message_test_hook: Callable = None,
     ):
         """
 
@@ -39,25 +50,22 @@ class TaskQueueSubscriber(multiprocessing.Process):
         kill_event: multiprocessing.Event
              This event is used to communicate a failure on the subscriber
 
-        _on_message_test_hook: Callable
-            This is a test_hook used only for testing. This is invoked on
-            every message
-
         endpoint_uuid: endpoint uuid string
         """
 
         super().__init__()
+        self.status = SubscriberProcessStatus.parent
+
         self.endpoint_uuid = endpoint_uuid
         self.conn_params = pika_conn_params
         self.external_queue = external_queue
         self.kill_event: multiprocessing.Event = kill_event
-        self.cleanup_complete = multiprocessing.Event()
-        self.external_callback = _on_message_test_hook
+        self._channel_closed = multiprocessing.Event()
+        self._cleanup_complete = multiprocessing.Event()
 
         self.queue_name = f"{self.endpoint_uuid}.tasks"
         self.routing_key = f"{self.endpoint_uuid}.tasks"
         self.params = pika_conn_params
-        self._closing = False
 
         self._connection = None
         self._channel = None
@@ -91,7 +99,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         """
         logger.warning(f"Connection closing: {exception}")
         self._channel = None
-        if self._closing:
+        if self.status is SubscriberProcessStatus.closing:
             connection.ioloop.stop()
         else:
             logger.warning(f"Connection closed, reopening in 5 seconds: {exception}")
@@ -105,7 +113,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         # This is the old connection IOLoop instance, stop its ioloop
         self._connection.ioloop.stop()
 
-        if not self._closing:
+        if self.status is SubscriberProcessStatus.running:
 
             # Create a new connection
             self._connection = self._connect()
@@ -133,16 +141,9 @@ class TaskQueueSubscriber(multiprocessing.Process):
         """
         logger.info(f"Channel opened: {channel}")
         self._channel = channel
-        self.add_on_channel_close_callback()
-        self.setup_exchange(self.EXCHANGE_NAME)
-
-    def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
-        RabbitMQ unexpectedly closes the channel.
-
-        """
         logger.info("Adding channel close callback")
         self._channel.add_on_close_callback(self._on_channel_closed)
+        self.setup_exchange(self.EXCHANGE_NAME)
 
     def _on_channel_closed(self, channel, exception):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
@@ -150,6 +151,9 @@ class TaskQueueSubscriber(multiprocessing.Process):
         violates the protocol, such as re-declare an EXCHANGE_NAME or queue with
         different parameters. In this case, we'll close the connection
         to shutdown the object.
+
+        This is also invoked at the end of a successful client-initiated close, as when
+        `connection.close()` is called and closes any open channels.
 
         :param pika.channel.Channel: The closed channel
         :param Exception: exception from pika
@@ -162,7 +166,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
                     "ownership by an active endpoint"
                 )
                 logger.warning("Channel will close without connection retry")
-                self._closing = True
+                self.status = SubscriberProcessStatus.closing
                 self.kill_event.set()
         elif isinstance(exception, pika.exceptions.ChannelClosedByClient):
             logger.debug("Detected channel closed by client")
@@ -171,6 +175,8 @@ class TaskQueueSubscriber(multiprocessing.Process):
                 f"Channel closed with code:{exception.reply_code}, "
                 f"error:{exception.reply_text}"
             )
+        logger.debug("marking channel as closed")
+        self._channel_closed.set()
 
     def setup_exchange(self, exchange_name):
         """Setup the EXCHANGE_NAME on RabbitMQ by invoking the Exchange.Declare RPC
@@ -295,14 +301,10 @@ class TaskQueueSubscriber(multiprocessing.Process):
         # Not sure if we need to do this in a locked context,
         # rabbit's ACK system should make sure you don't lose tasks.
         try:
-            if self.external_callback:
-                self.external_callback(body)
-
-            if self.external_queue:
-                self.external_queue.put(body)
+            self.external_queue.put(body)
         except Exception:
             # We only ack the message if the hand-off to queue worked
-            logger.exception("External callback failed")
+            logger.exception("External queue put failed")
             self._channel.basic_nack(basic_deliver.delivery_tag, requeue=True)
         else:
             self.acknowledge_message(basic_deliver.delivery_tag)
@@ -346,19 +348,33 @@ class TaskQueueSubscriber(multiprocessing.Process):
         logger.info("Closing the channel")
         self._channel.close()
 
+    def _shutdown(self):
+        logger.debug("set status to 'closing'")
+        self.status = SubscriberProcessStatus.closing
+        logger.debug("closing connection")
+        self._connection.close()
+        logger.debug("stopping ioloop")
+        self._connection.ioloop.stop()
+        logger.debug("waiting until channel is closed (timeout=1 second)")
+        if not self._channel_closed.wait(1.0):
+            logger.warning("reached timeout while waiting for channel closed")
+        logger.debug("closing connection to mp queue")
+        self.external_queue.close()
+        logger.debug("joining mp queue background thread")
+        self.external_queue.join_thread()
+        logger.info("shutdown done, setting cleanup event")
+        self._cleanup_complete.set()
+
     def event_watcher(self):
         """Polls the kill_event periodically to trigger a shutdown"""
         if self.kill_event.is_set():
             logger.info("Kill event is set. Start subscriber shutdown")
             try:
-                self.close_connection()
-                self._connection.ioloop.stop()
-                self.cleanup_complete.set()
+                self._shutdown()
             except Exception:
-                logger.exception("Failed to close connection cleanly")
+                logger.exception("error while shutting down")
                 raise
             logger.info("Shutdown complete")
-            return
         else:
             self._connection.ioloop.call_later(
                 self._watcher_poll_period, self.event_watcher
@@ -371,6 +387,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
 
         Note: Only one of these options should be used.
         """
+        self.status = SubscriberProcessStatus.running
         try:
             self._connection = self._connect()
             self.event_watcher()
@@ -378,21 +395,14 @@ class TaskQueueSubscriber(multiprocessing.Process):
         except Exception:
             logger.exception("Failed to start subscriber")
 
-    def close(self) -> None:
-        """This close method needs some rethinking since this whole thing is a separate
-        process with the ioloop callbacks not setting the vars properly
-        """
+    def stop(self) -> None:
+        """stop() is called by the parent to shutdown the subscriber"""
         logger.info("Stopping")
         self.kill_event.set()
-        self._closing = True
-        logger.warning("Waiting for cleanup_complete")
-        self.cleanup_complete.wait(2 * self._watcher_poll_period)
+        logger.info("Waiting for cleanup_complete")
+        if not self._cleanup_complete.wait(2 * self._watcher_poll_period):
+            logger.warning("Reached timeout while waiting for cleanup complete")
         # join shouldn't block if the above did not raise a timeout
         self.join()
-        super().close()
-        logger.warning("Cleanup done")
-
-    def close_connection(self):
-        """This method closes the connection to RabbitMQ."""
-        logger.info("Closing connection")
-        return self._connection.close()
+        self.close()
+        logger.info("Cleanup done")

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -356,6 +356,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
                 self.cleanup_complete.set()
             except Exception:
                 logger.exception("Failed to close connection cleanly")
+                raise
             logger.info("Shutdown complete")
             return
         else:

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -374,7 +374,6 @@ class TaskQueueSubscriber(multiprocessing.Process):
 
         Note: Only one of these options should be used.
         """
-        logger.warning("Run method")
         try:
             self._connection = self._connect()
             self.event_watcher()

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -40,6 +40,7 @@ REQUIRES = [
     # of different features and functions
     # pin exact versions because it does not use semver
     "parsl==1.1.0",
+    "pika>=1.2.0",
 ]
 
 TEST_REQUIRES = [

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -1,0 +1,22 @@
+import pika
+import pytest
+
+from funcx_endpoint.endpoint.rabbit_mq import ResultQueuePublisher
+
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
+
+
+@pytest.fixture(scope="module")
+def ensure_result_queue():
+    result_pub = ResultQueuePublisher(
+        endpoint_id="FIXTURE", pika_conn_params=CONN_PARAMS
+    )
+    result_pub.connect()
+    result_pub._channel.queue_declare(queue="results")
+    result_pub._channel.queue_bind(
+        queue="results",
+        exchange="results",
+        routing_key="*results",
+    )
+    result_pub.close()
+    return

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -1,22 +1,23 @@
 import pika
 import pytest
 
-from funcx_endpoint.endpoint.rabbit_mq import ResultQueuePublisher
-
 CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(autouse=True, scope="session")
 def ensure_result_queue():
-    result_pub = ResultQueuePublisher(
-        endpoint_id="FIXTURE", pika_conn_params=CONN_PARAMS
+    connection = pika.BlockingConnection(CONN_PARAMS)
+    channel = connection.channel()
+    channel.exchange_declare(
+        exchange="results",
+        exchange_type="topic",
     )
-    result_pub.connect()
-    result_pub._channel.queue_declare(queue="results")
-    result_pub._channel.queue_bind(
+    channel.queue_declare(queue="results")
+    channel.queue_bind(
         queue="results",
         exchange="results",
         routing_key="*results",
     )
-    result_pub.close()
+    channel.close()
+    connection.close()
     return

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -1,12 +1,17 @@
 import pika
 import pytest
 
-CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
+G_CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
+
+
+@pytest.fixture()
+def conn_params():
+    return G_CONN_PARAMS
 
 
 @pytest.fixture(autouse=True, scope="session")
 def ensure_result_queue():
-    connection = pika.BlockingConnection(CONN_PARAMS)
+    connection = pika.BlockingConnection(G_CONN_PARAMS)
     channel = connection.channel()
     channel.exchange_declare(
         exchange="results",

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -13,10 +13,6 @@ from funcx_endpoint.endpoint.rabbit_mq import (
     TaskQueueSubscriber,
 )
 
-LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-logger = logging.getLogger(__name__)
-
 ENDPOINT_ID = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
 CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 
@@ -68,7 +64,7 @@ def run_async_service():
         target=start_result_q_subscriber, args=(result_q,)
     )
     result_q_proc.start()
-    logger.warning("SERVICE: Here")
+    logging.warning("SERVICE: Here")
     for _i in range(10):
         try:
             message = {
@@ -76,16 +72,16 @@ def run_async_service():
                 "task_buf": "TASKBUF TASKBUF",
             }
             b_message = json.dumps(message).encode()
-            logger.warning("SERVICE: Trying to publish message")
+            logging.warning("SERVICE: Trying to publish message")
             task_q_pub.publish(b_message)
-            logger.warning(f"SERVICE: Published message: {message}")
+            logging.warning(f"SERVICE: Published message: {message}")
             from_ep, reply_message = result_q.get(timeout=5)
-            logger.warning(f"SERVICE: Received result message: {reply_message}")
+            logging.warning(f"SERVICE: Received result message: {reply_message}")
 
             assert from_ep == ENDPOINT_ID
             assert reply_message == b_message
         except Exception:
-            logger.exception("Caught error")
+            logging.exception("Caught error")
 
     result_q_proc.terminate()
     task_q_pub.close()
@@ -108,7 +104,7 @@ def test_simple_roundtrip():
     result_q_proc = start_result_q_subscriber(result_q)
 
     message = f"Hello {random.randint(0,2**10)}".encode()
-    logger.warning(f"Sending message: {message}")
+    logging.warning(f"Sending message: {message}")
     task_pub.publish(message)
     task_message = task_q.get(timeout=2)
     assert message == task_message

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -148,7 +148,7 @@ def test_simple_roundtrip():
     task_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
     task_pub.queue_purge()
     result_pub = start_result_q_publisher(endpoint_id=ENDPOINT_ID)
-    result_pub._queue_purge()  # Only tests should be able to do this
+    result_pub._channel.queue_purge("results")
     task_q, result_q = multiprocessing.Queue(), multiprocessing.Queue()
     task_fail_event = multiprocessing.Event()
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -18,7 +18,6 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 ENDPOINT_ID = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
-
 CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 
 
@@ -39,46 +38,23 @@ def start_task_q_subscriber(
 
 
 def start_result_q_publisher(endpoint_id) -> ResultQueuePublisher:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
     result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id, pika_conn_params=service_params
+        endpoint_id=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     result_pub.connect()
-    result_pub._channel.queue_declare(queue="results", passive=True)
-    result_pub._channel.queue_bind(
-        queue="results",
-        exchange="results",
-        routing_key="*results",
-    )
     return result_pub
 
 
 def start_task_q_publisher(endpoint_id: str) -> TaskQueuePublisher:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
     task_q_pub = TaskQueuePublisher(
-        endpoint_uuid=endpoint_id, pika_conn_params=service_params
+        endpoint_uuid=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     task_q_pub.connect()
     return task_q_pub
 
 
 def start_result_q_subscriber(queue: multiprocessing.Queue) -> ResultQueueSubscriber:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
-    result_q = ResultQueueSubscriber(
-        pika_conn_params=service_params, external_queue=queue
-    )
+    result_q = ResultQueueSubscriber(pika_conn_params=CONN_PARAMS, external_queue=queue)
     result_q.start()
     return result_q
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -64,7 +64,7 @@ def start_result_q_subscriber(
 def run_async_service():
     """Run a task_q_publisher and result_q_subscriber mocking a simple service"""
     task_q_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
-    task_q_pub.queue_purge()
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)
     result_q = multiprocessing.Queue()
     result_q_proc = multiprocessing.Process(
         target=start_result_q_subscriber, args=(result_q,)
@@ -94,9 +94,8 @@ def run_async_service():
 
 
 def test_simple_roundtrip(conn_params: pika.connection.Parameters):
-
     task_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID, conn_params=conn_params)
-    task_pub.queue_purge()
+    task_pub._channel.queue_purge(task_pub.queue_name)
     result_pub = start_result_q_publisher(
         endpoint_id=ENDPOINT_ID, conn_params=conn_params
     )

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import multiprocessing
+import random
+import uuid
+
+import pika
+import pytest
+
+from funcx_endpoint.endpoint.rabbit_mq import (
+    ResultQueuePublisher,
+    ResultQueueSubscriber,
+    TaskQueuePublisher,
+    TaskQueueSubscriber,
+)
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+ENDPOINT_ID = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
+
+
+def start_task_q_subscriber(
+    endpoint_id: str,
+    out_queue: multiprocessing.Queue,
+    disconnect_event: multiprocessing.Event,
+):
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    task_q = TaskQueueSubscriber(
+        endpoint_name=endpoint_id, pika_conn_params=service_params
+    )
+    task_q.connect()
+    task_q.run(queue=out_queue, disconnect_event=disconnect_event)
+    return task_q
+
+
+def start_result_q_publisher(endpoint_id) -> ResultQueuePublisher:
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id, pika_conn_params=service_params
+    )
+    result_pub.connect()
+    return result_pub
+
+
+def start_task_q_publisher(endpoint_id: str) -> TaskQueuePublisher:
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    task_q_pub = TaskQueuePublisher(
+        endpoint_name=endpoint_id, pika_conn_params=service_params
+    )
+    task_q_pub.connect()
+    return task_q_pub
+
+
+def start_result_q_subscriber(queue: multiprocessing.Queue) -> ResultQueueSubscriber:
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    result_q = ResultQueueSubscriber(pika_conn_params=service_params)
+    result_q.run(queue=queue)
+    return result_q
+
+
+def run_async_service():
+    """Run a task_q_publisher and result_q_subscriber mocking a simple service"""
+    task_q_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
+    task_q_pub.queue_purge()
+    result_q = multiprocessing.Queue()
+    result_q_proc = multiprocessing.Process(
+        target=start_result_q_subscriber, args=(result_q,)
+    )
+    result_q_proc.start()
+    logger.warning("SERVICE: Here")
+    for _i in range(10):
+        try:
+            message = {
+                "task_id": str(uuid.uuid4()),
+                "task_buf": "TASKBUF TASKBUF",
+            }
+            b_message = json.dumps(message).encode()
+            logger.warning("SERVICE: Trying to publish message")
+            task_q_pub.publish(b_message)
+            logger.warning(f"SERVICE: Published message: {message}")
+            from_ep, reply_message = result_q.get(timeout=5)
+            logger.warning(f"SERVICE: Received result message: {reply_message}")
+
+            assert from_ep == ENDPOINT_ID
+            assert reply_message == b_message
+        except Exception:
+            logger.exception("Caught error")
+
+    result_q_proc.terminate()
+    task_q_pub.close()
+
+
+# @pytest.mark.skip
+def test_mock_endpoint():
+
+    service = multiprocessing.Process(target=run_async_service, args=())
+    service.start()
+
+    tasks_out = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+
+    # Listen for 10 messages
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            ENDPOINT_ID,
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+    result_q_pub = start_result_q_publisher(ENDPOINT_ID)
+
+    logger.warning("ENDPOINT: Here")
+
+    for _i in range(10):
+        logger.warning("ENDPOINT: Waiting for task: ")
+        b_message = tasks_out.get(timeout=5)
+        logger.warning(f"ENDPOINT: Received message: {b_message}")
+        logger.warning("ENDPOINT: Publishing message to results_q")
+        result_q_pub.publish(b_message)
+
+    service.terminate()
+    proc.terminate()
+
+
+@pytest.mark.skip
+def test_simple_roundtrip():
+
+    task_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
+    task_pub.queue_purge()
+    result_pub = start_result_q_publisher(endpoint_id=ENDPOINT_ID)
+    result_pub._queue_purge()  # Only tests should be able to do this
+    task_q, result_q = multiprocessing.Queue(), multiprocessing.Queue()
+    task_fail_event = multiprocessing.Event()
+
+    task_q_proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            ENDPOINT_ID,
+            task_q,
+            task_fail_event,
+        ),
+    )
+    task_q_proc.start()
+
+    result_q_proc = multiprocessing.Process(
+        target=start_result_q_subscriber, args=(result_q,)
+    )
+
+    result_q_proc.start()
+
+    message = f"Hello {random.randint(0,2**10)}".encode()
+    logger.warning(f"Sending message: {message}")
+    task_pub.publish(message)
+    task_message = task_q.get(timeout=2)
+    assert message == task_message
+
+    result_pub.publish(task_message)
+    result_message = result_q.get(timeout=2)
+
+    assert result_message == (ENDPOINT_ID, message)
+
+    task_pub.close()
+    result_pub.close()
+    task_q_proc.terminate()
+    result_q_proc.terminate()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -32,7 +32,7 @@ def start_task_q_subscriber(
     )
 
     task_q = TaskQueueSubscriber(
-        endpoint_name=endpoint_id, pika_conn_params=service_params
+        endpoint_uuid=endpoint_id, pika_conn_params=service_params
     )
     task_q.connect()
     task_q.run(queue=out_queue, disconnect_event=disconnect_event)

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -48,6 +48,12 @@ def start_result_q_publisher(endpoint_id) -> ResultQueuePublisher:
         endpoint_id=endpoint_id, pika_conn_params=service_params
     )
     result_pub.connect()
+    result_pub._channel.queue_declare(queue="results", passive=True)
+    result_pub._channel.queue_bind(
+        queue="results",
+        exchange="results",
+        routing_key="*results",
+    )
     return result_pub
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -24,17 +24,10 @@ CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 
 
 def start_result_q_publisher(endpoint_id):
-
     result_pub = ResultQueuePublisher(
         endpoint_id=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     result_pub.connect()
-    result_pub._channel.queue_declare(queue="results", passive=True)
-    result_pub._channel.queue_bind(
-        queue="results",
-        exchange="results",
-        routing_key="*results",
-    )
     return result_pub
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import multiprocessing
+import uuid
+
+import pika
+import pytest
+
+from funcx.serialize import FuncXSerializer
+from funcx_endpoint.endpoint.rabbit_mq import (
+    ResultQueuePublisher,
+    ResultQueueSubscriber,
+)
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
+endpoint_id_2 = "9b2dbe0f-0420-4256-9f89-71cb8bfb26d2"
+
+
+def start_result_q_publisher(endpoint_id):
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id, pika_conn_params=service_params
+    )
+    result_pub.connect()
+    return result_pub
+
+
+def start_result_q_subscriber(queue: multiprocessing.Queue) -> ResultQueueSubscriber:
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    result_q = ResultQueueSubscriber(pika_conn_params=service_params)
+    result_q.run(queue=queue)
+    return result_q
+
+
+def publish_messages(count: int, endpoint_id: str, size=10) -> ResultQueuePublisher:
+    fxs = FuncXSerializer()
+    result_pub = start_result_q_publisher(endpoint_id)
+    for _i in range(count):
+        data = bytes(size)
+        message = {
+            "task_id": str(uuid.uuid4()),
+            "result": fxs.serialize(data),
+        }
+        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        result_pub.publish(b_message)
+
+    logger.warning(f"Published {count} messages")
+    return result_pub
+
+
+# @pytest.mark.skip
+def test_result_queue_basic(count=10):
+    """Test that any endpoint can publish
+    TO DO: Add in auth to ensure that you can publish results from *any* EP
+    Testing purging queue
+    """
+    result_pub = publish_messages(count=count, endpoint_id=str(uuid.uuid4()))
+    result_pub._queue_purge()
+    result_pub.close()
+
+
+@pytest.mark.parametrize("size", [10, 2 ** 10, 2 ** 20, (2 ** 20) * 10])
+# @pytest.mark.skip
+def test_message_integrity_across_sizes(size):
+    """Publish count messages from endpoint_1 and endpoint_1
+    Confirm that the subscriber gets all of them.
+    """
+
+    fxs = FuncXSerializer()
+    result_pub = start_result_q_publisher(endpoint_id_1)
+    data = bytes(size)
+    message = {
+        "task_id": str(uuid.uuid4()),
+        "result": fxs.serialize(data),
+    }
+    b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+    result_pub.publish(b_message)
+
+    results_q = multiprocessing.Queue()
+    sub_proc = multiprocessing.Process(
+        target=start_result_q_subscriber, args=(results_q,)
+    )
+    sub_proc.start()
+
+    (routing_key, received_message) = results_q.get(timeout=2)
+    assert endpoint_id_1 in routing_key
+    assert received_message == b_message
+    sub_proc.terminate()
+
+
+def test_publish_multiple_then_subscribe(count=10):
+    """Publish count messages from endpoint_1 and endpoint_1
+    Confirm that the subscriber gets all of them.
+    """
+    total_messages = 20
+    publish_messages(count=count, endpoint_id=endpoint_id_1)
+    publish_messages(count=count, endpoint_id=endpoint_id_2)
+
+    results_q = multiprocessing.Queue()
+    sub_proc = multiprocessing.Process(
+        target=start_result_q_subscriber, args=(results_q,)
+    )
+    sub_proc.start()
+
+    all_results = {}
+    for _i in range(total_messages):
+        (routing_key, b_message) = results_q.get(timeout=2)
+        all_results[routing_key] = all_results.get(routing_key, 0) + 1
+
+    routing_keys_stripped = [key.split(".")[0] for key in all_results]
+    assert endpoint_id_1 in routing_keys_stripped
+    assert endpoint_id_2 in routing_keys_stripped
+    assert list(all_results.values()) == [10, 10]
+
+    sub_proc.terminate()
+
+
+def test_broken_connection():
+    """Test exception raised on connect with bad connection info"""
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5671, credentials=cred  # Wrong port
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+    )
+    with pytest.raises(pika.exceptions.AMQPConnectionError):
+        result_pub.connect()
+
+
+def test_disconnect_from_client_side():
+    """Confirm that an exception is raised when the connection is closed
+    Ideally we use rabbitmqadmin to close the connection, but that is less reliable here
+    since the test env may not be have the util, and
+    """
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+    )
+    result_pub.connect()
+    res = result_pub.publish(b"Hello")
+    assert res is None
+
+    result_pub.close()
+
+    with pytest.raises(pika.exceptions.ChannelWrongStateError):
+        result_pub.publish(b"Hello")

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -12,11 +12,6 @@ from funcx_endpoint.endpoint.rabbit_mq import (
     ResultQueueSubscriber,
 )
 
-LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-logger = logging.getLogger(__name__)
-
-
 endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
 endpoint_id_2 = "9b2dbe0f-0420-4256-9f89-71cb8bfb26d2"
 
@@ -53,7 +48,7 @@ def publish_messages(count: int, endpoint_id: str, size=10) -> ResultQueuePublis
         b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
         result_pub.publish(b_message)
 
-    logger.warning(f"Published {count} messages")
+    logging.warning(f"Published {count} messages")
     return result_pub
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -33,9 +33,10 @@ def start_result_q_publisher(endpoint_id):
 
 
 def start_result_q_subscriber(queue: multiprocessing.Queue) -> ResultQueueSubscriber:
-    kill_event = multiprocessing.Event()
+
     result_q = ResultQueueSubscriber(
-        pika_conn_params=CONN_PARAMS, external_queue=queue, kill_event=kill_event
+        pika_conn_params=CONN_PARAMS,
+        external_queue=queue,
     )
     result_q.start()
     return result_q
@@ -63,7 +64,7 @@ def test_result_queue_basic(count=10):
     Testing purging queue
     """
     result_pub = publish_messages(count=count, endpoint_id=str(uuid.uuid4()))
-    result_pub._queue_purge()
+    result_pub._channel.queue_purge("results")
     result_pub.close()
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -29,6 +29,12 @@ def start_result_q_publisher(endpoint_id):
         endpoint_id=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     result_pub.connect()
+    result_pub._channel.queue_declare(queue="results", passive=True)
+    result_pub._channel.queue_bind(
+        queue="results",
+        exchange="results",
+        routing_key="*results",
+    )
     return result_pub
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
 endpoint_id_2 = "9b2dbe0f-0420-4256-9f89-71cb8bfb26d2"
 
-CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/%2F")
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 
 
 def start_result_q_publisher(endpoint_id):

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -1,14 +1,9 @@
-import logging
 import time
 
 import pika
 import pytest
 
 from funcx_endpoint.endpoint.rabbit_mq import ResultQueuePublisher
-
-LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-logger = logging.getLogger(__name__)
 
 endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
 RABBIT_MQ_URL = "amqp://guest:guest@localhost:5672/"

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -1,0 +1,84 @@
+import logging
+import time
+
+import pika
+import pytest
+
+from funcx_endpoint.endpoint.rabbit_mq import ResultQueuePublisher
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
+
+
+def test_heartbeat_ok():
+    """Confirm that result_q_publisher does not disconnect when delay
+    between messages exceed heartbeat period
+    """
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost",
+        heartbeat=1,
+        blocked_connection_timeout=2,
+        port=5672,
+        credentials=cred,
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+    )
+    result_pub.connect()
+
+    x = result_pub.publish(b"Hello")
+    assert x is None
+    time.sleep(5)
+    x = result_pub.publish(b"Hello")
+    assert x is None
+
+
+def test_fail_after_manual_close():
+    """Confirm that result_q_publisher raises an error following a manual conn close"""
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost",
+        heartbeat=1,
+        blocked_connection_timeout=2,
+        port=5672,
+        credentials=cred,
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+    )
+    result_pub.connect()
+
+    result_pub.publish(b"Hello")
+    result_pub.close()
+    with pytest.raises(pika.exceptions.ChannelWrongStateError):
+        result_pub.publish(b"Hello")
+
+
+def test_reconnect_after_disconnect():
+    """Confirm that result_q_publisher does not disconnect when delay
+    between messages exceed heartbeat period
+    """
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost",
+        heartbeat=1,
+        blocked_connection_timeout=2,
+        port=5672,
+        credentials=cred,
+    )
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+    )
+    result_pub.connect()
+
+    result_pub.publish(b"Hello")
+    result_pub.close()
+    result_pub.connect()
+    result_pub.publish(b"Hello")

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -14,7 +14,26 @@ endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
 RABBIT_MQ_URL = "amqp://guest:guest@localhost:5672/"
 
 
-def test_heartbeat_ok():
+def test_no_heartbeat():
+    """Confirm that result_q_publisher does not disconnect when delay
+    between messages exceed heartbeat period
+    """
+    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params._heartbeat = None  # Ensure heartbeat disabled
+    conn_params._blocked_connection_timeout = 2
+
+    result_pub = ResultQueuePublisher(
+        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
+    )
+    result_pub.connect()
+
+    x = result_pub.publish(b"Hello")
+    assert x is None
+    time.sleep(5)
+    x = result_pub.publish(b"Hello")
+
+
+def test_heartbeat_failure():
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
@@ -30,15 +49,13 @@ def test_heartbeat_ok():
     x = result_pub.publish(b"Hello")
     assert x is None
     time.sleep(5)
-    x = result_pub.publish(b"Hello")
-    assert x is None
+    with pytest.raises(pika.exceptions.StreamLostError):
+        x = result_pub.publish(b"Hello")
 
 
 def test_fail_after_manual_close():
     """Confirm that result_q_publisher raises an error following a manual conn close"""
     conn_params = pika.URLParameters(RABBIT_MQ_URL)
-    conn_params._heartbeat = 1
-    conn_params._blocked_connection_timeout = 2
 
     result_pub = ResultQueuePublisher(
         endpoint_id=endpoint_id_1, pika_conn_params=conn_params

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -1,3 +1,4 @@
+import copy
 import time
 
 import pika
@@ -9,11 +10,11 @@ endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
 RABBIT_MQ_URL = "amqp://guest:guest@localhost:5672/"
 
 
-def test_no_heartbeat():
+def test_no_heartbeat(conn_params):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params = copy.deepcopy(conn_params)
     conn_params._heartbeat = None  # Ensure heartbeat disabled
     conn_params._blocked_connection_timeout = 2
 
@@ -28,11 +29,11 @@ def test_no_heartbeat():
     x = result_pub.publish(b"Hello")
 
 
-def test_heartbeat_failure():
+def test_heartbeat_failure(conn_params):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params = copy.deepcopy(conn_params)
     conn_params._heartbeat = 1
     conn_params._blocked_connection_timeout = 2
 
@@ -48,10 +49,8 @@ def test_heartbeat_failure():
         x = result_pub.publish(b"Hello")
 
 
-def test_fail_after_manual_close():
+def test_fail_after_manual_close(conn_params):
     """Confirm that result_q_publisher raises an error following a manual conn close"""
-    conn_params = pika.URLParameters(RABBIT_MQ_URL)
-
     result_pub = ResultQueuePublisher(
         endpoint_id=endpoint_id_1, pika_conn_params=conn_params
     )
@@ -63,11 +62,11 @@ def test_fail_after_manual_close():
         result_pub.publish(b"Hello")
 
 
-def test_reconnect_after_disconnect():
+def test_reconnect_after_disconnect(conn_params):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params = copy.deepcopy(conn_params)
     conn_params._heartbeat = 1
     conn_params._blocked_connection_timeout = 2
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -11,23 +11,19 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
+RABBIT_MQ_URL = "amqp://guest:guest@localhost:5672/"
 
 
 def test_heartbeat_ok():
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost",
-        heartbeat=1,
-        blocked_connection_timeout=2,
-        port=5672,
-        credentials=cred,
-    )
+    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params._heartbeat = 1
+    conn_params._blocked_connection_timeout = 2
 
     result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
     )
     result_pub.connect()
 
@@ -40,17 +36,12 @@ def test_heartbeat_ok():
 
 def test_fail_after_manual_close():
     """Confirm that result_q_publisher raises an error following a manual conn close"""
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost",
-        heartbeat=1,
-        blocked_connection_timeout=2,
-        port=5672,
-        credentials=cred,
-    )
+    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params._heartbeat = 1
+    conn_params._blocked_connection_timeout = 2
 
     result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
     )
     result_pub.connect()
 
@@ -64,17 +55,12 @@ def test_reconnect_after_disconnect():
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost",
-        heartbeat=1,
-        blocked_connection_timeout=2,
-        port=5672,
-        credentials=cred,
-    )
+    conn_params = pika.URLParameters(RABBIT_MQ_URL)
+    conn_params._heartbeat = 1
+    conn_params._blocked_connection_timeout = 2
 
     result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=service_params
+        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
     )
     result_pub.connect()
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -38,7 +38,7 @@ def test_synch(conn_params, count=10):
     fxs = FuncXSerializer()
 
     task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub.queue_purge()  # Make sure queue is empty
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
     messages = {}
     for i in range(count):
         data = list(range(10))
@@ -81,7 +81,7 @@ def test_subscriber_recovery(conn_params):
     """Subscriber terminates after 10 messages, and reconnects."""
     fxs = FuncXSerializer()
     task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub.queue_purge()  # Make sure queue is empty
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
 
     # Launch 10 messages
     messages = {}
@@ -139,7 +139,7 @@ def test_exclusive_subscriber(conn_params):
     """2 subscribers connect, only last one should get any messages"""
     fxs = FuncXSerializer()
     task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub.queue_purge()  # Make sure queue is empty
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
 
     # Start two subscribers to the same queue
     tasks_out_1, tasks_out_2 = multiprocessing.Queue(), multiprocessing.Queue()
@@ -187,7 +187,7 @@ def test_exclusive_subscriber(conn_params):
 def test_combined_pub_sub_latency(conn_params, count=10):
     """Confirm that messages published are received."""
     task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub.queue_purge()  # Make sure queue is empty
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
 
     tasks_out = multiprocessing.Queue()
     disconnect_event = multiprocessing.Event()
@@ -216,7 +216,7 @@ def test_combined_pub_sub_latency(conn_params, count=10):
 def test_combined_throughput(conn_params, count=1000):
     """Confirm that messages published are received."""
     task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub.queue_purge()  # Make sure queue is empty
+    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
 
     tasks_out = multiprocessing.Queue()
     disconnect_event = multiprocessing.Event()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -14,8 +14,7 @@ LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(messag
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
-
-CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/%2F")
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 ENDPOINT_ID = "task-q-tests"
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -65,7 +65,6 @@ def test_synch(count=10):
         message = tasks_out.get()
         assert messages[i] == message
 
-    proc.close()
     proc.terminate()
     return
 

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -1,0 +1,331 @@
+import json
+import logging
+import multiprocessing
+import random
+import time
+import uuid
+
+import pika
+import pytest
+
+from funcx.serialize import FuncXSerializer
+from funcx_endpoint.endpoint.rabbit_mq import TaskQueuePublisher, TaskQueueSubscriber
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def offprocess_consumer():
+    print("Starting offprocess_consumer")
+    yield True
+    print("Closing offprocess_consumer")
+
+
+def listen_for_tasks():
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    endpoint_id = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
+
+    task_queue = TaskQueueSubscriber(service_params, endpoint_name=endpoint_id)
+    task_queue.run()
+
+
+def start_task_q_publisher():
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    endpoint_id = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
+
+    task_q = TaskQueuePublisher(
+        endpoint_name=endpoint_id, pika_conn_params=service_params
+    )
+    task_q.connect()
+    return task_q
+
+
+def start_task_q_subscriber(
+    out_queue: multiprocessing.Queue, disconnect_event: multiprocessing.Event
+):
+    cred = pika.PlainCredentials("guest", "guest")
+    service_params = pika.ConnectionParameters(
+        host="localhost", heartbeat=60, port=5672, credentials=cred
+    )
+
+    endpoint_id = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
+
+    task_q = TaskQueueSubscriber(
+        endpoint_name=endpoint_id, pika_conn_params=service_params
+    )
+    task_q.connect()
+    task_q.run(queue=out_queue, disconnect_event=disconnect_event)
+    return task_q
+
+
+def test_synch():
+    """Open publisher, and publish to task_q, then open subscriber a fetch"""
+    fxs = FuncXSerializer()
+    task_q_pub = start_task_q_publisher()
+    task_q_pub.queue_purge()  # Make sure queue is empty
+    messages = {}
+    for i in range(10):
+        data = list(range(10))
+        message = {
+            "task_id": str(uuid.uuid4()),
+            "result": fxs.serialize(data),
+        }
+        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        task_q_pub.publish(b_message)
+        messages[i] = b_message
+
+    task_q_pub.close()
+
+    tasks_out = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+    for i in range(10):
+        message = tasks_out.get()
+        logger.warning(f"Got message: {message}")
+        assert messages[i] == message
+
+    proc.terminate()
+    return
+
+
+def fallible_callback(queue: multiprocessing.Queue, message: bytes):
+    logger.warning("In callback")
+    x = random.randint(1, 10)
+    logger.warning(f"{x} > 7")
+    if x >= 7:
+        raise ValueError
+    else:
+        logger.warning(f"Got message: {message}")
+        queue.put(message)
+    return
+
+
+def test_subscriber_recovery():
+    """Subscriber terminates after 10 messages, and reconnects."""
+    fxs = FuncXSerializer()
+    task_q_pub = start_task_q_publisher()
+    task_q_pub.queue_purge()  # Make sure queue is empty
+
+    # Launch 10 messages
+    messages = {}
+    for i in range(10):
+        data = list(range(10))
+        message = {
+            "task_id": str(uuid.uuid4()),
+            "result": fxs.serialize(data),
+        }
+        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        task_q_pub.publish(b_message)
+        messages[i] = b_message
+
+    tasks_out = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+
+    # Listen for 10 messages
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+    logger.warning("Proc started")
+    for i in range(10):
+        message = tasks_out.get()
+        logger.warning(f"Got message: {message}")
+        assert messages[i] == message
+
+    # Terminate the connection
+    proc.terminate()
+
+    # Launch 10 messages
+    messages = {}
+    for i in range(10):
+        data = list(range(10))
+        message = {
+            "task_id": str(uuid.uuid4()),
+            "result": fxs.serialize(data),
+        }
+        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        task_q_pub.publish(b_message)
+        messages[i] = b_message
+
+    # Listen for the messages on a new connection
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+    logger.warning("Proc started")
+    for i in range(10):
+        message = tasks_out.get()
+        logger.warning(f"Got message: {message}")
+        assert messages[i] == message
+
+    proc.terminate()
+
+    task_q_pub.close()
+    return
+
+
+def test_exclusive_subscriber():
+    """2 subscribers connect, only last one should get any messages"""
+    fxs = FuncXSerializer()
+    task_q_pub = start_task_q_publisher()
+    task_q_pub.queue_purge()  # Make sure queue is empty
+
+    # Start two subscribers to the same queue
+    tasks_out_1, tasks_out_2 = multiprocessing.Queue(), multiprocessing.Queue()
+    disconnect_event_1, disconnect_event_2 = (
+        multiprocessing.Event(),
+        multiprocessing.Event(),
+    )
+    proc1 = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out_1,
+            disconnect_event_1,
+        ),
+    )
+    proc2 = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out_2,
+            disconnect_event_2,
+        ),
+    )
+    proc1.start()
+    time.sleep(1)
+    # TO-DO figure out from stephen the caplog mechanism to confirm that
+    # a warning/error is logged.
+    proc2.start()
+
+    logger.warning("TEST: Launching messages")
+    # Launch 10 messages
+    messages = {}
+    for i in range(10):
+        data = list(range(10))
+        message = {
+            "task_id": str(uuid.uuid4()),
+            "result": fxs.serialize(data),
+        }
+        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        task_q_pub.publish(b_message)
+        messages[i] = b_message
+    logger.warning("TEST: Launching messages")
+
+    # Give some delay
+    time.sleep(1)
+
+    # Check that the second subscriber did not receive any messages
+    assert tasks_out_2.empty()
+
+    # Confirm that the first subscriber received all the messages
+    for i in range(10):
+        message = tasks_out_1.get(timeout=5)
+        logger.warning(f"Got message: {message}")
+        assert messages[i] == message
+
+    proc1.terminate()
+    proc2.terminate()
+
+    task_q_pub.close()
+    return
+
+
+def test_combined_pub_sub_latency(count=10):
+    """Confirm that messages published are received."""
+    task_q_pub = start_task_q_publisher()
+    task_q_pub.queue_purge()  # Make sure queue is empty
+
+    tasks_out = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+
+    latency = []
+    for i in range(count):
+        b_message = f"Hello World! {i}".encode()
+        start_t = time.time()
+        task_q_pub.publish(b_message)
+        x = tasks_out.get()
+        delta = time.time() - start_t
+        latency.append(delta)
+        assert b_message == x
+
+    avg_latency = sum(latency) / len(latency)
+    logger.warning(
+        f"Message latencies in milliseconds, min:{1000*min(latency):.2f}, "
+        f"max:{1000*max(latency):.2f}, avg:{1000*avg_latency:.2f}"
+    )
+
+    task_q_pub.close()
+    proc.terminate()
+
+
+def test_combined_throughput(count=1000):
+    """Confirm that messages published are received."""
+    task_q_pub = start_task_q_publisher()
+    task_q_pub.queue_purge()  # Make sure queue is empty
+
+    tasks_out = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+    proc = multiprocessing.Process(
+        target=start_task_q_subscriber,
+        args=(
+            tasks_out,
+            disconnect_event,
+        ),
+    )
+    proc.start()
+
+    tput_at_size = {}
+    # Do 10 rounds of throughput measures
+    for i in range(10):
+        data_size = 2 ** i
+        b_message = bytes(data_size)
+        start_t = time.time()
+        for _i in range(count):
+            task_q_pub.publish(b_message)
+        send_t = time.time() - start_t
+        for _i in range(count):
+            message_received = tasks_out.get()
+            assert len(message_received) >= data_size
+        delta = time.time() - start_t
+        tput_at_size[data_size] = {"send": send_t, "ttc": delta}
+    for size in tput_at_size:
+        logger.warning(
+            f"TTC throughput for {count} messages at {size}B = "
+            f"{count/tput_at_size[size]['ttc']:.2f}messages/s"
+        )
+
+    task_q_pub.close()
+    proc.terminate()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -29,6 +29,5 @@ def test_terminate():
     task_q.start()
     time.sleep(3)
     logger.warning("Calling terminate")
-    task_q.close()
-    # task_q.terminate()
+    task_q.terminate()
     return task_q

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -7,10 +7,6 @@ import pytest
 
 from funcx_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
 
-LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-logger = logging.getLogger(__name__)
-
 CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 ENDPOINT_ID = "95abffc0-11cc-43cf-8b9b-c1acadf6f877"
 
@@ -26,10 +22,10 @@ def test_terminate():
         kill_event=disconnect_event,
         endpoint_uuid=ENDPOINT_ID,
     )
-    logger.warning("Start")
+    logging.warning("Start")
     task_q.start()
     time.sleep(3)
-    logger.warning("Calling terminate")
+    logging.warning("Calling terminate")
     task_q.close()
     with pytest.raises(ValueError):
         # Expected to raise ValueError since the process should

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -1,0 +1,35 @@
+import logging
+import multiprocessing
+import time
+
+import pika
+
+from funcx_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/%2F")
+ENDPOINT_ID = "95abffc0-11cc-43cf-8b9b-c1acadf6f877"
+
+
+def test_terminate():
+
+    out_queue = multiprocessing.Queue()
+    disconnect_event = multiprocessing.Event()
+
+    task_q = TaskQueueSubscriber(
+        CONN_PARAMS,
+        external_queue=out_queue,
+        kill_event=disconnect_event,
+        endpoint_uuid=ENDPOINT_ID,
+    )
+    logger.warning("Start")
+    task_q.start()
+    time.sleep(3)
+    logger.warning("Calling terminate")
+    task_q.close()
+    # task_q.terminate()
+    return task_q

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -3,6 +3,7 @@ import multiprocessing
 import time
 
 import pika
+import pytest
 
 from funcx_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
 
@@ -29,5 +30,10 @@ def test_terminate():
     task_q.start()
     time.sleep(3)
     logger.warning("Calling terminate")
-    task_q.terminate()
+    task_q.close()
+    with pytest.raises(ValueError):
+        # Expected to raise ValueError since the process should
+        # be terminated at this point from the close() call
+        task_q.terminate()
+
     return task_q

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -2,22 +2,20 @@ import logging
 import multiprocessing
 import time
 
-import pika
 import pytest
 
 from funcx_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
 
-CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 ENDPOINT_ID = "95abffc0-11cc-43cf-8b9b-c1acadf6f877"
 
 
-def test_terminate():
+def test_terminate(conn_params):
 
     out_queue = multiprocessing.Queue()
     disconnect_event = multiprocessing.Event()
 
     task_q = TaskQueueSubscriber(
-        CONN_PARAMS,
+        conn_params,
         external_queue=out_queue,
         kill_event=disconnect_event,
         endpoint_uuid=ENDPOINT_ID,

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -24,7 +24,7 @@ def test_terminate(conn_params):
     task_q.start()
     time.sleep(3)
     logging.warning("Calling terminate")
-    task_q.close()
+    task_q.stop()
     with pytest.raises(ValueError):
         # Expected to raise ValueError since the process should
         # be terminated at this point from the close() call

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -10,8 +10,7 @@ LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(messag
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
-
-CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/%2F")
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
 ENDPOINT_ID = "95abffc0-11cc-43cf-8b9b-c1acadf6f877"
 
 

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -551,7 +551,7 @@ class FuncXClient:
         int
             The port to connect to and a list of containers
         """
-        data = {"endpoint_name": name, "description": description}
+        data = {"endpoint_id": name, "description": description}
 
         r = self.web_client.post("get_containers", data=data)
         return r.data["endpoint_uuid"], r.data["endpoint_containers"]

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -551,7 +551,7 @@ class FuncXClient:
         int
             The port to connect to and a list of containers
         """
-        data = {"endpoint_id": name, "description": description}
+        data = {"endpoint_name": name, "description": description}
 
         r = self.web_client.post("get_containers", data=data)
         return r.data["endpoint_uuid"], r.data["endpoint_containers"]


### PR DESCRIPTION
# Description

This is the 2nd PR that should go into `rabbitmq_rearch_feature_branch`. 

This PR adds 4 classes and tests:

We have 4 new classes:
`TaskQueueSubscriber`: This is an endpoint-side component launched off-process that pipes task messages from the service over rabbit_mq into multiprocessing.Queue.
`ResultQueuePublisher`: This class enables publishing results from the endpoint to the service over rabbit_MQ
`TaskQueuePublisher`: Service side component that publishes tasks to the endpoint over rabbit_mq
`ResultQueueSubscriber`: Service side component that listens for results from the endpoint over rabbit_mq.

Key bits that are already implemented and more or less tested:
* Disconnects raise an error in TaskQueueSubsciber and ResultQueuePublisher.
    - [ ] TODO: Add tests with external_callback hook to check this behavior for TaskQueueSubscriber
    
* Once one TaskQueueSubscriber can be connected to an endpoint's rabbit_mq pipes preventing stealing by orphan EPs
* The subscribers all use RabbitMQ's `SelectConnection` which is fairly fast
* Longer duration connections are robust and do not timeout from missing heartbeats with the right components running asynchronously.
* ResultQueuePublisher publishes to a topic.

The bits that need work:
* No authz/n tests
* Tests assume there's a local rabbitMQ service with guest:guest as creds
* Limited/partial integration into the endpoint code replacing the existing ZMQ with the new code 
* The main limiting factor for ^ is the limited testing setup.

Please check the design notes: https://github.com/funcx-faas/funcX/commit/6fb842c22f0ad3c559a99e33db2cb1c9047f58f3


## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
