### PR TITLE
Replace login as a built-in part of FuncXClient

### DIFF
--- a/changelog.d/20220318_213947_sirosen_login_manager.rst
+++ b/changelog.d/20220318_213947_sirosen_login_manager.rst
@@ -1,18 +1,28 @@
 Added
 ^^^^^
 
-- The ``FuncXClient`` now accepts a new boolean argument ``do_version_check``,
-  which can be used to suppress a call to the FuncX API on initialization. Use
-  as in ``FuncXClient(do_version_check=False)``. This may lead to faster
-  instantiation of clients in some cases.
+- The ``FuncXClient`` now accepts a new argument ``login_manager``, which is
+  expected to implement a protocol for providing authenticated http client
+  objects, login, and logout capabilities.
+
+- The login manager and its protocol are now defined and may be imported as in
+  ``from funcx.sdk.login_manager import LoginManager, LoginManagerProtocol``.
+  They are internal components but may be used to force a login or to implement
+  an alternative ``LoginManagerProtocol`` to customize authentication
+
+Deprecated
+^^^^^^^^^^
+
+- The following arguments to ``FuncXClient`` are deprecated and will emit
+  warnings if used: ``fx_authorizer``, ``search_authorizer``,
+  ``openid_authorizer``. The use-cases for these arguments are now satisfied by
+  the ability to pass a custom ``LoginManager`` to the client class, if desired.
 
 Removed
 ^^^^^^^
 
 - The following arguments to ``FuncXClient`` are no longer supported:
-  ``force_login``, ``fx_authorizer``, ``search_authorizer``,
-  ``openid_authorizer``. The use-cases for these arguments are now satisfied by
-  the ability to pass a custom ``LoginManager`` to the client class, if desired.
+  ``force_login``
 
 Changed
 ^^^^^^^

--- a/changelog.d/20220318_213947_sirosen_login_manager.rst
+++ b/changelog.d/20220318_213947_sirosen_login_manager.rst
@@ -1,0 +1,29 @@
+Added
+^^^^^
+
+- The ``FuncXClient`` now accepts a new boolean argument ``do_version_check``,
+  which can be used to suppress a call to the FuncX API on initialization. Use
+  as in ``FuncXClient(do_version_check=False)``. This may lead to faster
+  instantiation of clients in some cases.
+
+Removed
+^^^^^^^
+
+- The following arguments to ``FuncXClient`` are no longer supported:
+  ``force_login``, ``fx_authorizer``, ``search_authorizer``,
+  ``openid_authorizer``. The use-cases for these arguments are now satisfied by
+  the ability to pass a custom ``LoginManager`` to the client class, if desired.
+
+Changed
+^^^^^^^
+
+- The ``FuncXClient`` constructor has been refactored. It can no longer be
+  passed authorizers for various sub-services. Instead, a new component, the
+  ``LoginManager``, has been introduced which makes it possible to pass
+  arbitrary globus-sdk client objects for services (by passing a customized
+  login manager). The default behavior remains the same, checking login and
+  doing a new login on init.
+
+- Tokens are now stored in a new location, in a sqlite database, using
+  ``globus_sdk.tokenstorage``. Users will need to login again after upgrading
+  from past versions of ``funcx``.

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -49,7 +49,7 @@ class FuncXClient:
         loop=None,
         results_ws_uri=None,
         use_offprocess_checker=True,
-        environment=None,
+        environment: str | None = None,
         task_group_id: t.Union[None, uuid.UUID, str] = None,
         do_version_check: bool = True,
         openid_authorizer: t.Any = None,
@@ -136,7 +136,7 @@ class FuncXClient:
         # but if login handling is implicit (as when no login manager is passed)
         # then ensure that the user is logged in
         else:
