### PR TITLE
`heartbeat_threshold` -> `heartbeat_period`

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -330,7 +330,7 @@ class EndpointInterchange:
         last = time.time()
 
         while not self._quiesce_event.is_set() and not self._kill_event.is_set():
-            if last + self.heartbeat_threshold < time.time():
+            if last + self.heartbeat_period < time.time():
                 log.debug("alive")
                 last = time.time()
 


### PR DESCRIPTION
Update loop to use `heartbeat_period` not `heartbeat_threshold`.  Nominally, the threshold is for "grace period" use, rather than a standard "periodic check."

## Type of change

- Code maintenance/cleanup