### PR TITLE
Common version logging

### DIFF
--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
     "funcx==0.4.0a1",
-    "funcx-common==0.0.13",
+    "funcx-common==0.0.14",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -11,6 +11,7 @@ import typing as t
 import uuid
 
 import globus_sdk
+from funcx_common.sdk_version_sharing import user_agent_substring
 
 from funcx.sdk._environments import get_web_service_url
 from funcx.sdk.errors import FuncxAPIError
@@ -158,7 +159,7 @@ class FuncxWebClient(globus_sdk.BaseClient):
     @user_app_name.setter
     def user_app_name(self, value):
         self._user_app_name = value
-        app_name = f"funcx-sdk-{__version__}"
+        app_name = user_agent_substring(__version__)
         if value is not None:
             app_name += f"/{value}"
         globus_sdk.BaseClient.app_name.fset(self, app_name)

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -18,6 +18,7 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
+    "funcx-common==0.0.14",
 ]
 DOCS_REQUIRES = [
     "sphinx<5",


### PR DESCRIPTION
# Description

I recently introduced some shared version logging code to `funcx-common` - this PR simply removes the old SDK version logging code from the web service and changes it to use the `funcx-common` module instead.

## Type of change

- Code maintenance/cleanup