-            self.login_manager = LoginManager()
+            self.login_manager = LoginManager(environment=environment)
             self.login_manager.ensure_logged_in()
 
         self.web_client = self.login_manager.get_funcx_web_client(

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -18,7 +18,7 @@ from funcx.serialize import FuncXSerializer
 from funcx.utils.errors import SerializationError, TaskPending, VersionMismatch
 from funcx.utils.handle_service_response import handle_response_errors
 
-from .login_manager import LoginManager
+from .login_manager import LoginManager, LoginManagerProtocol
 from .version import PARSED_VERSION, parse_version
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ class FuncXClient:
         search_authorizer: t.Any = None,
         fx_authorizer: t.Any = None,
         *,
-        login_manager: LoginManager | None = None,
+        login_manager: LoginManagerProtocol | None = None,
         **kwargs,
     ):
         """
@@ -132,7 +132,7 @@ class FuncXClient:
 
         # if a login manager was passed, no login flow is triggered
         if login_manager is not None:
-            self.login_manager = login_manager
+            self.login_manager: LoginManagerProtocol = login_manager
         # but if login handling is implicit (as when no login manager is passed)
         # then ensure that the user is logged in
         else:

--- a/funcx_sdk/funcx/sdk/login_manager/__init__.py
+++ b/funcx_sdk/funcx/sdk/login_manager/__init__.py
@@ -1,0 +1,6 @@
+from .manager import FuncxScopes, LoginManager
+
+__all__ = (
+    "LoginManager",
+    "FuncxScopes",
+)

--- a/funcx_sdk/funcx/sdk/login_manager/__init__.py
+++ b/funcx_sdk/funcx/sdk/login_manager/__init__.py
@@ -1,6 +1,8 @@
 from .manager import FuncxScopes, LoginManager
+from .protocol import LoginManagerProtocol
 
 __all__ = (
     "LoginManager",
     "FuncxScopes",
+    "LoginManagerProtocol",
 )

--- a/funcx_sdk/funcx/sdk/login_manager/globus_auth.py
+++ b/funcx_sdk/funcx/sdk/login_manager/globus_auth.py
@@ -1,0 +1,14 @@
+import os
+
+import globus_sdk
+
+
+def internal_auth_client():
+    """
+    This is the client that represents the FuncX application itself
+    """
+
+    client_id = os.environ.get(
+        "FUNCX_SDK_CLIENT_ID", "4cf29807-cf21-49ec-9443-ff9a3fb9f81c"
+    )
+    return globus_sdk.NativeAppAuthClient(client_id, app_name="FuncX (internal client)")

--- a/funcx_sdk/funcx/sdk/login_manager/login_flow.py
+++ b/funcx_sdk/funcx/sdk/login_manager/login_flow.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import platform
+
+from globus_sdk.tokenstorage import SQLiteAdapter
+
+from .globus_auth import internal_auth_client
+
+
+def do_link_auth_flow(tokenstore: SQLiteAdapter, scopes: list[str]) -> None:
+    auth_client = internal_auth_client()
+
+    # start the Confidential App Grant flow
+    auth_client.oauth2_start_flow(
+        redirect_uri=auth_client.base_url + "v2/web/auth-code",
+        refresh_tokens=True,
+        requested_scopes=scopes,
+        prefill_named_grant=platform.node(),
+    )
+
+    # prompt
+    query_params = {"prompt": "login"}
+    linkprompt = "Please authenticate with Globus here"
+    print(
+        "{0}:\n{1}\n{2}\n{1}\n".format(
+            linkprompt,
+            "-" * len(linkprompt),
+            auth_client.oauth2_get_authorize_url(query_params=query_params),
+        )
+    )
+
+    # come back with auth code
+    auth_code = input("Enter the resulting Authorization Code here: ").strip()
+
+    # finish auth flow
+    tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)
+    tokenstore.store(tkn)

--- a/funcx_sdk/funcx/sdk/login_manager/manager.py
+++ b/funcx_sdk/funcx/sdk/login_manager/manager.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+import os
+import typing as t
+
+import globus_sdk
+from globus_sdk.scopes import AuthScopes, ScopeBuilder, SearchScopes
+
+from ..web_client import FuncxWebClient
+from .globus_auth import internal_auth_client
+from .login_flow import do_link_auth_flow
+from .tokenstore import get_token_storage_adapter
+
+log = logging.getLogger(__name__)
+
+
+def _get_funcx_all_scope() -> str:
+    return os.getenv(
+        "FUNCX_SCOPE",
+        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+    )
+
+
+class FuncxScopeBuilder(ScopeBuilder):
+    # FIXME:
+    # for some reason, the funcx resource server name on the production scope is
+    # "funcx_service" even though this doesn't match the resource server ID and the
+    # scope is in URL format
+    # at some point, we ought to work out how to fix this to normalize this so that it
+    # conforms to one of the known, pre-existing modes for scopes
+    def __init__(self):
+        super().__init__("funcx_service")
+        self.all = _get_funcx_all_scope()
+
+
+#: a ScopeBuilder in the style of globus_sdk.scopes for the FuncX service
+#: it supports one scope named 'all', as in ``FuncxScopes.all``
+FuncxScopes = FuncxScopeBuilder()
+
+
+class LoginManager:
+    """
+    This class is primarily a wrapper over a sqlite tokenstorage adapter provided by the
+    globus-sdk.
+    See also: https://globus-sdk-python.readthedocs.io/en/stable/tokenstorage.html
+
+    The purpose of the LoginManager is to hold a tokenstorage object and combine it with
+    - a login flow which authenticates the user for the correct set of scopes
+    - a helper method for ensuring that the user is logged in (only doing login if
+      tokens are missing)
+    - methods for building SDK client objects with correct RefreshTokenAuthorizer
+      authorizers
+    """
+
+    SCOPES: dict[str, list[str]] = {
+        FuncxScopes.resource_server: [FuncxScopes.all],
+        AuthScopes.resource_server: [AuthScopes.openid],
+        SearchScopes.resource_server: [SearchScopes.all],
+    }
+
+    def __init__(self) -> None:
+        self._token_storage = get_token_storage_adapter()
+
+    @property
+    def login_requirements(self) -> t.Iterator[tuple[str, list[str]]]:
+        yield from self.SCOPES.items()
+
+    def run_login_flow(
+        self,
+        *,
+        scopes: list[str] | None = None,
+    ):
+        if scopes is None:  # flatten scopes to list of strings if none provided
+            scopes = [
+                s for _rs_name, rs_scopes in self.login_requirements for s in rs_scopes
+            ]
+
+        do_link_auth_flow(self._token_storage, scopes)
+
+    def logout(self) -> None:
+        auth_client = internal_auth_client()
+        for rs, tokendata in self._token_storage.get_by_resource_server().items():
+            for tok_key in ("access_token", "refresh_token"):
+                token = tokendata[tok_key]
+                auth_client.oauth2_revoke_token(token)
+
+            self._token_storage.remove_tokens_for_resource_server(rs)
+
+    def ensure_logged_in(self) -> None:
+        data = self._token_storage.get_by_resource_server()
+        needs_login = False
+        for rs_name, _rs_scopes in self.login_requirements:
+            if rs_name not in data:
+                needs_login = True
+                break
+
+        if needs_login:
+            self.run_login_flow()
+
+    def _get_authorizer(
+        self, resource_server: str
+    ) -> globus_sdk.RefreshTokenAuthorizer:
+        log.debug("build authorizer for %s", resource_server)
+        tokens = self._token_storage.get_token_data(resource_server)
+        if tokens is None:
+            raise LookupError(
+                f"LoginManager could not find tokens for {resource_server}"
+            )
+        return globus_sdk.RefreshTokenAuthorizer(
+            tokens["refresh_token"],
+            internal_auth_client(),
+            access_token=tokens["access_token"],
+            expires_at=tokens["expires_at_seconds"],
+            on_refresh=self._token_storage.on_refresh,
+        )
+
+    def get_auth_client(self) -> globus_sdk.AuthClient:
+        return globus_sdk.AuthClient(
+            authorizer=self._get_authorizer(AuthScopes.resource_server)
+        )
+
+    def get_search_client(self) -> globus_sdk.SearchClient:
+        return globus_sdk.SearchClient(
+            authorizer=self._get_authorizer(SearchScopes.resource_server)
+        )
+
+    def get_funcx_web_client(self, *, base_url: str | None = None) -> FuncxWebClient:
+        return FuncxWebClient(
+            base_url=base_url,
+            authorizer=self._get_authorizer(FuncxScopes.resource_server),
+        )

--- a/funcx_sdk/funcx/sdk/login_manager/manager.py
+++ b/funcx_sdk/funcx/sdk/login_manager/manager.py
@@ -59,8 +59,8 @@ class LoginManager:
         SearchScopes.resource_server: [SearchScopes.all],
     }
 
-    def __init__(self) -> None:
-        self._token_storage = get_token_storage_adapter()
+    def __init__(self, *, environment: str | None = None) -> None:
+        self._token_storage = get_token_storage_adapter(environment=environment)
 
     @property
     def login_requirements(self) -> t.Iterator[tuple[str, list[str]]]:

--- a/funcx_sdk/funcx/sdk/login_manager/protocol.py
+++ b/funcx_sdk/funcx/sdk/login_manager/protocol.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import typing as t
+
+import globus_sdk
+
+from ..web_client import FuncxWebClient
+
+
+class LoginManagerProtocol(t.Protocol):
+    def ensure_logged_in(self) -> None:
+        ...
+
+    def logout(self) -> None:
+        ...
+
+    def get_auth_client(self) -> globus_sdk.AuthClient:
+        ...
+
+    def get_search_client(self) -> globus_sdk.SearchClient:
+        ...
+
+    def get_funcx_web_client(self, *, base_url: str | None = None) -> FuncxWebClient:
+        ...

--- a/funcx_sdk/funcx/sdk/login_manager/protocol.py
+++ b/funcx_sdk/funcx/sdk/login_manager/protocol.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
-import typing as t
+import sys
 
 import globus_sdk
 
 from ..web_client import FuncxWebClient
 
+# these were added to stdlib typing in 3.8, so the import must be conditional
+# mypy and other tools expect and document a sys.version_info check
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
 
-@t.runtime_checkable
-class LoginManagerProtocol(t.Protocol):
+
+@runtime_checkable
+class LoginManagerProtocol(Protocol):
     def ensure_logged_in(self) -> None:
         ...
 

--- a/funcx_sdk/funcx/sdk/login_manager/protocol.py
+++ b/funcx_sdk/funcx/sdk/login_manager/protocol.py
@@ -7,6 +7,7 @@ import globus_sdk
 from ..web_client import FuncxWebClient
 
 
+@t.runtime_checkable
 class LoginManagerProtocol(t.Protocol):
     def ensure_logged_in(self) -> None:
         ...

--- a/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
+++ b/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
@@ -1,0 +1,68 @@
+import json
+import os
+import pathlib
+
+from globus_sdk.tokenstorage import SQLiteAdapter
+
+from .._environments import _get_envname
+from .globus_auth import internal_auth_client
+
+
+def _home() -> pathlib.Path:
+    # this is a hook point for tests to patch over
+    # it just returns `pathlib.Path.home()`
+    # replace this with a mock to return some test directory
+    return pathlib.Path.home()
+
+
+def invalidate_old_config() -> None:
+    token_file = _home() / ".funcx" / "credentials" / "funcx_sdk_tokens.json"
+
+    if token_file.exists():
+        try:
+            auth_client = internal_auth_client()
+            with open(token_file) as fp:
+                data = json.load(fp)
+            for token_data in data.values():
+                if "access_token" in token_data:
+                    auth_client.oauth2_revoke_token(token_data["access_token"])
+                if "refresh_token" in token_data:
+                    auth_client.oauth2_revoke_token(token_data["refresh_token"])
+        finally:
+            os.remove(token_file)
+
+
+def _ensure_funcx_dir() -> pathlib.Path:
+    dirname = _home() / ".funcx"
+    try:
+        os.makedirs(dirname)
+    except FileExistsError:
+        pass
+    return dirname
+
+
+def _get_storage_filename():
+    datadir = _ensure_funcx_dir()
+    return os.path.join(datadir, "storage.db")
+
+
+def _resolve_namespace() -> str:
+    """
+    For now, the following namespace will always be used:
+      user/<envname>
+
+    e.g.
+
+      user/production
+    """
+    return f"user/{_get_envname()}"
+
+
+def get_token_storage_adapter() -> SQLiteAdapter:
+    # when initializing the token storage adapter, check if the storage file exists
+    # if it does not, then use this as a flag to clean the old config
+    fname = _get_storage_filename()
+    if not os.path.exists(fname):
+        invalidate_old_config()
+    # namespace is equal to the current environment
+    return SQLiteAdapter(fname, namespace=_resolve_namespace())

--- a/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
+++ b/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import pathlib
@@ -46,7 +48,7 @@ def _get_storage_filename():
     return os.path.join(datadir, "storage.db")
 
 
-def _resolve_namespace() -> str:
+def _resolve_namespace(environment: str | None) -> str:
     """
     For now, the following namespace will always be used:
       user/<envname>
