### PR TITLE
Pin the exact version of funcx-common

### DIFF
--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
     "funcx==0.4.0a1",
-    "funcx_common>=0.0.13",
+    "funcx-common==0.0.13",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer


### PR DESCRIPTION
This library does not offer *any* backwards compatibility guarantees. As such, we need to always pin to an exact version.