### PR TITLE
Refactor unsafe scoping

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -46,12 +46,14 @@ class ResultQueuePublisher:
 
         self.routing_key = f"{self.endpoint_id}.results"
 
-    def connect(self) -> None:
-        """Connect
+    def __enter__(self):
+        pass
 
-        :rtype: pika.BlockingConnection
-        """
-        logger.info(f"Connecting to {self.conn_params}")
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.status == RabbitPublisherStatus.connected:
+            self.close()
+
+    def connect(self) -> ResultQueuePublisher:
         self._connection = pika.BlockingConnection(self.conn_params)
         self._channel = self._connection.channel()
         self._channel.confirm_delivery()
@@ -66,6 +68,7 @@ class ResultQueuePublisher:
             routing_key=self.GLOBAL_ROUTING_KEY,
         )
         self.status = RabbitPublisherStatus.connected
+        return self
 
     def publish(self, message: bytes) -> None:
         """Publish message to RabbitMQ with the routing key to identify the message source

--- a/funcx_endpoint/tests/unit/test_endpointinterchange.py
+++ b/funcx_endpoint/tests/unit/test_endpointinterchange.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from funcx_endpoint.endpoint.interchange import EndpointInterchange
+
+
+def test_main_exception_always_quiesces(mocker, tmp_path):
+    false_true_g = iter((False, True))
+
+    def false_true():
+        return next(false_true_g)
+
+    mock_conf = MagicMock()
+    mocker.patch("funcx_endpoint.endpoint.interchange.FuncXClient")
+    mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing")
+    mocker.patch("funcx_endpoint.endpoint.interchange.mpQueue")
+    ei = EndpointInterchange(
+        config=mock_conf,
+        logdir=str(tmp_path),
+        endpoint_dir=str(tmp_path),
+        results_ack_handler=MagicMock(),
+    )
+    ei._task_puller_proc = MagicMock()
+    ei._start_threads_and_main = MagicMock()
+    ei._start_threads_and_main.side_effect = Exception("Woot")
+    ei._kill_event.is_set = false_true
+    ei.start()
+
+    ei._quiesce_event.set.assert_called()


### PR DESCRIPTION
The main goal is to reduce the scoping of `self.results_outgoing`.  It was set inside the main loop function but accessed outside.  Reduce the scope, then move the try-except clause closer to it's intended protectee: the `quiesce()` invocation.  Finally, back it up with a unit test.

Along the way to SC-14129.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
