### PR TITLE
Remove distutils and reorganize version check

### DIFF
--- a/funcx_endpoint/funcx_endpoint/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/__init__.py
@@ -1,4 +1,4 @@
-from funcx_endpoint.version import VERSION
+from funcx_endpoint.version import __version__ as _version
 
 __author__ = "The funcX team"
-__version__ = VERSION
+__version__ = _version

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -121,7 +121,8 @@ class EndpointManager:
 
         [1] https://docs.python.org/3/library/fcntl.html
         """
-        _ = FuncXClient()
+        client = FuncXClient(do_version_check=False, use_offprocess_checker=False)
+        client.version_check(endpoint_version=__version__)
 
         if os.path.exists(self.funcx_config_file):
             typer.confirm(

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -28,8 +28,6 @@ from funcx_endpoint.executors.high_throughput import (
 )
 from funcx_endpoint.logging_config import setup_logging
 
-from ..version import __version__
-
 log = logging.getLogger(__name__)
 
 
@@ -121,8 +119,9 @@ class EndpointManager:
 
         [1] https://docs.python.org/3/library/fcntl.html
         """
-        client = FuncXClient(do_version_check=False, use_offprocess_checker=False)
-        client.version_check(endpoint_version=__version__)
+        # construct client to force login flow
+        # FIXME: `funcx` should provide a cleaner way of doing login
+        FuncXClient(do_version_check=False, use_offprocess_checker=False)
 
         if os.path.exists(self.funcx_config_file):
             typer.confirm(
@@ -184,10 +183,9 @@ class EndpointManager:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
-            "do_version_check": False,
+            "check_endpoint_version": True,
         }
         funcx_client = FuncXClient(**funcx_client_options)
-        funcx_client.version_check(endpoint_version=__version__)
 
         endpoint_uuid = self.check_endpoint_json(endpoint_json, endpoint_uuid)
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -183,7 +183,6 @@ class EndpointManager:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
-            "check_endpoint_version": True,
         }
         funcx_client = FuncXClient(**funcx_client_options)
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -28,6 +28,8 @@ from funcx_endpoint.executors.high_throughput import (
 )
 from funcx_endpoint.logging_config import setup_logging
 
+from ..version import __version__
+
 log = logging.getLogger(__name__)
 
 
@@ -181,9 +183,10 @@ class EndpointManager:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
-            "check_endpoint_version": True,
+            "do_version_check": False,
         }
         funcx_client = FuncXClient(**funcx_client_options)
+        funcx_client.version_check(endpoint_version=__version__)
 
         endpoint_uuid = self.check_endpoint_json(endpoint_json, endpoint_uuid)
 

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,7 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
 __version__ = "0.3.10-dev"
-VERSION = __version__
 
 # app name to send as part of requests
 app_name = f"funcX Endpoint v{__version__}"

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -2,5 +2,9 @@
 # see https://packaging.python.org/en/latest/single_source_version/
 __version__ = "0.3.10-dev"
 
