### PR TITLE
remove use of throttling_enabled in smoke_tests

### DIFF
--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -160,7 +160,6 @@ def funcx_test_config(pytestconfig, funcx_test_config_name):
 def fxc(funcx_test_config):
     client_args = funcx_test_config["client_args"]
     fxc = FuncXClient(**client_args)
-    fxc.throttling_enabled = False
     return fxc
 
 


### PR DESCRIPTION
# Description

Another quick one-liner, I was confused by this

https://github.com/funcx-faas/funcX/pull/744/files#diff-2a620095e706c574ee7aa0bd1321a5b2dac605ee3134408854a736d6ae174620L82

then realized `throttling_enabled` option is gone.

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
