### PR TITLE
Enable end-user to specify session id

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -62,6 +62,7 @@ class FuncXClient:
         results_ws_uri=None,
         use_offprocess_checker=True,
         environment=None,
+        task_group_id: t.Union[None, uuid.UUID, str] = None,
         **kwargs,
     ):
         """
@@ -115,6 +116,11 @@ class FuncXClient:
             used by the client.
             Default: True
 
+        task_group_id: str|uuid.UUID
+            Set the TaskGroup ID (a UUID) for this FuncXClient instance.  Typically,
+            one uses this to submit new tasks to an existing session.
+            Default: None (will be auto generated)
+
         Keyword arguments are the same as for BaseClient.
 
         """
@@ -124,10 +130,12 @@ class FuncXClient:
         if results_ws_uri is None:
             results_ws_uri = get_web_socket_url(environment)
 
-        self.func_table = {}
+        self.func_table: t.Dict[str, t.Dict] = {}
         self.use_offprocess_checker = use_offprocess_checker
         self.funcx_home = os.path.expanduser(funcx_home)
-        self.session_task_group_id = str(uuid.uuid4())
+        self.session_task_group_id = (
+            task_group_id and str(task_group_id) or str(uuid.uuid4())
+        )
 
         if not os.path.exists(self.TOKEN_DIR):
             os.makedirs(self.TOKEN_DIR)

--- a/funcx_sdk/funcx/tests/unit/test_client_init.py
+++ b/funcx_sdk/funcx/tests/unit/test_client_init.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 import globus_sdk
@@ -83,3 +84,14 @@ def test_client_init_sets_addresses_by_env(
     # finally, confirm that the addresses were set correctly
     assert client.funcx_service_address == web_uri
     assert client.results_ws_uri == ws_uri
+
+
+def test_client_init_accepts_specified_taskgroup(mocker):
+    mocker.patch("funcx.sdk.client.NativeClient")
+    mocker.patch("funcx.sdk.client.JSONTokenStorage")
+    mocker.patch("funcx.sdk.client.FuncxWebClient")
+    mocker.patch("funcx.sdk.client.FuncXSerializer")
+    mocker.patch("funcx.sdk.client.AuthClient")
+    tg_uuid = uuid.uuid4()
+    fxc = funcx.FuncXClient(task_group_id=tg_uuid)
+    assert fxc.session_task_group_id == str(tg_uuid)


### PR DESCRIPTION
i.e., teach `FuncXClient.__init__` the `task_group_id` argument.

At the moment, a largely transparent change for most users, but will see increased benefit come #11102.

## Type of change

- New feature (non-breaking change that adds functionality)