### PR TITLE
Update pre-commit.ci to point at 'rabbitmq'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,8 @@ repos:
   hooks:
     - id: flake8
       additional_dependencies: ['flake8-bugbear==21.4.3']
+
+
+ci:
+  # remove this once the 'rabbitmq' branch merges
+  autoupdate_branch: rabbitmq


### PR DESCRIPTION
Until this branch merges, having auto-update PRs against `main` is the wrong place. Once it merges, we should revert this config.

---

pre-commit.ci gives us weekly auto-update PRs like #823

This is the necessary config to point those PRs at our current mainline branch. It is read from the repo-default branch, which is `main`. As such, this is a PR against `main` rather than `rabbitmq`. As I have in the past, I will do a manual merge-back to `rabbitmq` to re-synchronize the branches after this is merged.