### PR TITLE
Bump versions to 0.4.0a1

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.10-dev"
+__version__ = "0.4.0a1"
 
 # TODO: remove after a `funcx` release
 # this variable is needed because it's imported by `funcx` to do the version check

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
-    "funcx>=0.3.6,<0.4.0",
+    "funcx>=0.3.6,<0.5.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/funcx_sdk/funcx/sdk/version.py
+++ b/funcx_sdk/funcx/sdk/version.py
@@ -4,22 +4,40 @@ import typing as t
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.3.10-dev"
+__version__ = "0.4.0a1"
 
 
-VersionType = t.Union[t.Tuple[int, int, int], t.Tuple[int, int, int, str]]
+VersionType = t.Union[t.Tuple[int, int, int], t.Tuple[int, int, int, str, int]]
 
 
 # parse to a tuple
 def parse_version(s: str) -> VersionType:
     pre: tuple[()] | tuple[str, int] = ()
-    if s.endswith("-dev"):
-        pre = ("dev", 0)
-        s = s.rsplit("-", 1)[0]
     vals = s.split(".")
     if len(vals) != 3:
         raise ValueError("bad version")
-    return t.cast(VersionType, tuple(int(x) for x in vals) + pre)
+    major = int(vals[0])
+    minor = int(vals[1])
+    patch_s: str = vals[2]
+    # handle pre versions:
+    #   X.Y.ZaN
+    #   X.Y.ZbN
+    #   X.Y.Z-dev
+    # no other forms supported (for now)
+    if patch_s.endswith("-dev"):
+        pre = ("dev", 0)
+        patch = int(patch_s.rsplit("-", 1)[0])
+    elif "a" in patch_s or "b" in patch_s:
+        pre_tag = "a" if "a" in patch_s else "b"
+        split_patch_s = patch_s.split(pre_tag)
+        if len(split_patch_s) != 2:
+            raise ValueError("bad version")
+        patch, pre_val = int(split_patch_s[0]), int(split_patch_s[1])
+        pre = (pre_tag, pre_val)
+    else:
+        patch = int(patch_s)
+
+    return t.cast(VersionType, (major, minor, patch) + pre)
 
 
 PARSED_VERSION = parse_version(__version__)

--- a/funcx_sdk/tests/unit/test_version_parse.py
+++ b/funcx_sdk/tests/unit/test_version_parse.py
@@ -10,13 +10,17 @@ from funcx.sdk.version import parse_version
         (("0.3.9"), (0, 3, 9)),
         (("1.2.3-dev"), (1, 2, 3, "dev", 0)),
         (("0.3.9-dev"), (0, 3, 9, "dev", 0)),
+        (("0.4.0a1"), (0, 4, 0, "a", 1)),
     ],
 )
 def test_parse_version_ok(as_str, as_tuple):
     assert parse_version(as_str) == as_tuple
 
 
-@pytest.mark.parametrize("bad_version", ["1.2", "1.2.3.4", "1.a.3", "1.0.0-dev-dev"])
+@pytest.mark.parametrize(
+    "bad_version",
+    ["1.2", "1.2.3.4", "1.a.3", "1.0.0-dev-dev", "0.1.1aa2", "0.1.1a-dev"],
+)
 def test_parse_version_bad_version(bad_version):
     with pytest.raises(ValueError):
         parse_version(bad_version)


### PR DESCRIPTION
Additionally, the version parsing code needs to be bumped to handle alpha version specifiers.

We'll start the alpha line with this. As soon as it merges, I'll release it.