### PR TITLE
Increase the sdk dependency to >=3.6 to include the globus_sdk v3 dep

### DIFF
--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
-    "funcx>=0.3.3,<0.4.0",
+    "funcx>=0.3.6,<0.4.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer


### PR DESCRIPTION
# Description

Increase the sdk dependency to >=3.6 to include the globus_sdk v3 dependency. The previous 0.3.3 requirement would cause issues when the endpoint was at 0.3.8 due to requiring the globus v3 sdk.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
