### PR TITLE
Clarify what is tested in test_executor_shutdown

### DIFF
--- a/funcx_sdk/funcx/tests/unit/test_executor.py
+++ b/funcx_sdk/funcx/tests/unit/test_executor.py
@@ -1,12 +1,25 @@
+import pytest
+
 from funcx import FuncXExecutor
 
 
 def test_executor_shutdown(mocker):
+    """ensure that executor shutdown does not crash"""
     mocker.patch("funcx.sdk.executor.atexit")
     mocker.patch("funcx.sdk.executor.ExecutorPollerThread.event_loop_thread")
     fcli = mocker.MagicMock()
     fexe = FuncXExecutor(funcx_client=fcli)
+    # increment starts the websocket handler, decrement is a no-op
     fexe.poller_thread.atomic_controller.increment()
     fexe.poller_thread.atomic_controller.decrement()
 
-    fexe.shutdown()  # No crashing, please.
+    # there is a handler for the websocket service
+    ws_handler = fexe.poller_thread.ws_handler
+    assert ws_handler is not None
+    # but its underlying connection is not valid because the
+    # executor's main thread is mocked
+    # the connection should not be gettable: ValueError on property access
+    with pytest.raises(ValueError):
+        ws_handler.ws
+
+    fexe.shutdown()


### PR DESCRIPTION
In #736 I had (in my comments) the case which was being tested backwards. I thought we were in the `ws_handler._ws is not None` case, but we were actually in the `is None` case. Rather than adding a test for the `is not None` case, which is exercised by most use of the executor, I just added a few more test conditions and comments to clarify what the purpose of the test is.

This also means that if the code under test changes such that the mock on the executor poller thread no longer has the desired effect, it will be flagged.