### PR TITLE
Make endpoint logging format richer

### DIFF
--- a/changelog.d/20220315_132500_benc_benc_logfmt.rst
+++ b/changelog.d/20220315_132500_benc_benc_logfmt.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- Endpoint logs now have richer metadata on each log line
+
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -10,7 +10,12 @@ import typing as t
 
 log = logging.getLogger(__name__)
 
-DEFAULT_FORMAT="%(created)f %(asctime)s %(levelname)s %(processName)s-%(process)d %(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s %(message)s"
+DEFAULT_FORMAT = (
+    "%(created)f %(asctime)s %(levelname)s %(processName)s-%(process)d "
+    "%(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s "
+    "%(message)s"
+)
+
 
 class FuncxConsoleFormatter(logging.Formatter):
     """

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -10,6 +10,7 @@ import typing as t
 
 log = logging.getLogger(__name__)
 
+DEFAULT_FORMAT="%(created)f %(asctime)s %(levelname)s %(processName)s-%(process)d %(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s %(message)s"
 
 class FuncxConsoleFormatter(logging.Formatter):
     """
@@ -27,7 +28,7 @@ class FuncxConsoleFormatter(logging.Formatter):
     def __init__(
         self,
         debug: bool = False,
-        fmt: str = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s] %(message)s",
+        fmt: str = DEFAULT_FORMAT,
         datefmt: str = "%Y-%m-%d %H:%M:%S",
     ) -> None:
         super().__init__()
@@ -57,10 +58,7 @@ def _get_file_dict_config(logfile: str, console_enabled: bool, debug: bool) -> d
                 "debug": debug,
             },
             "filefmt": {
-                "format": (
-                    "%(asctime)s.%(msecs)03d "
-                    "%(name)s:%(lineno)d [%(levelname)s] %(message)s"
-                ),
+                "format": DEFAULT_FORMAT,
                 "datefmt": "%Y-%m-%d %H:%M:%S",
             },
         },


### PR DESCRIPTION
This adds:

* a unix timestamp for machine readable processing of
log lines without needing to parse timestamps or be aware of
timezones. The existing human readable timestamp is preserved.

* process and thread names and IDs, and function name

These are intended to automatically add context on every log
line to eliminate the need for [SOME_THREAD] or [SOME_COMPONENT]
manual prefixes, so that that context is available on every
line.

This will make endpoint log files more verbose. However, this
commit is part of ongoing work to rationalise and reduce the
verbosity of endpoint logging.

Other commits will introduce more human-readable names on
processes and threads and remove [THESE_PREFIXES].

An example log line is:

1647345352.583025 2022-03-15 11:55:52 INFO MainProcess-20 Thread-4-140045822437120
funcx_endpoint.endpoint.interchange:340 _task_puller_loop [TASK_PULL_THREAD] Got
heartbeat from funcx-forwarder


## Type of change

- Code maintentance/cleanup