@@ -55,14 +57,15 @@ def _resolve_namespace() -> str:
 
       user/production
     """
-    return f"user/{_get_envname()}"
+    env = environment if environment is not None else _get_envname()
+    return f"user/{env}"
 
 
-def get_token_storage_adapter() -> SQLiteAdapter:
+def get_token_storage_adapter(*, environment: str | None = None) -> SQLiteAdapter:
     # when initializing the token storage adapter, check if the storage file exists
     # if it does not, then use this as a flag to clean the old config
     fname = _get_storage_filename()
     if not os.path.exists(fname):
         invalidate_old_config()
     # namespace is equal to the current environment
-    return SQLiteAdapter(fname, namespace=_resolve_namespace())
+    return SQLiteAdapter(fname, namespace=_resolve_namespace(environment))

--- a/funcx_sdk/funcx/sdk/search.py
+++ b/funcx_sdk/funcx/sdk/search.py
@@ -1,4 +1,4 @@
-from globus_sdk import SearchAPIError, SearchClient
+from globus_sdk import SearchAPIError
 from texttable import Texttable
 
 from funcx.serialize import FuncXSerializer
@@ -20,7 +20,7 @@ class SearchHelper:
     ENDPOINT_SEARCH_INDEX_NAME = "funcx_endpoints"
     ENDPOINT_SEARCH_INDEX_ID = "85bcc497-3ee9-4d73-afbb-2abf292e398b"
 
-    def __init__(self, authorizer):
+    def __init__(self, client):
         """Initialize the Search Helper
 
         Parameters
