### PR TITLE
Set executor batch mode active by default

### DIFF
--- a/changelog.d/20220407_145118_benc_executor_batch_default.rst
+++ b/changelog.d/20220407_145118_benc_executor_batch_default.rst
@@ -1,9 +1,9 @@
 Changed
 ^^^^^^^
 
-- FuncXExecutor will use batched submission by default. This can lead to significant 
-  improvements in task submission rate when using the executor interface (for example, 
-  3 seconds to submit 500 tasks vs 2 minutes, in an informal test). However, 
+- FuncXExecutor will use batched submission by default. This can lead to significant
+  improvements in task submission rate when using the executor interface (for example,
+  3 seconds to submit 500 tasks vs 2 minutes, in an informal test). However,
   individual task submission latency may be increased.
 
   To use non-batched submission mode, set batch_mode=False when creating FuncXExecutor.

--- a/changelog.d/20220407_145118_benc_executor_batch_default.rst
+++ b/changelog.d/20220407_145118_benc_executor_batch_default.rst
@@ -6,7 +6,7 @@ Changed
   improves the task submission rate when using the executor interface (for
   example, 3 seconds to submit 500 tasks vs 2 minutes, in an informal test).
   However, individual task submission latency may be increased.
- 
+
   To use non-batched submission mode, set `batch_mode=False` when instantiating
   the `FuncXExecutor <https://funcx.readthedocs.io/en/latest/executor.html>`_
   object.

--- a/changelog.d/20220407_145118_benc_executor_batch_default.rst
+++ b/changelog.d/20220407_145118_benc_executor_batch_default.rst
@@ -1,0 +1,10 @@
+Changed
+^^^^^^^
+
+- FuncXExecutor will use batched submission by default. This can lead to significant 
+  improvements in task submission rate when using the executor interface (for example, 
+  3 seconds to submit 500 tasks vs 2 minutes, in an informal test). However, 
+  individual task submission latency may be increased.
+
+  To use non-batched submission mode, set batch_mode=False when creating FuncXExecutor.
+

--- a/changelog.d/20220407_145118_benc_executor_batch_default.rst
+++ b/changelog.d/20220407_145118_benc_executor_batch_default.rst
@@ -1,10 +1,13 @@
 Changed
 ^^^^^^^
 
-- FuncXExecutor will use batched submission by default. This can lead to significant
-  improvements in task submission rate when using the executor interface (for example,
-  3 seconds to submit 500 tasks vs 2 minutes, in an informal test). However,
-  individual task submission latency may be increased.
-
-  To use non-batched submission mode, set batch_mode=False when creating FuncXExecutor.
+- `FuncXExecutor <https://funcx.readthedocs.io/en/latest/executor.html>`_
+  now uses batched submission by default.  This typically significantly
+  improves the task submission rate when using the executor interface (for
+  example, 3 seconds to submit 500 tasks vs 2 minutes, in an informal test).
+  However, individual task submission latency may be increased.
+ 
+  To use non-batched submission mode, set `batch_mode=False` when instantiating
+  the `FuncXExecutor <https://funcx.readthedocs.io/en/latest/executor.html>`_
+  object.
 

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -102,7 +102,7 @@ class FuncXExecutor(concurrent.futures.Executor):
         self,
         funcx_client: FuncXClient,
         label: str = "FuncXExecutor",
-        batch_enabled: bool = False,
+        batch_enabled: bool = True,
         batch_interval: float = 1.0,
         batch_size: int = 100,
     ):


### PR DESCRIPTION
Developer consensus seems to be that we should have this active by default, driving towards it being our preferred task submission path.

## Type of change

- New feature (non-breaking change that adds functionality)
