### PR TITLE
Pin click to v8.0.4 for typer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.14.0
+  rev: 0.14.1
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort

--- a/changelog.d/20220329_145838_sirosen_pin_click.rst
+++ b/changelog.d/20220329_145838_sirosen_pin_click.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Pin the version of `click` used by `funcx-endpoint`. This resolves issues
+  stemming from `typer` being incompatible with the latest `click` release.

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -25,6 +25,7 @@ REQUIRES = [
     #    backwards-incompatible changes are introduced, making our application
     #    safer to distribute
     "typer==0.4.0",
+    "click==8.0.4",  # pin `click` because typer uses `click` internals
     # disallow use of 22.3.0; the whl package on some platforms causes ZMQ issues
     #
     # NOTE: 22.3.0 introduced a patched version of libzmq.so to the wheel packaging


### PR DESCRIPTION
`typer==0.4.0` (current latest) is broken by `click==8.1.0`.

This is based off of #730 so that CI will pass.