### PR TITLE
remove logger.exception from deserialize_check on failure

### DIFF
--- a/funcx_sdk/funcx/serialize/facade.py
+++ b/funcx_sdk/funcx/serialize/facade.py
@@ -101,7 +101,6 @@ class FuncXSerializer:
             if status == "PONG":
                 return status
             else:
-                logger.exception("Got exception while attempting deserialization")
                 raise Exception(info)
 
     def serialize(self, data):


### PR DESCRIPTION
# Description

Came across this `logger.exception` that really should not be there: it is not in an `except` block, we are raising right afterwards anyway, and this logs strange messages to the user when a particular deserialization method fails (which is irrelevant to the user when a later deserialization method is successful)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
