### PR TITLE
Fix a race condition in interchange->manager task dispatch

### DIFF
--- a/changelog.d/20220326_181852_benc_benc_exa_race_interesting_managers.rst
+++ b/changelog.d/20220326_181852_benc_benc_exa_race_interesting_managers.rst
@@ -1,0 +1,40 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+Bug Fixes
+^^^^^^^^^
+
+- Improve performance in endpoint interchange->manager dispatch,
+  by fixing a race condition in worker status processing.
+  In an example kubernetes setup, this can double throughput of
+  5 second tasks on 6 workers.
+
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -1009,6 +1009,8 @@ class Interchange:
                     # previously used this; switched to mono-message,
                     # self.results_outgoing.send_multipart(b_messages)
                     self.results_outgoing.send(pickle.dumps(b_messages))
+                    interesting_managers.add(manager)   # BENC: because now we've adjusted t>
+
                     log.debug(
                         "[MAIN] Current tasks: {}".format(
                             self._ready_manager_queue[manager]["tasks"]

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -1009,7 +1009,7 @@ class Interchange:
                     # previously used this; switched to mono-message,
                     # self.results_outgoing.send_multipart(b_messages)
                     self.results_outgoing.send(pickle.dumps(b_messages))
-                    interesting_managers.add(manager)   # BENC: because now we've adjusted t>
+                    interesting_managers.add(manager)
 
                     log.debug(
                         "[MAIN] Current tasks: {}".format(


### PR DESCRIPTION
# Description

The interchange dispatches tasks to managers based on how many tasks it thinks the manager needs.

This starts with the manager reporting how many task slots it has. However, the interchange may have already sent some tasks, so it separately tracks how many tasks have been sent, and reduces the number of tasks to be sent.

This prevents a task queue building up in a manager - such a task queue can lead to tasks building up in one manager, when another manager has free capacity.

However, at the other end of a task, when a task finishes, I have observed:
* the manager now says it has capacity
* the interchange knows there is still a task there, so does not allocate a task
* the task result arrives
* the manager sits idle until the next advertisement (which might be on the order of 30s sometimes)

This PR adds in a re-evaluation of the manager after a task result arrives, meaning that dispatch of a new task can happen right away.

In my kubernetes dev setup, this led to a run of 500 x 5s jobs on 6 manager-worker pods going from around 1000s wall time to 500s walltime.

cc @WardLT who has experienced similar seeming delays and was the initial motivation for this investigation. We haven't verified if this PR changes what he is seeing, as of time of writing.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
