### PR TITLE
Bump websockets to v10.3.

### DIFF
--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     "requests>=2.20.0",
     "globus-sdk>=3.6.0,<4",
     # 'websockets' is used for the client-side websocket listener
-    "websockets==9.1",
+    "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy


### PR DESCRIPTION
Necessary to support Python 3.10; otherwise, will fall victim to [websockets issue #916](https://github.com/aaugustin/websockets/issues/916).

## Type of change

- Bug fix