### PR TITLE
Slack notification for tests

### DIFF
--- a/.github/_support/github-slack-notify.py
+++ b/.github/_support/github-slack-notify.py
@@ -22,7 +22,7 @@ def statusemoji(status):
 
 
 def get_message_title():
-    return os.getenv("SLACK_MESSAGE_TITLE", "GitHub Actions Build")
+    return os.getenv("SLACK_MESSAGE_TITLE", "GitHub Actions Tests")
 
 
 def get_build_url():
@@ -97,7 +97,7 @@ def check_status_changed(status):
 
 
 def get_failure_message():
-    return os.getenv("SLACK_FAILURE_MESSAGE", "tests failed")
+    return os.getenv("SLACK_FAILURE_MESSAGE", "@here tests failed")
 
 
 def build_payload(status):

--- a/.github/_support/github-slack-notify.py
+++ b/.github/_support/github-slack-notify.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+"""
+A script which runs as part of our GitHub Actions build to send notifications
+to Slack. Notifies when build status changes.
+
+Usage:
+    ./github-slack-notify.py $STATUS
+
+where $STATUS is the current build status.
+Requires GITHUB_TOKEN and SLACK_WEBHOOK_URL to be in the environment.
+"""
+import os
+import sys
+
+import requests
+
+
+def statusemoji(status):
+    return {"success": ":heavy_check_mark:", "failure": ":rotating_light:"}.get(
+        status, ":warning:"
+    )
+
+
+def get_message_title():
+    return os.getenv("SLACK_MESSAGE_TITLE", "GitHub Actions Build")
+
+
+def get_build_url():
+    return "https://github.com/{GITHUB_REPOSITORY}/commit/{GITHUB_SHA}/checks".format(
+        **os.environ
+    )
+
+
+def is_pr_build():
+    return os.environ["GITHUB_REF"].startswith("refs/pull/")
+
+
+def get_branchname():
+    # split on slashes, strip 'refs/heads/*' , and rejoin
+    # this is also the tag name if a tag is used
+    return "/".join(os.environ["GITHUB_REF"].split("/")[2:])
+
+
+def _get_workflow_id_map():
+    repo = os.environ["GITHUB_REPOSITORY"]
+    token = os.environ["GITHUB_TOKEN"]
+    r = requests.get(
+        f"https://api.github.com/repos/{repo}/actions/workflows",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+    )
+
+    ret = {}
+    for w in r.json().get("workflows", []):
+        ret[w["name"]] = w["id"]
+    print(f">> workflow IDs: {ret}")
+    return ret
+
+
+def get_last_build_status():
+    branch = get_branchname()
+    repo = os.environ["GITHUB_REPOSITORY"]
+    token = os.environ["GITHUB_TOKEN"]
+    workflow_id = _get_workflow_id_map()[os.environ["GITHUB_WORKFLOW"]]
+
+    r = requests.get(
+        f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_id}/runs",
+        params={"branch": branch, "status": "completed", "per_page": 1},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+    )
+    print(f">> get past workflow runs params: branch={branch},repo={repo}")
+    print(f">> get past workflow runs result: status={r.status_code}")
+    runs_docs = r.json().get("workflow_runs", [])
+    # no suitable status was found for a previous build, so the status is "None"
+    if not runs_docs:
+        print(">>> no previous run found for workflow")
+        return None
+    conclusion = runs_docs[0]["conclusion"]
+    print(f">>> previous run found with conclusion={conclusion}")
+    return conclusion
+
+
+def check_status_changed(status):
+    # NOTE: last_status==None is always considered a change. This is intentional
+    last_status = get_last_build_status()
+    res = last_status != status
+    if res:
+        print(f"status change detected (old={last_status}, new={status})")
+    else:
+        print(f"no status change detected (old={last_status}, new={status})")
+    return res
+
+
+def get_failure_message():
+    return os.getenv("SLACK_FAILURE_MESSAGE", "tests failed")
+
+
+def build_payload(status):
+    context = f"{statusemoji(status)} build for {get_branchname()}: {status}"
+    message = f"<{get_build_url()}|{get_message_title()}>"
+    if status == "failure":
+        message = f"{message}: {get_failure_message()}"
+
+    return {
+        "channel": os.getenv("SLACK_CHANNEL", "#testing"),
+        "username": "github-actions",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": message}},
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": context}]},
+        ],
+    }
+
+
+def on_main_repo():
+    """check if running from a fork"""
+    return os.environ["GITHUB_REPOSITORY"] == "funcx-faas/funcx"
+
+
+def should_notify(status):
+    return check_status_changed(status) and on_main_repo() and not is_pr_build()
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(2)
+    status = sys.argv[1]
+    if should_notify(status):
+        r = requests.post(os.environ["SLACK_WEBHOOK_URL"], json=build_payload(status))
+        print(f">> webhook response: status={r.status_code}")
+        print(r.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -55,22 +55,22 @@ jobs:
     - name: run safety check
       run: safety check
 
-  notify:
-    runs-on: ubuntu-latest
+  slack-notify:
     needs:
       - safety-check-sdk
       - safety-check-endpoint
-    if: failure()
+    if: always()
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
     steps:
-      # FIXME: make this send to a listhost or Slack
-      - name: Send mail
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: ${{ github.repository }} - Daily Check ${{ job.status }}
-          to: ryan.chard@gmail.com,rchard@anl.gov,chard@uchicago.edu,yadudoc1729@gmail.com,josh@globus.org,bengal1@illinois.edu,benc@hawaga.org.uk,sirosen@globus.org
-          from: funcX Tests # <user@example.com>
-          body: The daily ${{ github.repository }} workflow failed!
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install -U requests
+      - name: notify slack
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#commits'
+          SLACK_MESSAGE_TITLE: 'Daily Smoke Tests'
+          SLACK_FAILURE_MESSAGE: 'Daily test failed'
+        run: ./.github/_support/github-slack-notify.py ${{ needs.test.result }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -57,6 +57,7 @@ jobs:
 
   slack-notify:
     needs:
+      - smoke-test-dev
       - safety-check-sdk
       - safety-check-endpoint
     if: always()
@@ -73,4 +74,4 @@ jobs:
           SLACK_CHANNEL: '#commits'
           SLACK_MESSAGE_TITLE: 'Daily Smoke Tests'
           SLACK_FAILURE_MESSAGE: 'Daily test failed'
-        run: ./.github/_support/github-slack-notify.py ${{ needs.test.result }}
+        run: ./.github/_support/github-slack-notify.py ${{ needs.smoke-test-dev.result }}

--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -45,4 +45,4 @@ jobs:
           SLACK_CHANNEL: '#commits'
           SLACK_MESSAGE_TITLE: 'Hourly Automated Tests'
           SLACK_FAILURE_MESSAGE: 'Hourly run failed'
-        run: ./.github/_support/github-slack-notify.py ${{ needs.test.result }}
+        run: ./.github/_support/github-slack-notify.py ${{ needs.smoke-test.result }}

--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -29,20 +29,20 @@ jobs:
         cd smoke_tests
         make prod
 
-  notify:
-    runs-on: ubuntu-latest
+  slack-notify:
     needs: [smoke-test]
-    if: failure()
+    if: always()
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
     steps:
-      # FIXME: make this send to a listhost or Slack
-      - name: Send mail
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: ${{ github.repository }} - Hourly smoke test failed
-          to: ryan.chard@gmail.com,rchard@anl.gov,chard@uchicago.edu,yadudoc1729@gmail.com,josh@globus.org,bengal1@illinois.edu,benc@hawaga.org.uk,sirosen@globus.org
-          from: funcX Tests # <user@example.com>
-          body: The hourly ${{ github.repository }} workflow failed!
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install -U requests
+      - name: notify slack
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#commits'
+          SLACK_MESSAGE_TITLE: 'Hourly Automated Tests'
+          SLACK_FAILURE_MESSAGE: 'Hourly run failed'
+        run: ./.github/_support/github-slack-notify.py ${{ needs.test.result }}


### PR DESCRIPTION
# Description

Updates the daily and hourly tests to alert of failures using slack notifications. This change includes the slack notification script and modifies the two workflows to use it rather than send an email. The default message includes a here notification and will raise an alert when the status of the job changes.

Fixes # [sc-16011]
