### PR TITLE
SC-11102 Implement task group rehydration.

### DIFF
--- a/changelog.d/20220325_154137_kevin_ReloadTaskGroup.rst
+++ b/changelog.d/20220325_154137_kevin_ReloadTaskGroup.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Implement Task Group reloading on the FuncXExecutor.  Look for `.reload_tasks()`

--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -219,7 +219,8 @@ class WebSocketPollingTask:
             exit, False otherwise
         """
         try:
-            if "result" in task_data:
+            status = str(task_data.get("status")).lower()
+            if status == "success" and "result" in task_data:
                 task_fut.set_result(
                     self.funcx_client.fx_serializer.deserialize(task_data["result"])
                 )

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -99,7 +99,8 @@ class FuncXClient:
 
         task_group_id: str|uuid.UUID
             Set the TaskGroup ID (a UUID) for this FuncXClient instance.  Typically,
-            one uses this to submit new tasks to an existing session.
+            one uses this to submit new tasks to an existing session or to reestablish
+            FuncXExecutor futures.
             Default: None (will be auto generated)
 
         Keyword arguments are the same as for BaseClient.
@@ -522,7 +523,9 @@ class FuncXClient:
         return r.data
 
     def get_containers(self, name, description=None):
-        """Register a DLHub endpoint with the funcX service and get the containers to launch.
+        """
+        Register a DLHub endpoint with the funcX service and get the containers to
+        launch.
 
         Parameters
         ----------

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -114,6 +114,11 @@ class FuncxWebClient(globus_sdk.BaseClient):
     def get_version(self, *, service: str = "all") -> globus_sdk.GlobusHTTPResponse:
         return self.get("version", query_params={"service": service})
 
+    def get_taskgroup_tasks(
+        self, task_group_id: ID_PARAM_T
+    ) -> globus_sdk.GlobusHTTPResponse:
+        return self.get(f"/taskgroup/{task_group_id}")
+
     def get_task(self, task_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
         return self.get(f"tasks/{task_id}")
 

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -1,4 +1,8 @@
+import random
+import uuid
+
 import pytest
+from tests.unit.utils import randomstring
 
 from funcx import FuncXExecutor
 from funcx.sdk.executor import TaskSubmissionInfo
@@ -40,3 +44,110 @@ def test_task_submission_info_stringification():
     assert "future_id=10" in as_str
     assert "function_id='foo_func'" in as_str
     assert "endpoint_id='bar_ep'" in as_str
+
+
+def test_property_results_ws_uri_passthru(mocker):
+    fcli = mocker.MagicMock(results_ws_uri=randomstring())
+    fexe = FuncXExecutor(funcx_client=fcli)
+    assert fexe.results_ws_uri is fcli.results_ws_uri
+
+    fcli.results_ws_uri = randomstring()
+    assert fexe.results_ws_uri is fcli.results_ws_uri
+
+
+def test_property_task_group_id_passthru(mocker):
+    fcli = mocker.MagicMock(session_task_group_id=randomstring())
+    fexe = FuncXExecutor(funcx_client=fcli)
+    assert fexe.task_group_id is fcli.session_task_group_id
+
+    fcli.session_task_group_id = randomstring()
+    assert fexe.task_group_id is fcli.session_task_group_id
+
+
+@pytest.mark.parametrize("num_tasks", [0, 1, 2, 10])
+def test_reload_tasks_happy_path(mocker, num_tasks):
+    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+    mock_log = mocker.patch("funcx.sdk.executor.log")
+
+    tg_uuid = str(uuid.uuid4())
+    mock_data = {
+        "taskgroup_id": tg_uuid,
+        "tasks": [
+            {"id": randomstring(), "created_at": 1234567890} for _ in range(num_tasks)
+        ],
+    }
+
+    fcli = mocker.MagicMock()
+    fcli.session_task_group_id = tg_uuid
+    fcli.web_client.get_taskgroup_tasks.return_value = mock_data
+    fexe = FuncXExecutor(funcx_client=fcli)
+
+    client_futures = list(fexe.reload_tasks())
+    if num_tasks == 0:
+        log_args, log_kwargs = mock_log.warning.call_args
+        assert "Received no tasks" in log_args[0]
+        assert tg_uuid in log_args[0]
+    else:
+        assert not mock_log.warning.called
+
+    assert len(client_futures) == num_tasks
+    assert fexe.poller_thread.atomic_controller.increment.called
+    assert 1 == fexe.poller_thread.atomic_controller.increment.call_count
+    assert not any(fut.done() for fut in client_futures)
+
+    for fut in fexe._function_future_map.values():
+        fut.set_result(1)
+
+    assert all(fut.done() for fut in client_futures)
+
+
+def test_reload_tasks_cancels_existing_futures(mocker):
+    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+
+    tg_uuid = str(uuid.uuid4())
+
+    def mock_data():
+        return {
+            "taskgroup_id": tg_uuid,
+            "tasks": [
+                {"id": randomstring(), "created_at": 1234567890}
+                for i in range(random.randint(0, 20))
+            ],
+        }
+
+    fcli = mocker.MagicMock()
+    fcli.session_task_group_id = tg_uuid
+    fcli.web_client.get_taskgroup_tasks.return_value = mock_data()
+    fexe = FuncXExecutor(funcx_client=fcli)
+
+    client_futures_1 = list(fexe.reload_tasks())
+    fcli.get_taskgroup_tasks.return_value = mock_data()
+    client_futures_2 = list(fexe.reload_tasks())
+
+    assert all(fut.done() for fut in client_futures_1)
+    assert all(fut.cancelled() for fut in client_futures_1)
+    assert not any(fut.done() for fut in client_futures_2)
+
+
+def test_client_taskgroup_tasks_fails_gracefully(mocker):
+    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+
+    tg_uuid = str(uuid.uuid4())
+    mock_datum = (
+        (KeyError, {"mispeleed": tg_uuid}),
+        (ValueError, {"taskgroup_id": "abcd"}),
+        (None, {"taskgroup_id": tg_uuid}),
+    )
+
+    fcli = mocker.MagicMock()
+    fcli.session_task_group_id = tg_uuid
+    fexe = FuncXExecutor(funcx_client=fcli)
+
+    for expected_exc_class, md in mock_datum:
+        fcli.web_client.get_taskgroup_tasks.return_value = md
+        if expected_exc_class:
+            with pytest.raises(expected_exc_class):
+                fexe.reload_tasks()
+        else:
+            fexe.reload_tasks()
+            fexe.shutdown()

--- a/funcx_sdk/tests/unit/test_ws_poller.py
+++ b/funcx_sdk/tests/unit/test_ws_poller.py
@@ -1,5 +1,9 @@
 import asyncio
+import json
+import random
+import uuid
 
+from funcx.sdk.asynchronous.funcx_future import FuncXFuture
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
 from funcx.sdk.executor import AtomicController
 
@@ -23,3 +27,63 @@ def test_close_with_null_ws_state(mocker):
     )
     eventloop.run_until_complete(wspt.close())  # No crashing, please
     eventloop.close()
+
+
+def test_polling_task_cancels_futures_upon_upstream_failure(mocker):
+    mock_msg = "no task_id exception == no fix; quit!"
+
+    expected_num_good_results = random.randint(0, 10)
+    mock_data = [
+        {"task_id": str(uuid.uuid4()), "result": i}
+        for i in range(expected_num_good_results)
+    ]
+    mock_data.append({"exception": mock_msg})
+    mock_data.extend(
+        {"task_id": str(uuid.uuid4()), "result": i}
+        for i in range(random.randint(0, 10))
+    )
+    mock_data_iter = iter(mock_data)
+    tids = (md.get("task_id", uuid.uuid4()) for md in mock_data)
+    pending_futures = {tid: FuncXFuture(tid) for tid in tids}
+    futures = list(pending_futures.values())
+
+    async def mock_recv():
+        return json.dumps(next(mock_data_iter))
+
+    fxclient = mocker.MagicMock()
+    eventloop = asyncio.new_event_loop()
+    wspt = WebSocketPollingTask(
+        funcx_client=fxclient,
+        loop=eventloop,
+        atomic_controller=AtomicController(_start, _stop),
+        auto_start=False,
+    )
+    wspt._ws = mocker.MagicMock()
+    wspt._ws.recv = mock_recv
+    result = eventloop.run_until_complete(wspt.handle_incoming(pending_futures))
+    eventloop.close()
+
+    assert (
+        result
+    ), "Upstream has _not_ closed the connection -- just indicated unrecoverable error"
+
+    num_good = len(futures) - len(pending_futures)
+    assert num_good == expected_num_good_results
+    assert any(pf.cancelled() for pf in pending_futures.values())
+
+
+def test_malformed_response_handled_gracefully(mocker):
+    fxclient = mocker.MagicMock()
+    eventloop = asyncio.new_event_loop()
+    wspt = WebSocketPollingTask(
+        funcx_client=fxclient,
+        loop=eventloop,
+        atomic_controller=AtomicController(_start, _stop),
+        auto_start=False,
+    )
+    task_fut = FuncXFuture()
+    data = {"reason": "Jim bob Bonita Mae"}
+    eventloop.run_until_complete(wspt.set_result(task_fut, data))
+    eventloop.close()
+
+    assert data["reason"] in str(task_fut.exception())


### PR DESCRIPTION
# Description

By default, every instance of `FuncXClient` generates a fresh Task Group ID.  In the happy-path case, the user processes their tasks and never need know about it.  But in the case of a `FuncXExecutor`, access to this allows a user to reattach to a previous session (for example, if the researcher's script dies unexpectedly).  Reattaching looks like:

```python
saved_task_group_id = '<some_UUID_from_before>'
fxc = FuncXClient(task_group_id=saved_task_group_id)
fxe = FuncXExecutor(fxc)
rehydrated_futures = fxe.reload_tasks()
```
At which point the futures are like before, and one can wait for their results and exceptions:

```python
results, exc = [], []
for fut in rehydrated_futures:
  try:
    results.append(fut.result())
except Exception as exc:
    exceptions.append(exc)
```

Fixes # SC-11102

## Type of change

- New feature (non-breaking change that adds functionality)