### PR TITLE
Teach tests knowledge of RMQ env var

### DIFF
--- a/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/tests/conftest.py
@@ -1,8 +1,44 @@
+import os
 import uuid
 
+import pika
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def endpoint_uuid():
     return str(uuid.UUID(int=0))
+
+
+@pytest.fixture(scope="session")
+def default_endpoint_id():
+    return str(uuid.UUID(int=1))
+
+
+@pytest.fixture(scope="session")
+def other_endpoint_id():
+    return str(uuid.UUID(int=2))
+
+
+@pytest.fixture(scope="session")
+def rabbitmq_conn_url():
+    env_var_name = "RABBITMQ_INTEGRATION_TEST_URI"
+    rmq_test_uri = os.getenv(env_var_name, "amqp://guest:guest@localhost:5672/")
+
+    try:
+        # Die here and now, first thing, with a hopefully-helpful direct fix suggestion
+        # if rmq_test_uri is invalid or otherwise "not working."
+        pika.BlockingConnection(pika.URLParameters(rmq_test_uri))
+    except Exception as exc:
+        msg = (
+            f"Failed to connect to RabbitMQ via URI: {rmq_test_uri}\n"
+            f"  Do you need to export {env_var_name} ?  Typo?"
+        )
+        raise ValueError(msg) from exc
+
+    return rmq_test_uri
+
+
+@pytest.fixture()
+def pika_conn_params(rabbitmq_conn_url):
+    return pika.URLParameters(rabbitmq_conn_url)

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/conftest.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/conftest.py
@@ -1,17 +1,10 @@
 import pika
 import pytest
 
-G_CONN_PARAMS = pika.URLParameters("amqp://guest:guest@localhost:5672/")
-
-
-@pytest.fixture()
-def conn_params():
-    return G_CONN_PARAMS
-
 
 @pytest.fixture(scope="session")
-def ensure_result_queue():
-    connection = pika.BlockingConnection(G_CONN_PARAMS)
+def ensure_result_queue(pika_conn_params):
+    connection = pika.BlockingConnection(pika_conn_params)
     channel = connection.channel()
     channel.exchange_declare(
         exchange="results",
@@ -25,4 +18,3 @@ def ensure_result_queue():
     )
     channel.close()
     connection.close()
-    return

--- a/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_result_q_heartbeat.py
@@ -6,11 +6,11 @@ import pytest
 
 
 @pytest.mark.parametrize("use_heartbeat", [None, 1])
-def test_no_heartbeat(start_result_q_publisher, conn_params, use_heartbeat):
+def test_no_heartbeat(start_result_q_publisher, pika_conn_params, use_heartbeat):
     """Confirm that result_q_publisher does not disconnect when delay
     between messages exceed heartbeat period
     """
-    conn_params = copy.deepcopy(conn_params)
+    conn_params = copy.deepcopy(pika_conn_params)
     conn_params.heartbeat = use_heartbeat
     conn_params.blocked_connection_timeout = 2
 

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -3,8 +3,10 @@ envlist = py{37,310}
 skip_missing_interpreters = true
 
 [testenv]
-usedevelop = true
+passenv =
+    RABBITMQ_INTEGRATION_TEST_URI
 extras = test
+usedevelop = true
 commands =
     coverage erase
     coverage run -m pytest {posargs}


### PR DESCRIPTION
# Description

This is a first PR to begin teaching our testing infrastructure to make use of certain environment variables.  In this case, teach the `funcx_endpoint` subproject to use `RABBITMQ_INTEGRATION_TEST_URI` if available, but fallback to a suitable default.

A friendly shell reminder that to use it, can either set it per invocation:
    
    $ RABBITMQ_INTEGRATION_TEST_URI=amqp://u:p@rabbit... tox -e py
    
or export for the entire shell session:
    
    $ export RABBITMQ_INTEGRATION_TEST_URI=amqp://u:p@rabbit...
    $ tox -e py
    
Meanwhile, DRY out the fixtures a bit by utilizing the shared hierarchy.

## Type of change

- Code maintenance/cleanup
