### PR TITLE
Convert executor internal message objects from dict to dedicated object

### DIFF
--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -6,7 +6,6 @@ import queue
 import threading
 import time
 import typing as t
-from collections import namedtuple
 from concurrent.futures import Future
 
 from funcx.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
@@ -15,9 +14,30 @@ from funcx.sdk.client import FuncXClient
 log = logging.getLogger(__name__)
 
 
-TaskSubmissionInfo = namedtuple(
-    "TaskSubmissionInfo", "future_id, function_id, endpoint_id, args, kwargs"
-)
+class TaskSubmissionInfo:
+    def __init__(
+        self,
+        *,
+        future_id: int,
+        function_id: str,
+        endpoint_id: str,
+        args: t.Tuple[t.Any],
+        kwargs: t.Dict[str, t.Any],
+    ):
+        self.future_id = future_id
+        self.function_id = function_id
+        self.endpoint_id = endpoint_id
+        self.args = args
+        self.kwargs = kwargs
+
+    def __repr__(self):
+        return (
+            "TaskSubmissionInfo("
+            f"future_id={self.future_id}, "
+            f"function_id='{self.function_id}', "
+            f"endpoint_id='{self.endpoint_id}', "
+            "args=..., kwargs=...)"
+        )
 
 
 class AtomicController:

--- a/funcx_sdk/funcx/tests/unit/test_executor.py
+++ b/funcx_sdk/funcx/tests/unit/test_executor.py
@@ -1,6 +1,7 @@
 import pytest
 
 from funcx import FuncXExecutor
+from funcx.sdk.executor import TaskSubmissionInfo
 
 
 def test_executor_shutdown(mocker):
@@ -23,3 +24,19 @@ def test_executor_shutdown(mocker):
         ws_handler.ws
 
     fexe.shutdown()
+
+
+def test_task_submission_info_stringification():
+    fut_id = 10
+    func_id = "foo_func"
+    ep_id = "bar_ep"
+
+    info = TaskSubmissionInfo(
+        future_id=fut_id, function_id=func_id, endpoint_id=ep_id, args=(), kwargs={}
+    )
+    as_str = str(info)
+    assert as_str.startswith("TaskSubmissionInfo(")
+    assert as_str.endswith("args=..., kwargs=...)")
+    assert "future_id=10" in as_str
+    assert "function_id='foo_func'" in as_str
+    assert "endpoint_id='bar_ep'" in as_str


### PR DESCRIPTION
Mostly for type-checking, but also this clarifies a little what this object is by giving it a nice name.

I also did some very minor cleanup to control-flow to reduce the number of lines of code.