### PR TITLE
Removing unnecessary cmd_line flag

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_publisher.py
@@ -48,7 +48,7 @@ class TaskQueuePublisher:
         self._channel.exchange_declare(
             exchange=self.exchange, exchange_type=self.exchange_type
         )
-        self._channel.queue_declare(queue=self.queue_name)
+        self._channel.queue_declare(queue=self.queue_name, durable=True)
         self._channel.queue_bind(self.queue_name, self.exchange)
         self.status = RabbitPublisherStatus.connected
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -201,7 +201,9 @@ class TaskQueueSubscriber(multiprocessing.Process):
 
         """
         logger.info("Declaring queue %s", queue_name)
-        self._channel.queue_declare(queue_name, callback=self._on_queue_declareok)
+        self._channel.queue_declare(
+            queue_name, durable=True, callback=self._on_queue_declareok
+        )
 
     def _on_queue_declareok(self, method_frame):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -8,7 +8,7 @@ cp /funcx/credentials/storage.db ~/.funcx/
 if [ -z "$2" ]; then
   funcx-endpoint start $1
 else
-  funcx-endpoint start $1 --endpoint-uuid $2
+  funcx-endpoint start $1 $2
 fi
 
 while pgrep funcx-endpoint >/dev/null;


### PR DESCRIPTION
# Description

This PR removes and unnecessary `--endpoint-uuid` cmd line flag used in the docker boot script. 