### PR TITLE
Add coverage reporting to tox output for funcx

### DIFF
--- a/funcx_sdk/.coveragerc
+++ b/funcx_sdk/.coveragerc
@@ -1,0 +1,22 @@
+[run]
+include = funcx/*
+
+[report]
+show_missing = True
+skip_covered = True
+
+exclude_lines =
+    # the pragma to disable coverage
+    pragma: no cover
+    # don't complain if tests don't hit unimplemented methods/modes
+    raise NotImplementedError
+    # don't check on executable components of importable modules
+    if __name__ == .__main__.:
+    # don't check coverage on type checking conditionals
+    if TYPE_CHECKING:
+    if t.TYPE_CHECKING:
+    if typing.TYPE_CHECKING:
+    # skip overloads
+    @overload
+    @t.overload
+    @typing.overload

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -27,6 +27,7 @@ TEST_REQUIRES = [
     "numpy",
     "pytest",
     "pytest-mock",
+    "coverage",
     # easy mocking of the `requests` library
     "responses",
 ]

--- a/funcx_sdk/tox.ini
+++ b/funcx_sdk/tox.ini
@@ -5,7 +5,10 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 extras = test
-commands = pytest {posargs}
+commands =
+    coverage erase
+    coverage run -m pytest {posargs}
+    coverage report --skip-covered
 
 [testenv:mypy]
 deps = mypy


### PR DESCRIPTION
Run pytest under `coverage` and report coverage showing the exact lines which are not tested.

I've done a more sophisticated config in other projects which collects coverage data from multiple tox envs, but it's more work to set it up and the benefit would be minimal for us right now. This reports coverage on each env.

Example output:
```
py37 run-test: commands[1] | coverage run -m pytest
======================================================================================================= test session starts =======================================================================================================
platform linux -- Python 3.7.9, pytest-7.1.1, pluggy-1.0.0
cachedir: .tox/py37/.pytest_cache
rootdir: /home/sirosen/dev/funcx/funcx/funcx_sdk, configfile: setup.cfg
plugins: mock-3.7.0
collected 99 items

tests/integration/test_web_client_exceptions.py ................................................                                                                                                                            [ 48%]
tests/unit/test_atomiccontroller.py ...                                                                                                                                                                                     [ 51%]
tests/unit/test_client.py ................................                                                                                                                                                                  [ 83%]
tests/unit/test_environment_lookups.py ..                                                                                                                                                                                   [ 85%]
tests/unit/test_executor.py ..                                                                                                                                                                                              [ 87%]
tests/unit/test_version_parse.py ........                                                                                                                                                                                   [ 95%]
tests/unit/test_web_client.py ...                                                                                                                                                                                           [ 98%]
tests/unit/test_ws_poller.py .                                                                                                                                                                                              [100%]

======================================================================================================= 99 passed in 0.93s ========================================================================================================
py37 run-test: commands[2] | coverage report --skip-covered
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
funcx/sdk/asynchronous/funcx_task.py           10      5    50%   16-17, 20, 28-29
funcx/sdk/asynchronous/ws_polling_task.py     108     66    39%   95, 101, 104-130, 133-135, 150-184, 207-231, 236-237, 242-244, 252, 266-268
funcx/sdk/client.py                           217    128    41%   127, 139-140, 152, 157-160, 175-177, 181-196, 205, 221, 234-235, 244-245, 274-283, 301-309, 313-342, 367-374, 394-397, 410-440, 463-484, 509-517, 534-537, 554-557, 572-573, 610-623, 643, 662, 685-693, 710, 725, 742-747
funcx/sdk/errors/api_error.py                  12      3    75%   18, 22-23
funcx/sdk/executor.py                         183     76    58%   73, 85-86, 143-144, 155-164, 169-181, 206-231, 236-241, 245-266, 273-286, 291, 360-361, 366-377, 381, 386-389
funcx/sdk/login_manager/globus_auth.py          5      2    60%   11-14
funcx/sdk/login_manager/login_flow.py          13      8    38%   11-37
funcx/sdk/login_manager/manager.py             56     27    52%   63, 67, 74-79, 82-88, 91-99, 104-110, 119, 124, 129
funcx/sdk/login_manager/protocol.py            19      6    68%   12, 20, 23, 26, 29, 32
funcx/sdk/login_manager/tokenstore.py          40     27    32%   17, 21-34, 38-43, 47-48, 60-61, 67-71
funcx/sdk/search.py                            59     39    34%   31, 44-50, 69-91, 122-138, 141-144, 151-153, 170-178
funcx/sdk/utils/batch.py                       20     15    25%   15-17, 37-46, 58-64
funcx/sdk/web_client.py                        82     50    39%   25-26, 46-75, 78, 91, 111, 118, 126-131, 134, 137, 148-157, 162, 170-175, 178, 183-186, 191
funcx/serialize/base.py                        48     18    62%   12, 15, 18, 26, 30, 66, 73-78, 83, 86, 89, 95-97, 100
funcx/serialize/concretes.py                   74     26    65%   48-51, 54-57, 77-80, 83-86, 105-106, 109-111, 132-133, 136-138
funcx/serialize/facade.py                     125     77    38%   28-42, 56-73, 76, 79-82, 93-104, 112-124, 130-133, 139, 153, 157, 167-172, 180-187, 195-207
funcx/serialize/off_process_checker.py         54     44    19%   11-47, 53-57, 60-64, 67-70, 73-74
funcx/utils/errors.py                          57     23    60%   5, 12, 15, 22, 25, 32, 35, 44, 47, 56, 59, 66, 69, 76, 83, 86, 93, 96, 103, 106, 114-115, 118
funcx/utils/handle_service_response.py          6      4    33%   15-19
funcx/utils/response_errors.py                260    126    52%   63-64, 67, 70, 73, 83-162, 178-179, 195-197, 207-209, 219-221, 231-233, 243-245, 255-257, 267-269, 279-281, 291-296, 306-308, 318-320, 330-332, 342-344, 356-357, 367-369, 379-381, 393-395, 405-406, 419-421, 431-433, 443-445
-------------------------------------------------------------------------
TOTAL                                        1489    770    48%

10 files skipped due to complete coverage.
```