### PR TITLE
Rabbitmq uri from webservice

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -249,9 +249,9 @@ class Endpoint:
 
         # place registration after everything else so that the endpoint will
         # only be registered if everything else has been set up successfully
-        reg_info = None
+        rabbitmq_uri = None
         try:
-            reg_info = register_endpoint(
+            rabbitmq_uri = register_endpoint(
                 funcx_client, endpoint_uuid, endpoint_dir, self.name
             )
         # if the service sends back an error response, it will be a FuncxResponseError
@@ -298,7 +298,7 @@ class Endpoint:
         except Exception:
             raise
 
-        if reg_info:
+        if rabbitmq_uri:
             log.info("Launching endpoint daemon process")
         else:
             log.critical("Launching endpoint daemon process with errors noted above")
@@ -321,7 +321,7 @@ class Endpoint:
                 endpoint_dir,
                 keys_dir,
                 endpoint_config,
-                reg_info,
+                rabbitmq_uri,
                 funcx_client_options,
                 results_ack_handler,
             )

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -537,12 +537,8 @@ class EndpointInterchange:
         if not self.initial_registration_complete:
             # Register the endpoint
             log.info("Running endpoint registration retry loop")
-            reg_info = retry_call(
-                self.register_endpoint, delay=10, max_delay=300, backoff=1.2
-            )
-            log.info(
-                "Endpoint registered with UUID: {}".format(reg_info["endpoint_id"])
-            )
+            retry_call(self.register_endpoint, delay=10, max_delay=300, backoff=1.2)
+            log.info(f"Endpoint registered with UUID: {self.endpoint_id}")
 
         self.initial_registration_complete = False
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -170,7 +170,6 @@ class EndpointInterchange:
         self.initial_registration_complete = False
 
         self.connection_params = reg_info
-        self.initial_registration_complete = True
 
         self.heartbeat_period = self.config.heartbeat_period
         self.heartbeat_threshold = self.config.heartbeat_threshold

--- a/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
@@ -60,10 +60,11 @@ def register_endpoint(funcx_client, endpoint_uuid, endpoint_dir, endpoint_name):
     log.debug("Attempting registration")
     log.debug(f"Trying with eid : {endpoint_uuid}")
 
-    pika_url = mock_register_endpoint(
+    reg_info = funcx_client.register_endpoint(
         endpoint_name, endpoint_uuid, endpoint_version=funcx_endpoint.__version__
     )
 
+    log.debug("RabbitMQ URI From WebService:", reg_info)
     # NOTE: While all registration info is saved to endpoint.json, only the
     # endpoint UUID is reused from this file. The latest forwarder URI is used
     # every time we fetch registration info and register
@@ -72,7 +73,7 @@ def register_endpoint(funcx_client, endpoint_uuid, endpoint_dir, endpoint_name):
             "endpoint_name": endpoint_name,
             # This is named endpoint_id for backward compatibility when
             # funcx-endpoint list is called
-            "pika_conn_info": pika_url,
+            "pika_conn_info": reg_info["rabbitMQ_URI"],
             "endpoint_id": endpoint_uuid,
         }
         json.dump(endpoint_info, fp)
@@ -82,5 +83,4 @@ def register_endpoint(funcx_client, endpoint_uuid, endpoint_dir, endpoint_name):
             )
         )
 
-    reg_info = pika.URLParameters(pika_url)
-    return reg_info
+    return pika.URLParameters(reg_info["rabbitMQ_URI"])

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -355,10 +355,11 @@ class Interchange:
         log.info(f"Setting working_dir: {working_dir}")
 
         self.provider.script_dir = working_dir
-        log.warning("*" * 50)
-        log.warning(f"PROVIDER channel  : {self.provider.channel}")
-        log.warning("*" * 50)
         if hasattr(self.provider, "channel"):
+            log.warning("*" * 50)
+            log.warning(f"PROVIDER channel  : {self.provider.channel}")
+            log.warning("*" * 50)
+
             self.provider.channel.script_dir = os.path.join(
                 working_dir, "submit_scripts"
             )

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -355,12 +355,15 @@ class Interchange:
         log.info(f"Setting working_dir: {working_dir}")
 
         self.provider.script_dir = working_dir
