### PR TITLE
Cleanup for faster client init

### DIFF
--- a/changelog.d/20220331_205242_sirosen_no_userinfo_on_init.rst
+++ b/changelog.d/20220331_205242_sirosen_no_userinfo_on_init.rst
@@ -1,0 +1,18 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``FuncXClient`` may now be passed ``do_version_check=False`` on init,
+  which will lead to faster startup times
+
+Removed
+^^^^^^^
+
+- The ``SearchHelper`` object no longer exposes a method for searching for
+  endpoints, as this functionality was never fully implemented.
+
+Deprecated
+^^^^^^^^^^
+
+- The ``openid_authorizer`` argument to FuncXClient is now deprecated. It can
+  still be passed, but is ignored and will emit a ``DeprecationWarning`` if
+  used


### PR DESCRIPTION
The basic goal here is (much) faster test runs. To achieve this, three changes are made to FuncXClient:

1. Add a new argument, `do_version_check=False` to skip the version check callout

2. Avoid doing a userinfo callout to Globus Auth by removing the need for the user's ID from the SearchHelper object

3. Lazily initialize the SearchHelper object only when accessed as part of a path towards potential deprecation and removal

The tests should have mocked this functionality sufficiently for things to run very quickly, but for some reason they were slow. Perhaps the activities of the SearchHelper object were to blame, or perhaps something was amiss with the mocks. Rather than worry overmuch about exactly how the time was being spent, this "cuts through the noise" by trying to make client initialization faster in general, with tests only being one of the places which benefit.

Additionally, tests are now initializing FuncXClient objects with `do_version_check=False, use_offprocess_checker=False` to attempt to reduce external interactions from this code to nearly-zero.

`openid_authorizer` as an argument is no longer used. Rather than doing nothing, this takes the extra step of marking it as deprecated so that it can be removed in the following release.