### PR TITLE
Improve version comparison rules

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -19,7 +19,7 @@ from funcx.utils.errors import SerializationError, TaskPending, VersionMismatch
 from funcx.utils.handle_service_response import handle_response_errors
 
 from .login_manager import LoginManager, LoginManagerProtocol
-from .version import PARSED_VERSION, parse_version
+from .version import PARSED_VERSION, compare_versions
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +185,7 @@ class FuncXClient:
         min_sdk_version = data["min_sdk_version"]
 
         if endpoint_version is not None:
-            if parse_version(endpoint_version) < parse_version(min_ep_version):
+            if compare_versions(endpoint_version, min_ep_version) == -1:
                 raise VersionMismatch(
                     f"Your version={endpoint_version} is lower than the "
                     f"minimum version for an endpoint: {min_ep_version}.  "
@@ -193,7 +193,7 @@ class FuncXClient:
                     f"pip install funcx-endpoint>={min_ep_version}"
                 )
         else:
-            if PARSED_VERSION < parse_version(min_sdk_version):
+            if compare_versions(PARSED_VERSION, min_sdk_version) == -1:
                 raise VersionMismatch(
                     f"Your version={PARSED_VERSION} is lower than the "
                     f"minimum version for funcx SDK: {min_sdk_version}.  "

--- a/funcx_sdk/tests/unit/test_version_parse.py
+++ b/funcx_sdk/tests/unit/test_version_parse.py
@@ -1,6 +1,6 @@
 import pytest
 
-from funcx.sdk.version import parse_version
+from funcx.sdk.version import compare_versions, parse_version
 
 
 @pytest.mark.parametrize(
@@ -24,3 +24,31 @@ def test_parse_version_ok(as_str, as_tuple):
 def test_parse_version_bad_version(bad_version):
     with pytest.raises(ValueError):
         parse_version(bad_version)
+
+
+@pytest.mark.parametrize(
+    "left,right,expect_result",
+    [
+        # non pre-versions
+        ("1.2.3", "1.2.3", 0),
+        ("1.2.3", "1.2.4", -1),
+        # 'dev' allowed to match anything if the non-pre versions are equal
+        ("1.2.3-dev", "1.2.3", 0),
+        ("1.2.3-dev", "1.2.3-dev", 0),
+        ("1.2.3a1", "1.2.3-dev", 0),
+        ("1.2.3-dev", "1.2.3b2", 0),
+        # alpha and beta comparisons work as expected
+        ("1.2.3a1", "1.2.3a1", 0),  # equal alphas
+        ("1.2.3a2", "1.2.3a1", 1),  # mismatched alphas
+        ("1.2.3b1", "1.2.3a1", 1),  # alpha vs beta
+        ("1.2.3b1", "1.2.3b1", 0),  # equal betas
+        # alpha, beta, and dev versions take a back-seat  to
+        # mistmatched MAJOR.MINOR.PATCH
+        ("1.2.5a1", "1.2.4b1", 1),  # alpha vs beta
+        ("1.2.5a1", "1.2.4-dev", 1),  # alpha vs dev
+        ("1.2.5", "1.2.4-dev", 1),  # dev vs non-pre
+    ],
+)
+def test_compare_versions(left, right, expect_result):
+    assert compare_versions(left, right) == expect_result
+    assert compare_versions(right, left) == -expect_result


### PR DESCRIPTION
- add a comparator helper
- allow 'dev' to match alphas, betas, and non-pre-versions as "equal"
- ensure that pre-versions are compared "trimmed" against non-pre-versions
- comprehensively test all cases of version comparison

---

I find the comparator helper a little messy because it's very "C-style" rather than making objects which can be compared with native comparators. But it's also very straightforward and readable.
If we wanted fancy objects, I'd favor pulling in `packaging` and using the version parsing code it provides.