### PR TITLE
Refactor _update_task_table.

### DIFF
--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 import globus_sdk
 import pytest
+from tests.unit.utils import randomstring
 
 import funcx
+from funcx.serialize import FuncXSerializer
 
 
 @pytest.fixture(autouse=True)
@@ -85,3 +87,56 @@ def test_client_init_accepts_specified_taskgroup(_mock_login):
         task_group_id=tg_uuid, do_version_check=False, use_offprocess_checker=False
     )
     assert fxc.session_task_group_id == str(tg_uuid)
+
+
+@pytest.mark.parametrize(
+    "api_data",
+    [
+        {"status": "Success", "result": True},
+        {"status": "success", "result": True},
+        # Weird but currently technically possible
+        {"status": "Failed", "result": True},
+        {"status": "failed", "exception": True},
+        {"status": "failed", "reason": randomstring()},
+        {"status": "failed", "sentinel": 1},
+        {"status": "asdf", "sentinel": 1},
+    ],
+)
+def test_update_task_table_is_robust(_mock_login, api_data):
+    payload = randomstring()
+    exc = KeyError("asdf")
+    task_id = "some_task_id"
+    serde = FuncXSerializer()
+    data = dict(completion_t=1, **api_data)
+    if data.get("result"):
+        data["result"] = serde.serialize(payload)
+    if data.get("exception"):
+        data["exception"] = serde.serialize(exc)
+
+    # test kernel
+    fxc = funcx.FuncXClient(do_version_check=False, use_offprocess_checker=False)
+    st = fxc._update_task_table(data, task_id)
+
+    # verify results
+    if data.get("status", "").lower() in ("success", "failed"):
+        assert not st["pending"]
+    else:
+        assert st["pending"]
+
+    if "result" in data:
+        assert st["result"] == payload
+        assert "exception" not in st
+    elif not st["pending"]:
+        assert "result" not in st
+        assert "exception" in st
+
+    if "exception" in data:
+        assert exc.__class__ is st["exception"].__class__
+        assert exc.args == st["exception"].args
+    elif "reason" in data:
+        assert Exception is st["exception"].__class__
+        assert (data["reason"],) == st["exception"].args
+    elif not st["pending"] and "result" not in data:
+        assert Exception is st["exception"].__class__
+        for key in data:
+            assert str(key) in str(st["exception"].args)

--- a/funcx_sdk/tests/unit/utils.py
+++ b/funcx_sdk/tests/unit/utils.py
@@ -1,0 +1,6 @@
+import random as _random
+import string as _string
+
+
+def randomstring(length=5, alphabet=_string.ascii_letters):
+    return "".join(_random.choice(alphabet) for _ in range(length))


### PR DESCRIPTION
# Description

The major update here is mostly for robustness.  In the context of reloading tasks, it's possible to request a task from upstream that doesn't exist -- and thus returned from the API as 'Failed' but without an exception.  Catch that case by refactoring logic to better understand "pending" and to always create the exception.

Reviewer suggestion: may have luck seeing what changed by toggling whitespace.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
