### PR TITLE
In workflows using tox, ensure pip is up to date

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,8 +60,8 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install tox
-        run: python -m pip install tox
+      - run: python -m pip install -U pip setuptools
+      - run: python -m pip install tox
       - name: run tests
         run: |
           cd funcx_sdk
@@ -79,8 +79,8 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install tox
-        run: python -m pip install tox
+      - run: python -m pip install -U pip setuptools
+      - run: python -m pip install tox
       - name: run tests
         run: |
           cd funcx_endpoint

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: install tox
-      run: python -m pip install 'tox'
+    - run: python -m pip install -U pip setuptools
+    - run: python -m pip install 'tox'
     - name: run smoke tests (dev)
       env:
         FUNCX_SMOKE_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}

--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -19,8 +19,8 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install dependencies for funcx-sdk and test requirements
-      run: python -m pip install 'tox'
+    - run: python -m pip install -U pip setuptools
+    - run: python -m pip install tox
     - name: Run smoke tests to check liveness of hosted services
       env:
         FUNCX_SMOKE_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: install requirements
-      run: python -m pip install tox
+    - run: python -m pip install -U pip setuptools
+    - run: python -m pip install tox
     - name: Run smoke tests (localdeps)
       env:
         FUNCX_SMOKE_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}


### PR DESCRIPTION
Whenever we `pip install tox`, first `pip install -U pip setuptools`.
This ensures that we get the latest `tox` version and that dependency solving is done correctly.