### PR TITLE
Fix graceful endpoint shutdown

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -371,7 +371,8 @@ class Endpoint:
                 processes.append(parent)
                 for p in processes:
                     p.send_signal(signal.SIGTERM)
-                terminated, alive = psutil.wait_procs(processes, timeout=0.2)
+                # graceful RabbitMQ cleanup takes some time
+                terminated, alive = psutil.wait_procs(processes, timeout=10)
                 for p in alive:
                     # sometimes a process that was marked as alive before can terminate
                     # before this signal is sent

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -42,8 +42,6 @@ class TestStart:
             assert executor.endpoint_id == "mock_endpoint_id"
 
     def test_start_no_reg_info(self, mocker, funcx_dir):
-        mocker.patch("funcx_endpoint.endpoint.interchange.threading.Thread")
-
         def _fake_retry(func, *args, **kwargs):
             return func()
 
@@ -100,6 +98,9 @@ class TestStart:
         # this must be set to force the retry loop in the start method to only run once
         ic._test_start = True
         ic.start()
+        assert ic._task_puller_proc.is_alive()
+        ic._quiesce_event.set()
+        ic._task_puller_proc.join()
 
         # we need to ensure that retry_call is called during interchange
         # start if reg_info has not been passed into the interchange


### PR DESCRIPTION
# Description

- `quiesce` handling in the endpoint needs to be fixed a bit: The idea here is that for graceful shutdown we should simply set the kill/quiesce events without calling anything else, then the `_main_loop` will see these events and gracefully stop
- Child processes seem to be inheriting the main process SIGTERM handler which gets messy (see: https://app.shortcut.com/funcx/story/14977/endpoint-child-processes-inheriting-main-sigterm-handler)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
