### PR TITLE
Use new secrets file for k8s endpoint

### DIFF
--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -4,7 +4,7 @@ mkdir ~/.funcx/$1
 mkdir ~/.funcx/credentials
 cp /funcx/config/config.py ~/.funcx
 cp /funcx/$1/* ~/.funcx/$1
-cp /funcx/credentials/* ~/.funcx/credentials
+cp /funcx/credentials/storage.db ~/.funcx/
 if [ -z "$2" ]; then
   funcx-endpoint start $1
 else


### PR DESCRIPTION
This broke due to work around PR #724 which changes login mechanisms.

Existing users will need to do a user-environment login
and then transcribe the new tokens into a k8s secret
like this:

kubectl delete secret funcx-sdk-tokens
kubectl create secret generic funcx-sdk-tokens --from-file /root/.funcx/storage.db

## Type of change

- Bug fix (non-breaking change that fixes an issue)
