### PR TITLE
Cleanup TaskQueueSubscriber stop method

### DIFF
--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -177,13 +177,9 @@ def test_exclusive_subscriber(conn_params):
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
-    proc1.stop(block=False)
-    proc2.stop(block=False)
-    proc1.wait_until_stopped()
-    proc2.wait_until_stopped()
-
+    proc1.stop()
+    proc2.stop()
     task_q_pub.close()
-    return
 
 
 def test_combined_pub_sub_latency(conn_params, count=10):

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -60,9 +60,7 @@ def test_synch(conn_params, count=10):
     for i in range(count):
         message = tasks_out.get()
         assert messages[i] == message
-
-    proc.terminate()
-    return
+    proc.stop()
 
 
 def fallible_callback(queue: multiprocessing.Queue, message: bytes):
@@ -107,7 +105,7 @@ def test_subscriber_recovery(conn_params):
         assert messages[i] == message
 
     # Terminate the connection
-    proc.terminate()
+    proc.stop()
     logging.warning("Disconnected")
 
     # Launch 10 messages
@@ -123,16 +121,18 @@ def test_subscriber_recovery(conn_params):
         messages[i] = b_message
 
     # Listen for the messages on a new connection
+    disconnect_event.clear()
     proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
-    logging.warning("Proc started")
+
+    logging.warning("Replacement proc started")
     for i in range(10):
+        logging.warning("getting message")
         message = tasks_out.get()
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
-    proc.terminate()
+    proc.stop()
     task_q_pub.close()
-    return
 
 
 def test_exclusive_subscriber(conn_params):
@@ -177,8 +177,10 @@ def test_exclusive_subscriber(conn_params):
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
-    proc1.terminate()
-    proc2.terminate()
+    proc1.stop(block=False)
+    proc2.stop(block=False)
+    proc1.wait_until_stopped()
+    proc2.wait_until_stopped()
 
     task_q_pub.close()
     return
@@ -210,7 +212,7 @@ def test_combined_pub_sub_latency(conn_params, count=10):
     )
 
     task_q_pub.close()
-    proc.terminate()
+    proc.stop()
 
 
 def test_combined_throughput(conn_params, count=1000):
@@ -243,4 +245,4 @@ def test_combined_throughput(conn_params, count=1000):
         )
 
     task_q_pub.close()
-    proc.terminate()
+    proc.stop()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -24,7 +24,7 @@ def test_terminate(conn_params):
     task_q.start()
     time.sleep(3)
     logging.warning("Calling terminate")
-    task_q.close()
+    task_q.stop()
     with pytest.raises(ValueError):
         # Expected to raise ValueError since the process should
         # be terminated at this point from the close() call


### PR DESCRIPTION
I first replaced `close()` with `stop()` and tried switching all of the tests to use it. That led to test hangs, so I ended up making a few other changes in the course of clearing that up.
I think the changes are positive and worth keeping, but I'm happy to back anything out if necessary.

---

- Instead of redefining `close()`, add a new method, `stop()`, which is responsible for terminating clenaly from the parent and invoking `close()` as one of the steps
- Use a ternary enum instead of `_closing = t/f` to describe a subscriber as "parent process", "running child" or "closing child". Call this the `status` and use it to track `closing`
- Define a `_shutdown()` method which handles clean teardown, including closing the connection to the MP queue and joining the background thread to ensure the queue has data flushed
- Update tests and fix one test

The enum could be done with an optional bool (true/false/null), but then we'd need to explain that 'null' means 'parent process'. It's clearer to use an enum.

Most of the test updates are just `close()` -> `stop()`. However, two changes are interesting:

1. `stop(block=False); wait_until_stopped()` is used in one test to allow parallel shutdown of multiple subscriber objects following a typical "quit and join" pattern

2. test_subscriber_recovery was reusing the same disconnect event between multiple subscriber instances, but without clearing it inbetween