-        if hasattr(self.provider, "_channel"):
-            self.provider._channel.script_dir = os.path.join(
+        log.warning("*" * 50)
+        log.warning(f"PROVIDER channel  : {self.provider.channel}")
+        log.warning("*" * 50)
+        if hasattr(self.provider, "channel"):
+            self.provider.channel.script_dir = os.path.join(
                 working_dir, "submit_scripts"
             )
-            self.provider._channel.makedirs(
-                self.provider._channel.script_dir, exist_ok=True
+            self.provider.channel.makedirs(
+                self.provider.channel.script_dir, exist_ok=True
             )
             os.makedirs(self.provider.script_dir, exist_ok=True)
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -248,7 +248,7 @@ class Interchange:
         self.command_channel = self.context.socket(zmq.DEALER)
         self.command_channel.RCVTIMEO = 1000  # in milliseconds
         # self.command_channel.set_hwm(0)
-        log.info(f"Command channel on tcp://{client_address}:{client_ports[2]}")
+        log.info(f"Command _channel on tcp://{client_address}:{client_ports[2]}")
         self.command_channel.connect(f"tcp://{client_address}:{client_ports[2]}")
         log.info("Connected to forwarder")
 
@@ -355,12 +355,12 @@ class Interchange:
         log.info(f"Setting working_dir: {working_dir}")
 
         self.provider.script_dir = working_dir
-        if hasattr(self.provider, "channel"):
-            self.provider.channel.script_dir = os.path.join(
+        if hasattr(self.provider, "_channel"):
+            self.provider._channel.script_dir = os.path.join(
                 working_dir, "submit_scripts"
             )
-            self.provider.channel.makedirs(
-                self.provider.channel.script_dir, exist_ok=True
+            self.provider._channel.makedirs(
+                self.provider._channel.script_dir, exist_ok=True
             )
             os.makedirs(self.provider.script_dir, exist_ok=True)
 
@@ -641,7 +641,7 @@ class Interchange:
                 else:
                     log.error(
                         f"Received unsupported message type:{command.type} on "
-                        "command channel"
+                        "command _channel"
                     )
                     reply = BadCommand(f"Unknown command type: {command.type}")
 

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.6-dev"
+__version__ = "0.4.0"
 VERSION = __version__
 
 # app name to send as part of requests

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -49,6 +49,7 @@ class TestStart:
             endpoint_config.config,
             endpoint_id="mock_endpoint_id",
             keys_dir=keys_dir,
+            reg_info="amqp://guest:guest@localhost:5672/%2F",
             **optionals,
         )
 
@@ -91,6 +92,7 @@ class TestStart:
             endpoint_config.config,
             endpoint_id="mock_endpoint_id",
             keys_dir=keys_dir,
+            reg_info="amqp://guest:guest@localhost:5672/%2F",
             **optionals,
         )
 
@@ -145,6 +147,7 @@ class TestStart:
             endpoint_config.config,
             endpoint_id="mock_endpoint_id",
             keys_dir=keys_dir,
+            reg_info="amqp://guest:guest@localhost:5672/%2F",
             **optionals,
         )
 

--- a/funcx_endpoint/tests/integration/test_config.py
+++ b/funcx_endpoint/tests/integration/test_config.py
@@ -19,8 +19,10 @@ if __name__ == "__main__":
     print("Loading : ", config)
     # Set script dir
     config.provider.script_dir = working_dir
-    config.provider.channel.script_dir = os.path.join(working_dir, "submit_scripts")
-    config.provider.channel.makedirs(config.provider.channel.script_dir, exist_ok=True)
+    config.provider._channel.script_dir = os.path.join(working_dir, "submit_scripts")
+    config.provider._channel.makedirs(
+        config.provider._channel.script_dir, exist_ok=True
+    )
     os.makedirs(config.provider.script_dir, exist_ok=True)
 
     debug_opts = "--debug" if config.worker_debug else ""

--- a/funcx_endpoint/tests/test_ep_with_mock_service/test_interchange.py
+++ b/funcx_endpoint/tests/test_ep_with_mock_service/test_interchange.py
@@ -1,0 +1,133 @@
+import logging
+import multiprocessing
+import os
+import pickle
+import time
+
+import pika
+from parsl.providers import LocalProvider
+
+import funcx
+from funcx_endpoint.endpoint.interchange import EndpointInterchange
+from funcx_endpoint.endpoint.rabbit_mq import ResultQueueSubscriber, TaskQueuePublisher
+from funcx_endpoint.endpoint.register_endpoint import register_endpoint
+from funcx_endpoint.endpoint.results_ack import ResultsAckHandler
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+from funcx_endpoint.executors.high_throughput.messages import EPStatusReport, Task
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            provider=LocalProvider(
+                init_blocks=1,
+                min_blocks=0,
+                max_blocks=1,
+            ),
+        )
+    ],
+    funcx_service_address="https://api2.funcx.org/v2",
+)
+
+ENDPOINT_UUID = "9d8f5fcc-8d70-4d8e-a027-510ed6084b2e"
+
+LOG_FORMAT = "%(levelname) -10s %(asctime)s %(name) -20s %(lineno) -5d: %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+def make_mock_task():
+    task_buf = (
+        b"\x05TID=16a3b7d0-1c7f-4701-b3d5-dc22e8819f79;CID=RAW;"
+        b"85\n04\ngANYBgAAAGRvdWJsZXEAWCAAAABkZWYgZG91YmxlKHgpO"
+        b"gogICAgcmV0dXJuIHggKiAyCnEBhnEC\nLg==\n16\n00\ngANLAI"
+        b"VxAC4=\n12\n00\ngAN9cQAu\n"
+    )
+    task = Task(
+        task_id="16a3b7d0-1c7f-4701-b3d5-dc22e8819f79",
+        container_id="RAW",
+        task_buffer=task_buf,
+    )
+    return task
+
+
+def run_ix_process(reg_info):
+    results_ack_handler = ResultsAckHandler(endpoint_dir=".")
+    ix = EndpointInterchange(
+        config=config,
+        endpoint_id=ENDPOINT_UUID,
+        results_ack_handler=results_ack_handler,
+        reg_info=reg_info,
+    )
+
+    logger.warning("IX created, starting")
+    ix.start()
+    logger.warning("Done")
+
+
+def test_endpoint_interchange_against_rabbitmq():
+    """This test registers the endpoint against local RabbitMQ, and
+    uses mock tasks
+    """
+
+    # Use register_endpoint to get connection params
+    endpoint_name = "endpoint_foo"
+    fxc = funcx.FuncXClient()
+    reg_info = register_endpoint(
+        fxc,
+        endpoint_uuid=ENDPOINT_UUID,
+        endpoint_dir=os.getcwd(),
+        endpoint_name=endpoint_name,
+    )
+    assert isinstance(reg_info, pika.URLParameters)
+
+    # Start the service side components:
+    # Connect the TaskQueuePublisher and submit some mock tasks
+    task_q_out = TaskQueuePublisher(
+        endpoint_uuid=ENDPOINT_UUID, pika_conn_params=reg_info
+    )
+    task_q_out.connect()
+    logger.warning(f"Publishing task to {ENDPOINT_UUID}")
+
+    result_q_in = multiprocessing.Queue()
+    kill_event = multiprocessing.Event()
+    result_pub_proc = ResultQueueSubscriber(
+        pika_conn_params=reg_info, external_queue=result_q_in, kill_event=kill_event
+    )
+    result_pub_proc.start()
+
+    # Make a Task and publish it
+    task = make_mock_task()
+    task_q_out.publish(task.pack())
+
+    # Create the endpoint
+    ix_proc = multiprocessing.Process(target=run_ix_process, args=(reg_info,))
+    ix_proc.start()
+
+    time.sleep(2)
+    for _i in range(10):
+        from_ep, b_message = result_q_in.get()
+        # logger.warning(f"Got message: {message} from {from_ep}")
+
+        assert from_ep == ENDPOINT_UUID
+        try:
+            message = pickle.loads(b_message)
+        except Exception:
+            logger.warning(f"Unknown message: {b_message} from {from_ep}")
+            continue
+
+        if isinstance(message, EPStatusReport):
+            logger.warning(f"Got EPStatusMessage: {message}")
+            continue
+
+        if "result" in message or "exception" in message:
+            logger.warning(f"Received result/exception for {message['task_id']}")
+            assert message["task_id"] == task.task_id
+            logger.warning(f"Message : {message}")
+            break
+
+    logger.warning("Exiting...")
+    result_pub_proc.terminate()
+    task_q_out.close()
+    ix_proc.terminate()
+    ix_proc.join()

