### PR TITLE
Enable mypy (passing on SDK, setup but failing on Endpoint)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
-      - name: install pre-commit
+      - name: install requirements
         run: |
           python -m pip install -U pip setuptools wheel
-          python -m pip install pre-commit
+          python -m pip install pre-commit tox
       - name: run pre-commit
         run: pre-commit run -a
+      - name: mypy (sdk)
+        run: |
+          cd funcx_sdk
+          tox -e mypy
 
   # ensure docs can build, imitating the RTD build as best we can
   check-docs:

--- a/funcx_endpoint/setup.cfg
+++ b/funcx_endpoint/setup.cfg
@@ -1,0 +1,16 @@
+[isort]
+profile = black
+known_first_party = funcx,funcx_endpoint
+
+[flake8]
+# config to be black-compatible
+max-line-length = 88
+ignore = E203,W503,W504
+
+[mypy]
+# strict = true
+ignore_missing_imports = true
+warn_unreachable = true
+warn_no_return = true
+exclude = tests
+

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -6,3 +6,7 @@ skip_missing_interpreters = true
 usedevelop = true
 extras = test
 commands = python -m coverage run -m pytest tests/funcx_endpoint {posargs}
+
+[testenv:mypy]
+deps = mypy
+commands = mypy funcx_endpoint/

--- a/funcx_sdk/funcx/sdk/errors/api_error.py
+++ b/funcx_sdk/funcx/sdk/errors/api_error.py
@@ -14,6 +14,9 @@ class FuncxAPIError(globus_sdk.GlobusAPIError):
         A friendly string name for the error code which was recieved, or
         ``"UNKNOWN"`` if the code is not recognized.
         """
+        if self.raw_json is None:
+            raise ValueError("could not JSON decode response")
+
         try:
             code_int = self.raw_json["code"]
         except KeyError as e:

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -6,6 +6,7 @@ import logging
 import queue
 import threading
 import time
+import typing as t
 from concurrent.futures import Future
 
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
@@ -87,10 +88,10 @@ class FuncXExecutor(concurrent.futures.Executor):
         self.batch_interval = batch_interval
         self.batch_size = batch_size
 
-        self._tasks = {}
+        self._tasks: t.Dict[str, Future] = {}
         self._task_counter = 0
-        self._function_registry = {}
-        self._function_future_map = {}
+        self._function_registry: t.Dict[t.Any, str] = {}
+        self._function_future_map: t.Dict[str, Future] = {}
         self.task_group_id = (
             self.funcx_client.session_task_group_id
         )  # we need to associate all batch launches with this id

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -145,7 +145,7 @@ class FuncxWebClient(globus_sdk.BaseClient):
         endpoint_version: t.Optional[str] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
-        data = {
+        data: t.Dict[str, t.Any] = {
             "endpoint_name": endpoint_name,
             "endpoint_uuid": str(endpoint_id),
             "version": endpoint_version,

--- a/funcx_sdk/setup.cfg
+++ b/funcx_sdk/setup.cfg
@@ -6,3 +6,10 @@ known_first_party = funcx,funcx_endpoint
 # config to be black-compatible
 max-line-length = 88
 ignore = E203,W503,W504
+
+[mypy]
+# strict = true
+ignore_missing_imports = true
+warn_unreachable = true
+warn_no_return = true
+exclude = tests

--- a/funcx_sdk/tox.ini
+++ b/funcx_sdk/tox.ini
@@ -6,3 +6,7 @@ skip_missing_interpreters = true
 usedevelop = true
 extras = test
 commands = pytest funcx/tests/unit/ funcx/tests/integration/ {posargs}
+
+[testenv:mypy]
+deps = mypy
+commands = mypy funcx/


### PR DESCRIPTION
This is almost all just "annotate the code as it exists today" in order to get mypy passing.

The only case of even mild complexity is the WebSocketsPollingTask. Two issues there need fixing:
1. There's a nasty issue with the type publishing from `websockets` (it has a custom importer) but the solution is simple: import from `websockets.client` rather than the top-level package. A comment on the import points at the relevant thread.

2. Wrapping `ws` in a property to narrow its type
There are at least half-a-dozen ways of handling this. It's sufficient to toss in some `assert` calls if we wanted to go really, really lightweight. However, the property strikes me as the nicest solve.