### PR TITLE
Improve test robustness for rabbitmq tests

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -210,14 +210,15 @@ class EndpointInterchange:
                 f" as {endpoint_uuid}"
             )
             task_q_proc = TaskQueueSubscriber(
-                pika_conn_params=connection_params,
+                conn_params=connection_params,
                 external_queue=pending_task_queue,
                 kill_event=quiesce_event,
-                endpoint_uuid=endpoint_uuid,
+                endpoint_id=endpoint_uuid,
             )
             task_q_proc.start()
         except Exception:
             log.exception("Unhandled exception in TaskQueueSubscriber")
+            raise
 
         return task_q_proc
 
@@ -341,7 +342,7 @@ class EndpointInterchange:
 
         self.results_outgoing = ResultQueuePublisher(
             endpoint_id=self.endpoint_id,
-            pika_conn_params=self.result_q_connection_params["pika_conn_params"],
+            conn_params=self.result_q_connection_params["pika_conn_params"],
         )
 
         self.results_outgoing.connect()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/__init__.py
@@ -1,3 +1,4 @@
+from .base import RabbitPublisherStatus, SubscriberProcessStatus
 from .result_queue_publisher import ResultQueuePublisher
 from .result_queue_subscriber import ResultQueueSubscriber
 from .task_queue_publisher import TaskQueuePublisher
@@ -8,4 +9,6 @@ __all__ = (
     "TaskQueuePublisher",
     "ResultQueuePublisher",
     "ResultQueueSubscriber",
+    "RabbitPublisherStatus",
+    "SubscriberProcessStatus",
 )

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/base.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/base.py
@@ -1,0 +1,22 @@
+"""
+common elements to rabbitmq tools
+"""
+
+import enum
+
+
+class RabbitPublisherStatus(enum.Enum):
+    closed = enum.auto()
+    connected = enum.auto()
+
+
+# a status enum to describe the different states of the subscriber subprocs
+class SubscriberProcessStatus(enum.Enum):
+    # the object is in the parent process, it has no notion of the process state other
+    # than that it is none of the other values
+    parent = enum.auto()
+    # the process is in the child proc and should try to start or continue to run
+    running = enum.auto()
+    # the process is in the child proc and is closing down, it should not try to
+    # reconnect or otherwise handle failures
+    closing = enum.auto()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -2,6 +2,8 @@ import logging
 
 import pika
 
+from .base import RabbitPublisherStatus
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,35 +19,38 @@ class ResultQueuePublisher:
 
     def __init__(
         self,
+        *,
         endpoint_id: str,
-        pika_conn_params: pika.connection.Parameters,
+        conn_params: pika.connection.Parameters,
     ):
         """
         Parameters
         ----------
         endpoint_uuid: str
             Endpoint UUID string used to identify the endpoint
-        pika_conn_params: pika.connection.Parameters
+        conn_params: pika.connection.Parameters
             Pika connection parameters to connect to RabbitMQ
         """
         self.endpoint_id = endpoint_id
-        self.params = pika_conn_params
-        if self.params.heartbeat is None:
+        self.conn_params = conn_params
+        if self.conn_params.heartbeat != 0:
             # result_q is blocking, and shouldn't use heartbeats
-            self.params.heartbeat = 0
+            self.conn_params.heartbeat = 0
 
         self._channel = None
         self._connection = None
+        # start closed ("connected" after connect)
+        self.status = RabbitPublisherStatus.closed
 
         self.routing_key = f"{self.endpoint_id}.results"
 
-    def connect(self) -> pika.BlockingConnection:
+    def connect(self) -> None:
         """Connect
 
         :rtype: pika.BlockingConnection
         """
-        logger.info(f"Connecting to {self.params}")
-        self._connection = pika.BlockingConnection(self.params)
+        logger.info(f"Connecting to {self.conn_params}")
+        self._connection = pika.BlockingConnection(self.conn_params)
         self._channel = self._connection.channel()
         self._channel.confirm_delivery()
         self._channel.exchange_declare(
@@ -58,8 +63,7 @@ class ResultQueuePublisher:
             exchange=self.EXCHANGE_NAME,
             routing_key=self.GLOBAL_ROUTING_KEY,
         )