--- a/funcx_endpoint/tests/test_ep_with_mock_service/test_register_ep.py
+++ b/funcx_endpoint/tests/test_ep_with_mock_service/test_register_ep.py
@@ -1,0 +1,42 @@
+import json
+import os
+
+import pika
+
+import funcx
+import funcx_endpoint
+from funcx_endpoint.endpoint.register_endpoint import (
+    mock_register_endpoint,
+    register_endpoint,
+)
+
+ENDPOINT_UUID = "c65f076d-d731-406a-bb55-137faef153b8"
+
+
+def test_mock_register_ep():
+    res = mock_register_endpoint(
+        endpoint_name="foo",
+        endpoint_uuid=ENDPOINT_UUID,
+        endpoint_version=funcx_endpoint.__version__,
+    )
+
+    assert isinstance(res, pika.URLParameters)
+
+
+def test_register_ep():
+    endpoint_name = "endpoint_foo"
+    fxc = funcx.FuncXClient()
+    reg_info = register_endpoint(
+        fxc,
+        endpoint_uuid=ENDPOINT_UUID,
+        endpoint_dir=os.getcwd(),
+        endpoint_name=endpoint_name,
+    )
+    assert isinstance(reg_info, pika.URLParameters)
+
+    assert os.path.exists("../test_rabbit_mq/endpoint.json")
+
+    with open("../test_rabbit_mq/endpoint.json") as f:
+        data = json.load(f)
+        assert data["endpoint_uuid"] == ENDPOINT_UUID
+        assert data["endpoint_uuid"] == endpoint_name

