### PR TITLE
Fix smoke tests to work against prod

### DIFF
--- a/smoke_tests/Makefile
+++ b/smoke_tests/Makefile
@@ -2,4 +2,4 @@
 prod:
 	tox
 dev:
-	tox -- --funcx-config dev
+	tox -e localdeps -- --funcx-config dev

--- a/smoke_tests/tests/test_s3_indirect.py
+++ b/smoke_tests/tests/test_s3_indirect.py
@@ -1,7 +1,12 @@
 import pytest
 from funcx_common.task_storage.default_storage import DEFAULT_REDIS_STORAGE_THRESHOLD
 
-from funcx.errors import FuncxTaskExecutionFailed
+try:
+    from funcx.errors import FuncxTaskExecutionFailed
+
+    has_task_exec_error_type = True
+except ImportError:
+    has_task_exec_error_type = False
 
 
 def large_result_producer(size: int) -> str:
@@ -26,6 +31,9 @@ def test_allowed_result_sizes(submit_function_and_get_result, endpoint, size):
     assert len(r.result) == size
 
 
+@pytest.mark.skipif(
+    not has_task_exec_error_type, reason="Test requires newer execution exception type"
+)
 def test_result_size_too_large(submit_function_and_get_result, endpoint):
     """
     funcX should raise a MaxResultSizeExceeded exception when results exceeds 10MB

--- a/smoke_tests/tox.ini
+++ b/smoke_tests/tox.ini
@@ -13,6 +13,7 @@ skip_install = true
 deps =
     funcx
     funcx-endpoint
+    funcx-common
     pytest
 commands = pytest -v {posargs}
 


### PR DESCRIPTION
- add `funcx-common` to deps because v0.3.10 of the packages do not install it and it is used in test files
- add a conditional skip to ensure that `FuncxTaskExecutionFailed` is only used when a newer (`0.4.0-dev+`) version is in use

Additionally, `make dev` should (for now) use `tox e- localdeps` to install from the local repo. This fails at the moment but does not appear to be related to the tests themselves.