### PR TITLE
Remove texttable from funcx deps

### DIFF
--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -8,8 +8,6 @@ REQUIRES = [
     "globus-sdk>=3.6.0,<4",
     # 'websockets' is used for the client-side websocket listener
     "websockets==9.1",
-    # table printing used in search result rendering
-    "texttable>=1.6.4,<2",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy


### PR DESCRIPTION
All usage of this library was removed from the client package, and although it is used by `funcx-endpoint`, that package
independently lists `texttable` as a dependency. Therefore, we can remove texttable without issue.