### PR TITLE
Fix mismatch that happens when web-service declares a queue as durable but tests do not

### DIFF
--- a/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/tests/conftest.py
@@ -69,7 +69,7 @@ def _flush_results(pika_conn_params):
                 exchange_type="topic",
                 durable=True,
             )
-            chan.queue_declare(queue=queue_name)
+            chan.queue_declare(queue=queue_name, durable=True)
             chan.queue_purge(queue=queue_name)
 
 

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -34,7 +34,7 @@ def ensure_result_queue(pika_conn_params):
                 "durable": True,
             }
         if not queue_opts:
-            queue_opts = {"queue": "results"}
+            queue_opts = {"queue": "results", "durable": True}
         # play nice with dev/test resources; auto clean
         queue_opts.setdefault("arguments", {"x-expires": 30 * 1000})
 

--- a/funcx_endpoint/tests/test_rabbit_mq/result_queue_subscriber.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/result_queue_subscriber.py
@@ -170,7 +170,9 @@ class ResultQueueSubscriber(multiprocessing.Process):
 
         """
         logger.info("Exchange declared. Declaring queue %s", self.QUEUE_NAME)
-        self._channel.queue_declare(self.QUEUE_NAME, callback=self._on_queue_declareok)
+        self._channel.queue_declare(
+            self.QUEUE_NAME, callback=self._on_queue_declareok, durable=True
+        )
 
     def _on_queue_declareok(self, method_frame):
         """Method invoked by pika when the Queue.Declare RPC call made in


### PR DESCRIPTION
# Description

Small fix that came about as I was cleaning my dev environment. Currently if you try to run tests using a local kubernetes cluster as the rabbitmq instance for integrations, many calls to `queue_declare` result in an error due to the fact that the web-service declares the 'results' queue as `durable=true` while tests declare it as `durable=false` (the default).

## Type of change

- Code maintenance/cleanup
