### PR TITLE
Don't try to close channel if connection failed

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -82,6 +82,8 @@ class ResultQueuePublisher:
             raise
 
     def close(self):
-        self._channel.close()
-        self._connection.close()
+        if self._channel is not None:
+            self._channel.close()
+        if self._connection is not None:
+            self._connection.close()
         self.status = RabbitPublisherStatus.closed


### PR DESCRIPTION
This attempt to `close()` while `self._channel == None` results in an attribute error when the "real" error is a failure to connect.