### PR TITLE
Correct example use of batch executor

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -49,7 +49,7 @@ More complex cases
 .. code-block:: python
 
    ...
-   fx = FuncXExecutor(FuncXClient())
+   fx = FuncXExecutor(FuncXClient(batch_enabled=True))
 
 
    def double(x):
@@ -58,7 +58,7 @@ More complex cases
    # Here's how you'd launch several functions:
    futures = []
    for i in range(10):
-       futures.append(double(i))
+       futures.append(fx.submit(double, i, endpoint_id=endpoint_id)
 
    # Now wait and print each result:
    for f in futures:


### PR DESCRIPTION
# Description

The documentation for the usage of the executor interface in a batch is incorrect.
