### PR TITLE
Add tblib python dependency

### DIFF
--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -19,7 +19,7 @@ REQUIRES = [
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
     "funcx-common==0.0.14",
-    "tblib==1.7.0"
+    "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [
     "sphinx<5",

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -19,6 +19,7 @@ REQUIRES = [
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
     "funcx-common==0.0.14",
+    "tblib==1.7.0"
 ]
 DOCS_REQUIRES = [
     "sphinx<5",


### PR DESCRIPTION
This is required by RemoteExceptionWrapper, and without tblib,
exceptions from an endpoint cannot be deserialized on the
client.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
