### PR TITLE
Remove `TaskStatusCode` and replace it with `TaskState` from `funcx-common`

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import psutil
 import zmq
+from funcx_common.tasks import TaskState
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.version import VERSION as PARSL_VERSION
 
@@ -29,7 +30,6 @@ from funcx_endpoint.executors.high_throughput.messages import (
     ManagerStatusReport,
     Message,
     Task,
-    TaskStatusCode,
 )
 from funcx_endpoint.executors.high_throughput.worker_map import WorkerMap
 from funcx_endpoint.logging_config import setup_logging
@@ -240,7 +240,7 @@ class Manager:
         self.next_worker_q: list[str] = []  # FIFO queue for spinning up workers.
         self.worker_procs: dict[str, subprocess.Popen] = {}
 
-        self.task_status_deltas: dict[str, TaskStatusCode] = {}
+        self.task_status_deltas: dict[str, TaskState] = {}
 
         self._kill_event = threading.Event()
         self._result_pusher_thread = threading.Thread(
@@ -646,7 +646,7 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            self.task_status_deltas[task.task_id] = TaskStatusCode.RUNNING
+            self.task_status_deltas[task.task_id] = TaskState.RUNNING
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,
                 "task_type": task_type,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -16,6 +16,7 @@ from typing import Any, Sequence
 
 import daemon
 import zmq
+from funcx_common.tasks import TaskState
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.errors import ScalingFailed
 from parsl.version import VERSION as PARSL_VERSION
@@ -31,7 +32,6 @@ from funcx_endpoint.executors.high_throughput.messages import (
     Heartbeat,
     Message,
     MessageType,
-    TaskStatusCode,
 )
 from funcx_endpoint.logging_config import setup_logging
 
@@ -339,7 +339,7 @@ class Interchange:
 
         self.task_cancel_running_queue: queue.Queue = queue.Queue()
         self.task_cancel_pending_trap: dict[str, str] = {}
-        self.task_status_deltas: dict[str, TaskStatusCode] = {}
+        self.task_status_deltas: dict[str, TaskState] = {}
         self.container_switch_count: dict[str, int] = {}
 
     def load_config(self):
@@ -457,7 +457,7 @@ class Interchange:
                     }
                 )
                 self.total_pending_task_count += 1
-                self.task_status_deltas[msg.task_id] = TaskStatusCode.WAITING_FOR_NODES
+                self.task_status_deltas[msg.task_id] = TaskState.WAITING_FOR_NODES
                 log.debug(
                     f"[TASK_PULL_THREAD] task {msg.task_id} is now WAITING_FOR_NODES"
                 )
@@ -891,7 +891,7 @@ class Interchange:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
                             self.task_status_deltas[
                                 task_id
-                            ] = TaskStatusCode.WAITING_FOR_LAUNCH
+                            ] = TaskState.WAITING_FOR_LAUNCH
 
             # Receive any results and forward to client
             if (

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
@@ -28,15 +28,6 @@ class MessageType(Enum):
         return MessageType(mtype), buffer[MESSAGE_TYPE_FORMATTER.size :]
 
 
-class TaskStatusCode(int, Enum):
-    WAITING_FOR_NODES = auto()
-    WAITING_FOR_LAUNCH = auto()
-    RUNNING = auto()
-    SUCCESS = auto()
-    FAILED = auto()
-    CANCELLED = auto()
-
-
 COMMAND_TYPES = {MessageType.HEARTBEAT_REQ, MessageType.TASK_CANCEL}
 
 


### PR DESCRIPTION
# Description

In service of decoupling the services from the endpoint, this removes `TaskStatusCode`, as originally defined in the HTEX, and replaces it with `TaskState`, a pre-existing enum defined in `funcx-common`.

Related to [sc-16360]

## Type of change

- Code maintenance/cleanup