@@ -28,8 +28,7 @@ class SearchHelper:
         authorizer : class:
 
         """
-        self._authorizer = authorizer
-        self._sc = SearchClient(authorizer=self._authorizer)
+        self._sc = client
 
     def _exists(self, func_uuid):
         """

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -5,8 +5,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.20.0",
-    "globus-sdk>=3,<4",
-    "fair_research_login==0.2.6",
+    "globus-sdk>=3.6.0,<4",
     # 'websockets' is used for the client-side websocket listener
     "websockets==9.1",
     # table printing used in search result rendering

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -14,6 +14,8 @@ REQUIRES = [
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy
     "dill==0.3.4",
+    # typing_extensions, so we can use Protocol and other typing features on python3.7
+    'typing_extensions>=4.0;python_version<"3.8"',
 ]
 DOCS_REQUIRES = [
     "sphinx<5",

--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -1,7 +1,6 @@
 import uuid
 from unittest import mock
 
-import globus_sdk
 import pytest
 from tests.unit.utils import randomstring
 
@@ -12,22 +11,6 @@ from funcx.serialize import FuncXSerializer
 @pytest.fixture(autouse=True)
 def _clear_sdk_env(monkeypatch):
     monkeypatch.delenv("FUNCX_SDK_ENVIRONMENT", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _mock_login(monkeypatch):
-    mock_fair_research_client_object = mock.Mock()
-    monkeypatch.setattr(
-        "funcx.sdk.client.NativeClient",
-        mock.Mock(return_value=mock_fair_research_client_object),
-    )
-    mock_fair_research_client_object.get_authorizers_by_scope.return_value = {
-        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all": (
-            globus_sdk.NullAuthorizer()
-        ),
-        "urn:globus:auth:scope:search.api.globus.org:all": globus_sdk.NullAuthorizer(),
-        "openid": globus_sdk.NullAuthorizer(),
-    }
 
 
 @pytest.mark.parametrize("env", [None, "dev", "production"])
@@ -46,8 +29,11 @@ def test_client_init_sets_addresses_by_env(
         raise NotImplementedError
 
     # default kwargs: turn off external interactions
-    kwargs = {"do_version_check": False, "use_offprocess_checker": False}
-
+    kwargs = {
+        "login_manager": mock.Mock(),
+        "do_version_check": False,
+        "use_offprocess_checker": False,
+    }
     # either pass the env as a param or set it in the environment
     if usage_method == "param":
         kwargs["environment"] = env
@@ -81,10 +67,13 @@ def test_client_init_sets_addresses_by_env(
     assert client.results_ws_uri == ws_uri
 
 
-def test_client_init_accepts_specified_taskgroup(_mock_login):
+def test_client_init_accepts_specified_taskgroup():
     tg_uuid = uuid.uuid4()
     fxc = funcx.FuncXClient(
-        task_group_id=tg_uuid, do_version_check=False, use_offprocess_checker=False
+        task_group_id=tg_uuid,
+        do_version_check=False,
+        use_offprocess_checker=False,
+        login_manager=mock.Mock(),
     )
     assert fxc.session_task_group_id == str(tg_uuid)
 

--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -103,7 +103,9 @@ def test_update_task_table_is_robust(api_data):
         data["exception"] = serde.serialize(exc)
 
     # test kernel
-    fxc = funcx.FuncXClient(do_version_check=False, use_offprocess_checker=False)
+    fxc = funcx.FuncXClient(
+        do_version_check=False, use_offprocess_checker=False, login_manager=mock.Mock()
+    )
     st = fxc._update_task_table(data, task_id)
 
     # verify results

--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -91,7 +91,7 @@ def test_client_init_accepts_specified_taskgroup():
         {"status": "asdf", "sentinel": 1},
     ],
 )
-def test_update_task_table_is_robust(_mock_login, api_data):
+def test_update_task_table_is_robust(api_data):
     payload = randomstring()
     exc = KeyError("asdf")
     task_id = "some_task_id"

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -30,10 +30,7 @@ _LOCAL_ENDPOINT_ID = os.getenv("FUNCX_LOCAL_ENDPOINT_ID")
 
 _CONFIGS = {
     "dev": {
-        "client_args": {
-            "funcx_service_address": "https://api.dev.funcx.org/v2",
-            "results_ws_uri": "wss://api.dev.funcx.org/ws/v2/",
-        },
+        "client_args": {"environment": "dev"},
         # assert versions are as expected on dev
         "forwarder_min_version": "0.3.5",
         "api_min_version": "0.3.5",
@@ -127,6 +124,11 @@ def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_ar
 
     try:
         from funcx.sdk.login_manager import LoginManagerProtocol
+    except ImportError:
+        client_args["fx_authorizer"] = funcx_authorizer
+        client_args["search_authorizer"] = search_authorizer
+        client_args["openid_authorizer"] = auth_authorizer
+    else:
 
         class TestsuiteLoginManager:
             def ensure_logged_in(self) -> None:
@@ -153,11 +155,6 @@ def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_ar
             assert isinstance(login_manager, LoginManagerProtocol)
 
         client_args["login_manager"] = login_manager
-
-    except ImportError:
-        client_args["fx_authorizer"] = funcx_authorizer
-        client_args["search_authorizer"] = search_authorizer
-        client_args["openid_authorizer"] = auth_authorizer
 
 
 @pytest.fixture(scope="session")

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import collections
 import json
 import os
 import time
 
 import pytest
-from globus_sdk import AccessTokenAuthorizer, ConfidentialAppAuthClient
+from globus_sdk import (
+    AccessTokenAuthorizer,
+    AuthClient,
+    ConfidentialAppAuthClient,
+    SearchClient,
+)
 
 from funcx import FuncXClient
+from funcx.sdk.web_client import FuncxWebClient
 
 # the non-tutorial endpoint will be required, with the following priority order for
 # finding the ID:
@@ -97,6 +105,57 @@ def funcx_test_config_name(pytestconfig):
     return pytestconfig.getoption("--funcx-config")
 
 
+def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_args):
+    auth_client = ConfidentialAppAuthClient(api_client_id, api_client_secret)
+    scopes = [
+        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+        SearchClient.scopes.all,
+        AuthClient.scopes.openid,
+    ]
+    tokens = auth_client.oauth2_client_credentials_tokens(
+        requested_scopes=scopes
+    ).by_resource_server
+
+    funcx_token = tokens["funcx_service"]["access_token"]
+    search_token = tokens[SearchClient.resource_server]["access_token"]
+    auth_token = tokens[AuthClient.resource_server]["access_token"]
+
+    funcx_authorizer = AccessTokenAuthorizer(funcx_token)
+    search_authorizer = AccessTokenAuthorizer(search_token)
+    auth_authorizer = AccessTokenAuthorizer(auth_token)
+
+    try:
+        from funcx.sdk.login_manager import LoginManagerProtocol
+
+        class TestsuiteLoginManager:
+            def ensure_logged_in(self) -> None:
+                pass
+
+            def logout(self) -> None:
+                pass
+
+            def get_auth_client(self) -> AuthClient:
+                return AuthClient(authorizer=auth_authorizer)
+
+            def get_search_client(self) -> SearchClient:
+                return SearchClient(authorizer=search_authorizer)
+
+            def get_funcx_web_client(
+                self, *, base_url: str | None = None
+            ) -> FuncxWebClient:
+                return FuncxWebClient(base_url=base_url, authorizer=funcx_authorizer)
+
+        login_manager = TestsuiteLoginManager()
+        assert isinstance(login_manager, LoginManagerProtocol)
+
+        client_args["login_manager"] = login_manager
+
+    except ImportError:
+        client_args["fx_authorizer"] = funcx_authorizer
+        client_args["search_authorizer"] = search_authorizer
+        client_args["openid_authorizer"] = auth_authorizer
+
+
 @pytest.fixture(scope="session")
 def funcx_test_config(pytestconfig, funcx_test_config_name):
     # start with basic config load
@@ -127,31 +186,7 @@ def funcx_test_config(pytestconfig, funcx_test_config_name):
         client_args["funcx_service_address"] = api_uri
 
     if api_client_id and api_client_secret:
-        client = ConfidentialAppAuthClient(api_client_id, api_client_secret)
-        scopes = [
-            "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
-            "urn:globus:auth:scope:search.api.globus.org:all",
-            "openid",
-        ]
-
-        token_response = client.oauth2_client_credentials_tokens(
-            requested_scopes=scopes
-        )
-        fx_token = token_response.by_resource_server["funcx_service"]["access_token"]
-        search_token = token_response.by_resource_server["search.api.globus.org"][
-            "access_token"
-        ]
-        openid_token = token_response.by_resource_server["auth.globus.org"][
-            "access_token"
-        ]
-
-        fx_auth = AccessTokenAuthorizer(fx_token)
-        search_auth = AccessTokenAuthorizer(search_token)
-        openid_auth = AccessTokenAuthorizer(openid_token)
-
-        client_args["fx_authorizer"] = fx_auth
-        client_args["search_authorizer"] = search_auth
-        client_args["openid_authorizer"] = openid_auth
+        _add_args_for_client_creds_login(api_client_id, api_client_secret, client_args)
 
     return config
 

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import json
 import os
+import sys
 import time
 
 import pytest
@@ -146,7 +147,10 @@ def _add_args_for_client_creds_login(api_client_id, api_client_secret, client_ar
                 return FuncxWebClient(base_url=base_url, authorizer=funcx_authorizer)
 
         login_manager = TestsuiteLoginManager()
-        assert isinstance(login_manager, LoginManagerProtocol)
+
+        # check runtime-checkable protocol on python versions which support it
+        if sys.version_info >= (3, 8):
+            assert isinstance(login_manager, LoginManagerProtocol)
 
         client_args["login_manager"] = login_manager
 

--- a/smoke_tests/tox.ini
+++ b/smoke_tests/tox.ini
@@ -29,3 +29,8 @@ deps =
     -e ../funcx_endpoint
     pytest
 commands = pytest -v {posargs}
+
+[flake8]  # black-compatible
+ignore = W503, W504, E203, B008
+# TODO: reduce this to 88 once `black` is applied to all code
+max-line-length = 88


### PR DESCRIPTION
Instead of login happening as part of client init (and only as part of client init), login is now handled by an independent component called the LoginManager. This encapsulates token storage and globus_sdk client builders.

For the most part, the LoginManager replaces any notion that a FuncXClient consumes authorizers for various internal clients directly. Instead, it may be given an object (not necessarily a LoginManager in the future) which is answerable for building usable HTTP clients for various APIs which may be needed.

---

Particular notes:
- This will force users to login again after upgrading, as noted in the changelog. In order to reduce the cost of testing, I decided to revoke old tokens if the new storage is not visible, and otherwise take no action. There is no token migration, for simplicity.
- This removes dead code from the SearchHelper class with no note in the changelog. Endpoint Search doesn't exist, so the support for it is purely vestigial. This made some of the mechanical tinkering simpler.
- There are no automated tests for the new components. There are parts of this which can and should be tested, but for now one of the primary goals has been achieved: `FuncXClient(login_manager=mock.Mock())` is now possible for other testing. Rather than blocking while I work on a suite of automated tests, I think this is better to move forward now.
- Login on init behavior is preserved. Until we've made changes to the endpoint, this seems best.
- `do_version_check: bool` is not directly related to this work, but came up and simplified things while testing
- There is no `logout` method. One can be added if that's considered a blocker, but `rm ~/.funcx/storage.db` is probably sufficient for most users (no revocation)
- Remove the dependency on `fair-research-login`
- `force_login` is removed. It could be emulated with `LoginManager().run_login_flow()`
- Remove the userinfo call on client init (this was related to SearchHelper, and is not necessary anymore)
- If the env var is used to set the environment to "dev", the tokenstorage will pick that up and store "dev" tokens separately from "production" tokens

I'm aware that it's pretty unusual for me to advocate for a change with only manual testing, but it's the end of the week and I'm out next week, so I wanted to get this in front of people.