--- a/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_endpoint.py
@@ -19,60 +19,44 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 ENDPOINT_ID = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
+CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/%2F")
 
 
 def start_task_q_subscriber(
-    endpoint_id: str,
-    out_queue: multiprocessing.Queue,
-    disconnect_event: multiprocessing.Event,
+    out_queue: multiprocessing.Queue, disconnect_event: multiprocessing.Event
 ):
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
     task_q = TaskQueueSubscriber(
-        endpoint_uuid=endpoint_id, pika_conn_params=service_params
+        CONN_PARAMS,
+        external_queue=out_queue,
+        kill_event=disconnect_event,
+        endpoint_uuid=ENDPOINT_ID,
     )
-    task_q.connect()
-    task_q.run(queue=out_queue, disconnect_event=disconnect_event)
+    task_q.start()
     return task_q
 
 
 def start_result_q_publisher(endpoint_id) -> ResultQueuePublisher:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
     result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id, pika_conn_params=service_params
+        endpoint_id=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     result_pub.connect()
     return result_pub
 
 
 def start_task_q_publisher(endpoint_id: str) -> TaskQueuePublisher:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
-    )
-
     task_q_pub = TaskQueuePublisher(
-        endpoint_name=endpoint_id, pika_conn_params=service_params
+        endpoint_uuid=endpoint_id, pika_conn_params=CONN_PARAMS
     )
     task_q_pub.connect()
     return task_q_pub
 
 
 def start_result_q_subscriber(queue: multiprocessing.Queue) -> ResultQueueSubscriber:
