### PR TITLE
Show task uuid rather than Python object repr in pull_tasks dispatch

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -453,7 +453,8 @@ class Manager:
                             )
                         )
                         log.debug(
-                            f"Task {task.task_id} pushed to task queue for type: {task_type}"
+                            f"Task {task.task_id} pushed to task queue "
+                            f"for type: {task_type}"
                         )
 
             else:

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -452,7 +452,7 @@ class Manager:
                                 self.outstanding_task_count
                             )
                         )
-                        log.debug(f"Task {task} pushed to a task queue {task_type}")
+                        log.debug(f"Task {task.task_id} pushed to task queue for type: {task_type}")
 
             else:
                 log.debug("[TASK_PULL_THREAD] No incoming tasks")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -452,7 +452,9 @@ class Manager:
                                 self.outstanding_task_count
                             )
                         )
-                        log.debug(f"Task {task.task_id} pushed to task queue for type: {task_type}")
+                        log.debug(
+                            f"Task {task.task_id} pushed to task queue for type: {task_type}"
+                        )
 
             else:
                 log.debug("[TASK_PULL_THREAD] No incoming tasks")


### PR DESCRIPTION
# Description

This replaces a relatively useless process level object ID with a global funcx task ID, which makes understanding which task this applies to easier.

## Type of change

- Code maintentance/cleanup