-
-        return self._connection
+        self.status = RabbitPublisherStatus.connected
 
     def publish(self, message: bytes) -> None:
         """Publish message to RabbitMQ with the routing key to identify the message source
@@ -80,3 +84,4 @@ class ResultQueuePublisher:
     def close(self):
         self._channel.close()
         self._connection.close()
+        self.status = RabbitPublisherStatus.closed

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -48,9 +48,7 @@ TEST_REQUIRES = [
     "responses",
     "pytest>=5.2",
     "coverage>=5.2",
-    "codecov==2.1.8",
     "pytest-mock==3.2.0",
-    "flake8>=3.8",
 ]
 
 

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange_with_rabbit.py
@@ -98,8 +98,8 @@ def test_endpoint_interchange_against_rabbitmq(
     # Start the service side components:
     # Connect the TaskQueuePublisher and submit some mock tasks
     task_q_out = TaskQueuePublisher(
-        endpoint_uuid=endpoint_uuid,
-        pika_conn_params=task_queue_info["pika_conn_params"],
+        endpoint_id=endpoint_uuid,
+        conn_params=task_queue_info["pika_conn_params"],
     )
     task_q_out.connect()
     task_q_out._channel.queue_purge(task_q_out.queue_name)
@@ -107,7 +107,7 @@ def test_endpoint_interchange_against_rabbitmq(
 
     result_q_in = multiprocessing.Queue()
     result_sub_proc = ResultQueueSubscriber(
-        pika_conn_params=result_queue_info["pika_conn_params"],
+        conn_params=result_queue_info["pika_conn_params"],
         external_queue=result_q_in,
     )
     result_sub_proc.start()

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -1,17 +1,38 @@
+from __future__ import annotations
+
+import multiprocessing
+import uuid
+
 import pika
 import pytest
 
-G_CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
+from funcx_endpoint.endpoint.rabbit_mq import (
+    RabbitPublisherStatus,
+    ResultQueuePublisher,
+    ResultQueueSubscriber,
+    TaskQueuePublisher,
+    TaskQueueSubscriber,
+)
 
 
-@pytest.fixture()
-def conn_params():
-    return G_CONN_PARAMS
+@pytest.fixture(scope="session")
+def default_endpoint_id():
+    return str(uuid.UUID(int=1))
+
+
+@pytest.fixture(scope="session")
+def other_endpoint_id():
+    return str(uuid.UUID(int=2))
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_conn_url():
+    return "amqp://guest:guest@localhost:5672/"
 
 
 @pytest.fixture(autouse=True, scope="session")
-def ensure_result_queue():
-    connection = pika.BlockingConnection(G_CONN_PARAMS)
+def ensure_result_queue(rabbitmq_conn_url):
+    connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_conn_url))
     channel = connection.channel()
     channel.exchange_declare(
         exchange="results",
@@ -26,3 +47,142 @@ def ensure_result_queue():
     channel.close()
     connection.close()
     return
+
+
+@pytest.fixture()
+def conn_params(rabbitmq_conn_url):
+    return pika.URLParameters(rabbitmq_conn_url)
+
+
+@pytest.fixture
+def running_subscribers(request):
+    run_list = []
+
+    def cleanup():
+        for x in run_list:
+            try:  # cannot check is_alive on closed proc
+                is_alive = x.is_alive()
+            except ValueError:
+                is_alive = False
+            if is_alive:
+                try:
+                    x.stop()
+                except Exception as e:
+                    x.terminate()
+                    raise Exception(
+                        f"{x.__class__.__name__} did not shutdown correctly"
+                    ) from e
+
+    request.addfinalizer(cleanup)
+    return run_list
+
+
+@pytest.fixture
+def start_task_q_subscriber(running_subscribers, conn_params, default_endpoint_id):
+    def func(
+        *,
+        endpoint_id: str | None = None,
+        queue: multiprocessing.Queue | None = None,
+        kill_event: multiprocessing.Event | None = None,
+        override_params: pika.connection.Parameters | None = None,
+    ):
+        if endpoint_id is None:
+            endpoint_id = default_endpoint_id
+        if kill_event is None:
+            kill_event = multiprocessing.Event()
+        if queue is None:
+            queue = multiprocessing.Queue()
+        task_q = TaskQueueSubscriber(
+            conn_params=conn_params if override_params is None else override_params,
+            external_queue=queue,
+            kill_event=kill_event,
+            endpoint_id=endpoint_id,
+        )
+        task_q.start()
+        running_subscribers.append(task_q)
+        return task_q
+
+    return func
+
+
+@pytest.fixture
+def start_result_q_subscriber(running_subscribers, conn_params):
+    def func(
+        *,
+        queue: multiprocessing.Queue | None = None,
+        kill_event: multiprocessing.Event | None = None,
+        override_params: pika.connection.Parameters | None = None,
+    ):
+        if kill_event is None:
+            kill_event = multiprocessing.Event()
+        if queue is None:
+            queue = multiprocessing.Queue()
+        result_q = ResultQueueSubscriber(
+            conn_params=conn_params if override_params is None else override_params,
+            external_queue=queue,
+            kill_event=kill_event,
+        )
+        result_q.start()
+        running_subscribers.append(result_q)
+        return result_q
+
+    return func
+
+
+@pytest.fixture
+def running_publishers(request):
+    run_list = []
+
+    def cleanup():
+        for x in run_list:
+            if x.status is RabbitPublisherStatus.connected:
+                x.close()
+
+    request.addfinalizer(cleanup)
+    return run_list
+
+
+@pytest.fixture
+def start_result_q_publisher(running_publishers, conn_params, default_endpoint_id):
+    def func(
+        *,
+        endpoint_id: str | None = None,
+        override_params: pika.connection.Parameters | None = None,
+        queue_purge: bool = True,
+    ):
+        if endpoint_id is None:
+            endpoint_id = default_endpoint_id
+        result_pub = ResultQueuePublisher(
+            endpoint_id=endpoint_id,
+            conn_params=conn_params if override_params is None else override_params,
+        )
+        result_pub.connect()
+        if queue_purge:  # Make sure queue is empty
+            result_pub._channel.queue_purge("results")
+        running_publishers.append(result_pub)
+        return result_pub
+
+    return func
+
+
+@pytest.fixture
+def start_task_q_publisher(running_publishers, conn_params, default_endpoint_id):
+    def func(
+        *,
+        endpoint_id: str | None = None,
+        override_params: pika.connection.Parameters | None = None,
+        queue_purge: bool = True,
+    ):
+        if endpoint_id is None:
+            endpoint_id = default_endpoint_id
+        task_pub = TaskQueuePublisher(
+            endpoint_id=endpoint_id,
+            conn_params=conn_params if override_params is None else override_params,
+        )
+        task_pub.connect()
+        if queue_purge:  # Make sure queue is empty
+            task_pub._channel.queue_purge(task_pub.queue_name)
+        running_publishers.append(task_pub)
+        return task_pub
+
+    return func

--- a/funcx_endpoint/tests/test_rabbit_mq/test_rabbit_e2e.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_rabbit_e2e.py
@@ -1,116 +1,21 @@
-import json
 import logging
 import multiprocessing
 import random
-import uuid
-
-import pika
-
-from funcx_endpoint.endpoint.rabbit_mq import (
-    ResultQueuePublisher,
-    ResultQueueSubscriber,
-    TaskQueuePublisher,
-    TaskQueueSubscriber,
-)
-
-ENDPOINT_ID = "231fab4e-630a-4d76-bbbb-cf0b4aedbdf9"
 
 
-def start_task_q_subscriber(
-    endpoint_id: str,
-    out_queue: multiprocessing.Queue,
-    disconnect_event: multiprocessing.Event,
-    conn_params: pika.connection.Parameters,
+def test_simple_roundtrip(
+    start_task_q_publisher,
+    start_task_q_subscriber,
+    start_result_q_subscriber,
+    start_result_q_publisher,
+    default_endpoint_id,
 ):
-
-    task_q = TaskQueueSubscriber(
-        conn_params,
-        external_queue=out_queue,
-        kill_event=disconnect_event,
-        endpoint_uuid=endpoint_id,
-    )
-    task_q.start()
-    return task_q
-
-
-def start_result_q_publisher(
-    endpoint_id, conn_params: pika.connection.Parameters
-) -> ResultQueuePublisher:
-    result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id, pika_conn_params=conn_params
-    )
-    result_pub.connect()
-    return result_pub
-
-
-def start_task_q_publisher(
-    endpoint_id: str, conn_params: pika.connection.Parameters
-) -> TaskQueuePublisher:
-    task_q_pub = TaskQueuePublisher(
-        endpoint_uuid=endpoint_id, pika_conn_params=conn_params
-    )
-    task_q_pub.connect()
-    return task_q_pub
-
-
-def start_result_q_subscriber(
-    queue: multiprocessing.Queue, conn_params: pika.connection.Parameters
-) -> ResultQueueSubscriber:
-    result_q = ResultQueueSubscriber(pika_conn_params=conn_params, external_queue=queue)
-    result_q.start()
-    return result_q
-
-
-def run_async_service():
-    """Run a task_q_publisher and result_q_subscriber mocking a simple service"""
-    task_q_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)
-    result_q = multiprocessing.Queue()
-    result_q_proc = multiprocessing.Process(
-        target=start_result_q_subscriber, args=(result_q,)
-    )
-    result_q_proc.start()
-    logging.warning("SERVICE: Here")
-    for _i in range(10):
-        try:
-            message = {
-                "task_id": str(uuid.uuid4()),
-                "task_buf": "TASKBUF TASKBUF",
-            }
-            b_message = json.dumps(message).encode()
-            logging.warning("SERVICE: Trying to publish message")
-            task_q_pub.publish(b_message)
-            logging.warning(f"SERVICE: Published message: {message}")
-            from_ep, reply_message = result_q.get(timeout=5)
-            logging.warning(f"SERVICE: Received result message: {reply_message}")
-
-            assert from_ep == ENDPOINT_ID
-            assert reply_message == b_message
-        except Exception:
-            logging.exception("Caught error")
-
-    result_q_proc.terminate()
-    task_q_pub.close()
-
-
-def test_simple_roundtrip(conn_params: pika.connection.Parameters):
-    task_pub = start_task_q_publisher(endpoint_id=ENDPOINT_ID, conn_params=conn_params)
-    task_pub._channel.queue_purge(task_pub.queue_name)
-    result_pub = start_result_q_publisher(
-        endpoint_id=ENDPOINT_ID, conn_params=conn_params
-    )
-    result_pub._channel.queue_purge("results")
+    task_pub = start_task_q_publisher()
+    result_pub = start_result_q_publisher()
     task_q, result_q = multiprocessing.Queue(), multiprocessing.Queue()
-    task_fail_event = multiprocessing.Event()
 
-    task_q_proc = start_task_q_subscriber(
-        ENDPOINT_ID,
-        out_queue=task_q,
-        disconnect_event=task_fail_event,
-        conn_params=conn_params,
-    )
-
-    result_q_proc = start_result_q_subscriber(result_q, conn_params=conn_params)
+    start_task_q_subscriber(queue=task_q)
+    start_result_q_subscriber(queue=result_q)
 
     message = f"Hello {random.randint(0,2**10)}".encode()
     logging.warning(f"Sending message: {message}")
@@ -121,9 +26,4 @@ def test_simple_roundtrip(conn_params: pika.connection.Parameters):
     result_pub.publish(task_message)
     result_message = result_q.get(timeout=2)
 
-    assert result_message == (ENDPOINT_ID, message)
-
-    task_pub.close()
-    result_pub.close()
-    task_q_proc.terminate()
-    result_q_proc.terminate()
+    assert result_message == (default_endpoint_id, message)

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -4,57 +4,27 @@ import time
 import pika
 import pytest
 
-from funcx_endpoint.endpoint.rabbit_mq import ResultQueuePublisher
 
-endpoint_id_1 = "a9aec9a1-ff86-4d6a-a5b8-5bb160746b5c"
-RABBIT_MQ_URL = "amqp://guest:guest@localhost:5672/"
-
-
-def test_no_heartbeat(conn_params):
+@pytest.mark.parametrize("use_heartbeat", [None, 1])
+def test_no_heartbeat(start_result_q_publisher, conn_params, use_heartbeat):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
     conn_params = copy.deepcopy(conn_params)
-    conn_params._heartbeat = None  # Ensure heartbeat disabled
-    conn_params._blocked_connection_timeout = 2
+    conn_params.heartbeat = use_heartbeat
+    conn_params.blocked_connection_timeout = 2
 
-    result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
-    )
-    result_pub.connect()
+    result_pub = start_result_q_publisher(override_params=conn_params)
 
-    x = result_pub.publish(b"Hello")
-    assert x is None
+    # simply ensure no crash between two message sends
+    result_pub.publish(b"Hello")
     time.sleep(5)
-    x = result_pub.publish(b"Hello")
+    result_pub.publish(b"Hello")
 
 
-def test_heartbeat_failure(conn_params):
-    """Confirm that result_q_publisher does not disconnect when delay
-    between messages exceed heartbeat period
-    """
-    conn_params = copy.deepcopy(conn_params)
-    conn_params._heartbeat = 1
-    conn_params._blocked_connection_timeout = 2
-
-    result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
-    )
-    result_pub.connect()
-
-    x = result_pub.publish(b"Hello")
-    assert x is None
-    time.sleep(5)
-    with pytest.raises(pika.exceptions.StreamLostError):
-        x = result_pub.publish(b"Hello")
-
-
-def test_fail_after_manual_close(conn_params):
+def test_fail_after_manual_close(start_result_q_publisher):
     """Confirm that result_q_publisher raises an error following a manual conn close"""
-    result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
-    )
-    result_pub.connect()
+    result_pub = start_result_q_publisher()
 
     result_pub.publish(b"Hello")
     result_pub.close()
@@ -62,19 +32,8 @@ def test_fail_after_manual_close(conn_params):
         result_pub.publish(b"Hello")
 
 
-def test_reconnect_after_disconnect(conn_params):
-    """Confirm that result_q_publisher does not disconnect when delay
-    between messages exceed heartbeat period
-    """
-    conn_params = copy.deepcopy(conn_params)
-    conn_params._heartbeat = 1
-    conn_params._blocked_connection_timeout = 2
-
-    result_pub = ResultQueuePublisher(
-        endpoint_id=endpoint_id_1, pika_conn_params=conn_params
-    )
-    result_pub.connect()
-
+def test_reconnect_after_disconnect(start_result_q_publisher):
+    result_pub = start_result_q_publisher()
     result_pub.publish(b"Hello")
     result_pub.close()
     result_pub.connect()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -1,128 +1,71 @@
 import json
 import logging
 import multiprocessing
-import random
 import time
 import uuid
 
-from funcx.serialize import FuncXSerializer
-from funcx_endpoint.endpoint.rabbit_mq import TaskQueuePublisher, TaskQueueSubscriber
 
-ENDPOINT_ID = "task-q-tests"
-
-
-def start_task_q_publisher(conn_params):
-    task_q = TaskQueuePublisher(endpoint_uuid=ENDPOINT_ID, pika_conn_params=conn_params)
-    task_q.connect()
-    return task_q
-
-
-def start_task_q_subscriber(
-    out_queue: multiprocessing.Queue,
-    disconnect_event: multiprocessing.Event,
-    conn_params,
-):
-    task_q = TaskQueueSubscriber(
-        conn_params,
-        external_queue=out_queue,
-        kill_event=disconnect_event,
-        endpoint_uuid=ENDPOINT_ID,
-    )
-    task_q.start()
-    return task_q
-
-
-def test_synch(conn_params, count=10):
+def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
 
     """Open publisher, and publish to task_q, then open subscriber a fetch"""
-    fxs = FuncXSerializer()
+    task_q_pub = start_task_q_publisher()
 
-    task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
-    messages = {}
+    messages = []
     for i in range(count):
-        data = list(range(10))
-        message = {
-            "task_id": str(uuid.uuid4()),
-            "result": fxs.serialize(data),
-        }
-        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        message = {"task_id": str(uuid.uuid4()), "result": f"foo-{i}"}
+        b_message = json.dumps(message).encode()
+        messages.append(b_message)
         task_q_pub.publish(b_message)
-        messages[i] = b_message
 
-    task_q_pub.close()
     logging.warning(f"Published {count} messages, closing task_q_pub")
     logging.warning("Starting task_q_subscriber")
-    tasks_out = multiprocessing.Queue()
-    disconnect_event = multiprocessing.Event()
 
-    proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
+    tasks_out = multiprocessing.Queue()
+    start_task_q_subscriber(queue=tasks_out)
     for i in range(count):
         message = tasks_out.get()
         assert messages[i] == message
-    proc.stop()
 
 
-def fallible_callback(queue: multiprocessing.Queue, message: bytes):
-    logging.warning("In callback")
-    x = random.randint(1, 10)
-    logging.warning(f"{x} > 7")
-    if x >= 7:
-        raise ValueError
-    else:
-        logging.warning(f"Got message: {message}")
-        queue.put(message)
-    return
-
-
-def test_subscriber_recovery(conn_params):
+def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
     """Subscriber terminates after 10 messages, and reconnects."""
-    fxs = FuncXSerializer()
-    task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
+    task_q_pub = start_task_q_publisher()
 
     # Launch 10 messages
-    messages = {}
+    messages = []
     for i in range(10):
-        data = list(range(10))
-        message = {
-            "task_id": str(uuid.uuid4()),
-            "result": fxs.serialize(data),
-        }
-        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        message = {"task_id": str(uuid.uuid4()), "result": f"foo-{i}"}
+        b_message = json.dumps(message).encode()
         task_q_pub.publish(b_message)
-        messages[i] = b_message
-
-    tasks_out = multiprocessing.Queue()
-    disconnect_event = multiprocessing.Event()
+        messages.append(b_message)
 
     # Listen for 10 messages
-    proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
+    tasks_out = multiprocessing.Queue()
+    kill_event = multiprocessing.Event()
+    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
     logging.warning("Proc started")
     for i in range(10):
         message = tasks_out.get()
-        logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
     # Terminate the connection
     proc.stop()
     logging.warning("Disconnected")
 
-    # Launch 10 messages
-    messages = {}
+    # Launch 10 more messages
+    messages = []
     for i in range(10):
-        data = list(range(10))
         message = {
             "task_id": str(uuid.uuid4()),
-            "result": fxs.serialize(data),
+            "result": f"bar-{i}",
         }
-        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        b_message = json.dumps(message).encode()
         task_q_pub.publish(b_message)
-        messages[i] = b_message
+        messages.append(b_message)
 
     # Listen for the messages on a new connection
-    disconnect_event.clear()
-    proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
+    kill_event.clear()
+    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
 
     logging.warning("Replacement proc started")
     for i in range(10):
@@ -131,68 +74,49 @@ def test_subscriber_recovery(conn_params):
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
-    proc.stop()
-    task_q_pub.close()
 
+def test_exclusive_subscriber(start_task_q_publisher, start_task_q_subscriber):
+    """2 subscribers connect, only first one should get any messages"""
+    task_q_pub = start_task_q_publisher()
 
-def test_exclusive_subscriber(conn_params):
-    """2 subscribers connect, only last one should get any messages"""
-    fxs = FuncXSerializer()
-    task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
-
-    # Start two subscribers to the same queue
+    # Start two subscribers on the same rabbit queue
     tasks_out_1, tasks_out_2 = multiprocessing.Queue(), multiprocessing.Queue()
-    disconnect_event_1, disconnect_event_2 = (
-        multiprocessing.Event(),
-        multiprocessing.Event(),
-    )
-    proc1 = start_task_q_subscriber(tasks_out_1, disconnect_event_1, conn_params)
+    start_task_q_subscriber(queue=tasks_out_1)
     time.sleep(1)
-    proc2 = start_task_q_subscriber(tasks_out_2, disconnect_event_2, conn_params)
+    start_task_q_subscriber(queue=tasks_out_2)
 
     logging.warning("TEST: Launching messages")
     # Launch 10 messages
-    messages = {}
+    messages = []
     for i in range(10):
-        data = list(range(10))
         message = {
             "task_id": str(uuid.uuid4()),
-            "result": fxs.serialize(data),
+            "result": f"foo={i}",
         }
-        b_message = json.dumps(message, ensure_ascii=True).encode("utf-8")
+        b_message = json.dumps(message).encode("utf-8")
         task_q_pub.publish(b_message)
-        messages[i] = b_message
+        messages.append(b_message)
     logging.warning("TEST: Launching messages")
 
-    # Give some delay
-    time.sleep(1)
+    # Confirm that the first subscriber received all the messages
+    for i in range(10):
+        message = tasks_out_1.get(timeout=1)
+        logging.warning(f"Got message: {message}")
+        assert messages[i] == message
 
     # Check that the second subscriber did not receive any messages
     assert tasks_out_2.empty()
 
-    # Confirm that the first subscriber received all the messages
-    for i in range(10):
-        message = tasks_out_1.get(timeout=5)
-        logging.warning(f"Got message: {message}")
-        assert messages[i] == message
 
-    proc1.stop()
-    proc2.stop()
-    task_q_pub.close()
-
-
-def test_combined_pub_sub_latency(conn_params, count=10):
+def test_perf_combined_pub_sub_latency(start_task_q_publisher, start_task_q_subscriber):
     """Confirm that messages published are received."""
-    task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
+    task_q_pub = start_task_q_publisher()
 
     tasks_out = multiprocessing.Queue()
-    disconnect_event = multiprocessing.Event()
-    proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
+    start_task_q_subscriber(queue=tasks_out)
 
     latency = []
-    for i in range(count):
+    for i in range(100):
         b_message = f"Hello World! {i}".encode()
         start_t = time.time()
         task_q_pub.publish(b_message)
@@ -206,39 +130,44 @@ def test_combined_pub_sub_latency(conn_params, count=10):
         f"Message latencies in milliseconds, min:{1000*min(latency):.2f}, "
         f"max:{1000*max(latency):.2f}, avg:{1000*avg_latency:.2f}"
     )
+    # average latency is expected to be below 5ms
+    # if it exceeds this, it means something is wrong
+    assert avg_latency < 0.005
 
-    task_q_pub.close()
-    proc.stop()
 
-
-def test_combined_throughput(conn_params, count=1000):
+def test_perf_combined_pub_sub_throughput(
+    start_task_q_publisher, start_task_q_subscriber
+):
     """Confirm that messages published are received."""
-    task_q_pub = start_task_q_publisher(conn_params)
-    task_q_pub._channel.queue_purge(task_q_pub.queue_name)  # Make sure queue is empty
-
+    task_q_pub = start_task_q_publisher()
     tasks_out = multiprocessing.Queue()
-    disconnect_event = multiprocessing.Event()
-    proc = start_task_q_subscriber(tasks_out, disconnect_event, conn_params)
+    start_task_q_subscriber(queue=tasks_out)
 
-    tput_at_size = {}
-    # Do 10 rounds of throughput measures
-    for i in range(10):
-        data_size = 2**i
-        b_message = bytes(data_size)
+    num_messages = 1000
+
+    for factor in range(10):
+        message_size = 2**factor
+        b_message = bytes(message_size)
+
         start_t = time.time()
-        for _i in range(count):
+        for _i in range(num_messages):
             task_q_pub.publish(b_message)
-        send_t = time.time() - start_t
-        for _i in range(count):
-            message_received = tasks_out.get()
-            assert len(message_received) >= data_size
-        delta = time.time() - start_t
-        tput_at_size[data_size] = {"send": send_t, "ttc": delta}
-    for size in tput_at_size:
-        logging.warning(
-            f"TTC throughput for {count} messages at {size}B = "
-            f"{count/tput_at_size[size]['ttc']:.2f}messages/s"
-        )
+        send_time = time.time() - start_t
 
-    task_q_pub.close()
-    proc.stop()
+        for _i in range(num_messages):
+            tasks_out.get()
+        total_time = time.time() - start_t
+
+        sent_per_second = num_messages / send_time
+        messages_per_second = num_messages / total_time
+
+        logging.warning(
+            f"task throughput for {num_messages} messages at {message_size}B = "
+            f"{messages_per_second:.2f} messages/s"
+        )
+        # each size should record at least 500 messages per second even in an
+        # untuned context with other processes running
+        # slower than that indicates that a serious performance regression has
+        # been introduced
+        assert sent_per_second > 500
+        assert messages_per_second > 500

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q_shutdown.py
@@ -1,33 +1,15 @@
 import logging
-import multiprocessing
 import time
 
 import pytest
 
-from funcx_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
 
-ENDPOINT_ID = "95abffc0-11cc-43cf-8b9b-c1acadf6f877"
-
-
-def test_terminate(conn_params):
-
-    out_queue = multiprocessing.Queue()
-    disconnect_event = multiprocessing.Event()
-
-    task_q = TaskQueueSubscriber(
-        conn_params,
-        external_queue=out_queue,
-        kill_event=disconnect_event,
-        endpoint_uuid=ENDPOINT_ID,
-    )
-    logging.warning("Start")
-    task_q.start()
-    time.sleep(3)
-    logging.warning("Calling terminate")
+def test_terminate(start_task_q_subscriber):
+    task_q = start_task_q_subscriber()
+    time.sleep(1)
     task_q.stop()
+    logging.warning("Calling terminate")
     with pytest.raises(ValueError):
         # Expected to raise ValueError since the process should
         # be terminated at this point from the close() call
         task_q.terminate()
-
-    return task_q


### PR DESCRIPTION
This is basically the cleanup I wanted on #701 but which I agreed to forgo for the sake of expediency.
It also converts arguments to be required keyword arguments and makes some names explicit in the spirit of "general cleanup".

---

Move all publisher and subscriber instantiation into dedicated fixture functions. The fixture funcs put created objects into "teardown lists" which have their relevant cleanup run at the end of each test in the form of a finalizer function.

As a result, there is no danger of resource leaks around these tests as every object is well accounted-for. The fixture funcs also fill in numerous default values like connection parameters and the default endpoint ID, so that tests are not required or expected to redundantly define the same or similar information.

When publisher objects are created, the relevant queue_purge call is made unless the helper is invoked with `queue_purge=False`, and more generally the setup for these tests is consolidated into these fixtures.

Tests are modified as necessary, and usually only as necessary. In a few cases, there is relevant cleanup to the test logic included. In particular, tests which use `FuncXSerializer` now use simple strings instead. The serializer object is not under test in these cases, and its use serves only to increase test runtime. Perf tests are mostly unchanged, but now include asserts for the minimum acceptable performance -- meaning that these are now tests which can fail, whereas they were not proper tests beforehand.

The ResultQueueSubscriber object -- which exists primarily for testing -- now has the full shutdown and wait behavior used in the TaskQueueSubscriber. This ensures that shutdown can happen gracefully during tests with no unexpected resource leaks.