### PR TITLE
Mypy fix for Python 3.7

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
@@ -112,8 +112,8 @@ class Task(Message):
             # all of this code is going to be eliminated soonish by
             # funcx_common.messagepack in part because of issues like this
             add_ons = (
-                f"TID={self.task_id};CID={self.container_id};"
-                f"{self.task_buffer}"  # type: ignore
+                f"TID={self.task_id};CID={self.container_id};"  # type: ignore
+                f"{self.task_buffer}"
             )
             self.raw_buffer = add_ons.encode("utf-8")
 


### PR DESCRIPTION
# Description

On python 3.7, running `tox -e mypy` against the endpoint fails. This tweak moves the `type: ignore` annotation introduced in the recent `mypy` fixup up one line so that `mypy` runs successfully on this version.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)