### PR TITLE
Fix FuncXExecutor docstring that was causing sphinx errors

### DIFF
--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -289,7 +289,7 @@ class FuncXExecutor(concurrent.futures.Executor):
         Load the set of tasks associated with this Executor's Task Group (FuncXClient)
         from the server and return a set of futures, one for each task.  This is
         nominally intended to "reattach" to a previously initiated session, based on
-        the Task Group ID.  An example use might be:
+        the Task Group ID.  An example use might be::
 
             import sys
             import typing as T


### PR DESCRIPTION

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
