### PR TITLE
Update "compat" funcx-endpoint error imports

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -16,18 +16,13 @@ import psutil
 import texttable
 from globus_sdk import GlobusAPIError, NetworkError
 
+from funcx.errors import FuncxResponseError
 from funcx.sdk.client import FuncXClient
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
 from funcx_endpoint.endpoint.register_endpoint import register_endpoint
 from funcx_endpoint.endpoint.results_ack import ResultsAckHandler
 from funcx_endpoint.logging_config import setup_logging
-
-# temporary: try both import paths; update to the new path in the next release
-try:
-    from funcx.errors import FuncxResponseError
-except ImportError:
-    from funcx.utils.response_errors import FuncxResponseError
 
 log = logging.getLogger(__name__)
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -13,14 +13,9 @@ import types
 import typing as t
 
 import zmq
-
-try:
-    from funcx.errors import MaxResultSizeExceeded
-except ImportError:
-    from funcx.utils.errors import MaxResultSizeExceeded
-
 from funcx_common import messagepack
 
+from funcx.errors import MaxResultSizeExceeded
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.executors.high_throughput.messages import Message
 from funcx_endpoint.logging_config import setup_logging


### PR DESCRIPTION
In several places, imports are done with an ImportError handler to manage the relocation of error classes. Now that v0.4.0a2 is published to pypi, remove this handling.

Equivalent handling is *not* removed from smoke_tests because those will need to work against the last non-alpha funcx version for now.