### PR TITLE
Add task uuid to Futures

### DIFF
--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -229,6 +229,7 @@ class FuncXExecutor(concurrent.futures.Executor):
                     self._function_future_map[batch_tasks[i]] = self._tasks.pop(
                         msg["task_id"]
                     )
+                    self._function_future_map[batch_tasks[i]].task_id = batch_tasks[i]
                     self.poller_thread.atomic_controller.increment()
 
     def _get_tasks_in_batch(self):


### PR DESCRIPTION
# Description

This PR adds the task UUID onto futures returned by the executor interface.

This allows user code to know the task UUID, which can then be used to correlate client side behaviour with other parts of the system - for example, for users on their endpoint, and when debugging with funcx internal people, with cloudwatch logs.

I have already used this debugging for debugging performance.

## Type of change

- New feature (non-breaking change that adds functionality)
