### PR TITLE
Avoid possible crash during ws close

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -227,15 +227,15 @@ class WebSocketPollingTask:
             count = self.atomic_controller.decrement()
             # Only close when count == 0 and unknown_results are empty
             if count == 0 and len(self.unknown_results) == 0:
-                await self.ws.close()
-                self._ws = None
+                await self.close()
                 return True
         return False
 
     async def close(self):
         """Close underlying web-sockets, does not stop listeners directly"""
-        await self.ws.close()
-        self._ws = None
+        if self._ws:
+            await self._ws.close()
+            self._ws = None
 
     def put_task_group_id(self, task_group_id):
         # prevent the task_group_id from being sent to the WebSocket server

--- a/funcx_sdk/funcx/tests/unit/test_ws_poller.py
+++ b/funcx_sdk/funcx/tests/unit/test_ws_poller.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
+from funcx.sdk.executor import AtomicController
+
+
+def _start():
+    pass
+
+
+def _stop():
+    pass
+
+
+def test_close_with_null_ws_state(mocker):
+    fxclient = mocker.MagicMock()
+    eventloop = asyncio.new_event_loop()
+    wspt = WebSocketPollingTask(
+        funcx_client=fxclient,
+        loop=eventloop,
+        atomic_controller=AtomicController(_start, _stop),
+        auto_start=False,
+    )
+    eventloop.run_until_complete(wspt.close())  # No crashing, please
+    eventloop.close()


### PR DESCRIPTION
If it's already None, then there's no need to crash (per None if-guard in property).  Do the deed directly or do nothing.

In pursuit of #11102

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