+# TODO: remove after a `funcx` release
+# this variable is needed because it's imported by `funcx` to do the version check
+VERSION = __version__
+
 # app name to send as part of requests
 app_name = f"funcX Endpoint v{__version__}"

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -55,7 +55,7 @@ TEST_REQUIRES = [
 version_ns = {}
 with open(os.path.join("funcx_endpoint", "version.py")) as f:
     exec(f.read(), version_ns)
-version = version_ns["VERSION"]
+version = version_ns["__version__"]
 
 setup(
     name="funcx-endpoint",

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -110,7 +110,6 @@ class TestStart:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
-            "check_endpoint_version": True,
         }
 
         mock_daemon.assert_called_with(
@@ -252,7 +251,6 @@ class TestStart:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
-            "check_endpoint_version": True,
         }
 
         # We should expect reg_info in this test to be None when passed into

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -110,6 +110,7 @@ class TestStart:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
+            "check_endpoint_version": True,
         }
 
         mock_daemon.assert_called_with(
@@ -251,6 +252,7 @@ class TestStart:
 
         funcx_client_options = {
             "funcx_service_address": endpoint_config.config.funcx_service_address,
+            "check_endpoint_version": True,
         }
 
         # We should expect reg_info in this test to be None when passed into

--- a/funcx_sdk/funcx/__init__.py
+++ b/funcx_sdk/funcx/__init__.py
@@ -1,10 +1,10 @@
 """ funcX : Fast function serving for clouds, clusters and supercomputers.
 
 """
-from funcx.sdk.version import VERSION
+from funcx.sdk.version import __version__ as _version
 
 __author__ = "The funcX team"
-__version__ = VERSION
+__version__ = _version
 
 from funcx.sdk.client import FuncXClient
 from funcx.sdk.errors import FuncxAPIError

--- a/funcx_sdk/funcx/sdk/__init__.py
+++ b/funcx_sdk/funcx/sdk/__init__.py
@@ -1,3 +1,0 @@
-from funcx.sdk.version import VERSION
-
-__all__ = ("VERSION",)

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -12,7 +12,7 @@ VersionType = t.Union[t.Tuple[int, int, int], t.Tuple[int, int, int, str]]
 
 # parse to a tuple
 def parse_version(s: str) -> VersionType:
-    pre: tuple[str, ...] = ()
+    pre: tuple[()] | tuple[str, int] = ()
     if s.endswith("-dev"):
         pre = ("dev", 0)
         s = s.rsplit("-", 1)[0]

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -1,7 +1,29 @@
+from __future__ import annotations
+
+import typing as t
+
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
 __version__ = "0.3.10-dev"
-VERSION = __version__
+
+
+VersionType = t.Union[t.Tuple[int, int, int], t.Tuple[int, int, int, str]]
+
+
+# parse to a tuple
+def parse_version(s: str) -> VersionType:
+    pre: tuple[str, ...] = ()
+    if s.endswith("-dev"):
+        pre = ("dev",)
+        s = s.rsplit("-", 1)[0]
+    vals = s.split(".")
+    if len(vals) != 3:
+        raise ValueError("bad version")
+    return t.cast(VersionType, tuple(int(x) for x in vals) + pre)
+
+
+PARSED_VERSION = parse_version(__version__)
+
 
 # app name to send as part of SDK requests
 app_name = f"funcX SDK v{__version__}"

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -14,7 +14,7 @@ VersionType = t.Union[t.Tuple[int, int, int], t.Tuple[int, int, int, str]]
 def parse_version(s: str) -> VersionType:
     pre: tuple[str, ...] = ()
     if s.endswith("-dev"):
-        pre = ("dev",)
+        pre = ("dev", 0)
         s = s.rsplit("-", 1)[0]
     vals = s.split(".")
     if len(vals) != 3:

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -36,7 +36,7 @@ DEV_REQUIRES = TEST_REQUIRES + [
 version_ns = {}
 with open(os.path.join("funcx", "sdk", "version.py")) as f:
     exec(f.read(), version_ns)
-version = version_ns["VERSION"]
+version = version_ns["__version__"]
 
 setup(
     name="funcx",

--- a/funcx_sdk/tests/unit/test_version_parse.py
+++ b/funcx_sdk/tests/unit/test_version_parse.py
@@ -8,8 +8,8 @@ from funcx.sdk.version import parse_version
     [
         (("1.2.3"), (1, 2, 3)),
         (("0.3.9"), (0, 3, 9)),
-        (("1.2.3-dev"), (1, 2, 3, "dev")),
-        (("0.3.9-dev"), (0, 3, 9, "dev")),
+        (("1.2.3-dev"), (1, 2, 3, "dev", 0)),
+        (("0.3.9-dev"), (0, 3, 9, "dev", 0)),
     ],
 )
 def test_parse_version_ok(as_str, as_tuple):

--- a/funcx_sdk/tests/unit/test_version_parse.py
+++ b/funcx_sdk/tests/unit/test_version_parse.py
@@ -1,0 +1,22 @@
+import pytest
+
+from funcx.sdk.version import parse_version
+
+
+@pytest.mark.parametrize(
+    "as_str, as_tuple",
+    [
+        (("1.2.3"), (1, 2, 3)),
+        (("0.3.9"), (0, 3, 9)),
+        (("1.2.3-dev"), (1, 2, 3, "dev")),
+        (("0.3.9-dev"), (0, 3, 9, "dev")),
+    ],
+)
+def test_parse_version_ok(as_str, as_tuple):
+    assert parse_version(as_str) == as_tuple
+
+
+@pytest.mark.parametrize("bad_version", ["1.2", "1.2.3.4", "1.a.3", "1.0.0-dev-dev"])
+def test_parse_version_bad_version(bad_version):
+    with pytest.raises(ValueError):
+        parse_version(bad_version)


### PR DESCRIPTION
- Remove distutils (deprecated in py3.10). Write a small version parsing helper instead (can use `packaging` in the future)
- ~set do_version_check=False in the endpoint code~
- remove check_endpoint_version as a client init argument
- version_check can now accept the endpoint version as an input (instead of that being automatic from local package versioning information), removing the funcx->funcx-endpoint import path
- ~use the explicit version check in the endpoint code (only once, on start)~

---

Beyond the unit tests for the quick version-parsing helper, I'm not sure what kind of testing this deserves?

EDIT: I've reverted changes to the version check on endpoint start from the endpoint code. These are struck-out above as they are incompatible with the last release of `funcx`.