-    cred = pika.PlainCredentials("guest", "guest")
-    service_params = pika.ConnectionParameters(
-        host="localhost", heartbeat=60, port=5672, credentials=cred
+    kill_event = multiprocessing.Event()
+    result_q = ResultQueueSubscriber(
+        pika_conn_params=CONN_PARAMS, external_queue=queue, kill_event=kill_event
     )
-
-    result_q = ResultQueueSubscriber(pika_conn_params=service_params)
-    result_q.run(queue=queue)
+    result_q.start()
     return result_q
 
 
@@ -81,10 +65,8 @@ def run_async_service():
     task_q_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
     task_q_pub.queue_purge()
     result_q = multiprocessing.Queue()
-    result_q_proc = multiprocessing.Process(
-        target=start_result_q_subscriber, args=(result_q,)
-    )
-    result_q_proc.start()
+    result_q_proc = start_result_q_subscriber(result_q)
+
     logger.warning("SERVICE: Here")
     for _i in range(10):
         try:
@@ -96,19 +78,23 @@ def run_async_service():
             logger.warning("SERVICE: Trying to publish message")
             task_q_pub.publish(b_message)
             logger.warning(f"SERVICE: Published message: {message}")
-            from_ep, reply_message = result_q.get(timeout=5)
+            from_ep, reply_message = result_q.get(timeout=2)
             logger.warning(f"SERVICE: Received result message: {reply_message}")
 
             assert from_ep == ENDPOINT_ID
             assert reply_message == b_message
+        except (AssertionError, TimeoutError):
+            raise
         except Exception:
+            # Catching and logging so that errors from this process are logged
+            # rather than silently ignored upon process fail/exit
             logger.exception("Caught error")
+        finally:
+            result_q_proc.terminate()
+            task_q_pub.close()
 
-    result_q_proc.terminate()
-    task_q_pub.close()
 
-
-# @pytest.mark.skip
+@pytest.mark.skip
 def test_mock_endpoint():
 
     service = multiprocessing.Process(target=run_async_service, args=())
@@ -118,22 +104,15 @@ def test_mock_endpoint():
     disconnect_event = multiprocessing.Event()
 
     # Listen for 10 messages
-    proc = multiprocessing.Process(
-        target=start_task_q_subscriber,
-        args=(
-            ENDPOINT_ID,
-            tasks_out,
-            disconnect_event,
-        ),
-    )
-    proc.start()
+    proc = start_task_q_subscriber(tasks_out, disconnect_event)
     result_q_pub = start_result_q_publisher(ENDPOINT_ID)
+    result_q_pub._queue_purge()
 
     logger.warning("ENDPOINT: Here")
 
     for _i in range(10):
         logger.warning("ENDPOINT: Waiting for task: ")
-        b_message = tasks_out.get(timeout=5)
+        b_message = tasks_out.get(timeout=2)
         logger.warning(f"ENDPOINT: Received message: {b_message}")
         logger.warning("ENDPOINT: Publishing message to results_q")
         result_q_pub.publish(b_message)
@@ -142,7 +121,6 @@ def test_mock_endpoint():
     proc.terminate()
 
 
-@pytest.mark.skip
 def test_simple_roundtrip():
 
     task_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
@@ -152,21 +130,10 @@ def test_simple_roundtrip():
     task_q, result_q = multiprocessing.Queue(), multiprocessing.Queue()
     task_fail_event = multiprocessing.Event()
 
-    task_q_proc = multiprocessing.Process(
-        target=start_task_q_subscriber,
-        args=(
-            ENDPOINT_ID,
-            task_q,
-            task_fail_event,
-        ),
+    task_q_proc = start_task_q_subscriber(
+        out_queue=task_q, disconnect_event=task_fail_event
     )
-    task_q_proc.start()
-
-    result_q_proc = multiprocessing.Process(
-        target=start_result_q_subscriber, args=(result_q,)
-    )
-
-    result_q_proc.start()
+    result_q_proc = start_result_q_subscriber(result_q)
 
     message = f"Hello {random.randint(0,2**10)}".encode()
     logger.warning(f"Sending message: {message}")
@@ -178,7 +145,7 @@ def test_simple_roundtrip():
     result_message = result_q.get(timeout=2)
 
     assert result_message == (ENDPOINT_ID, message)
-
+    logger.warning("Roundtrip complete")
     task_pub.close()
     result_pub.close()
     task_q_proc.terminate()

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -146,7 +146,7 @@ class FuncxWebClient(globus_sdk.BaseClient):
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data = {
-            "endpoint_id": endpoint_name,
+            "endpoint_name": endpoint_name,
             "endpoint_uuid": str(endpoint_id),
             "version": endpoint_version,
         }

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -146,7 +146,7 @@ class FuncxWebClient(globus_sdk.BaseClient):
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data = {
-            "endpoint_name": endpoint_name,
+            "endpoint_id": endpoint_name,
             "endpoint_uuid": str(endpoint_id),
             "version": endpoint_version,
         }


### PR DESCRIPTION
# Problem

The endpoint needs to retrieve a RabbitMQ connection URI from the web service

This is part of the overall solution for [Shortcut Issue 1344](https://app.shortcut.com/funcx/story/13344/create-integration-environment-for-rabbitmq-based-forwarder).

This PR is intended to be combined with the [RabbitMQ CI Env Branch](https://github.com/globusonline/funcx-services/compare/rabbitmq_ci_env)

# Approach
Assume that the web service returns a dict from the register_endpoint POST that includes a property called `rabbitMQ_URI` this will contain a string with the complete RabbitMQ URI