### PR TITLE
Docs fixes

### DIFF
--- a/changelog.d/20220705_163242_chris_funcx_client_url_mismatch.rst
+++ b/changelog.d/20220705_163242_chris_funcx_client_url_mismatch.rst
@@ -5,7 +5,7 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
-- `FuncXClient` now warns you if it thinks you may have supplied `funcx_service_address`
-    and `results_ws_uri` that point to different environments. This behavior can be
-    turned off by passing `warn_about_url_mismatch=False`.
+- ``FuncXClient`` now warns you if it thinks you may have supplied ``funcx_service_address``
+  and ``results_ws_uri`` that point to different environments. This behavior can be
+  turned off by passing ``warn_about_url_mismatch=False``.
 

--- a/changelog.d/20220706_095230_LeiGlobus_off_process_checker_removal_sc_13659.rst
+++ b/changelog.d/20220706_095230_LeiGlobus_off_process_checker_removal_sc_13659.rst
@@ -10,4 +10,5 @@ Changed
 -------
 
 - Pickle module references were replaced with dill
+
 - The order of serialization method attempts has been changed to try dill.dumps first

--- a/docs/actionprovider.rst
+++ b/docs/actionprovider.rst
@@ -13,7 +13,7 @@ The funcX Action Provider interface uses:
 Action Input Schema
 -------------------
 
-The Action Provider input schema accepts a list of tasks, with each task requiring an `endpoint`, `function`, and `payload` field.
+The Action Provider input schema accepts a list of tasks, with each task requiring an ``endpoint``, ``function``, and ``payload`` field.
 The endpoint and function arguments are UUIDs and the payload is a dictionary of kwargs to be passed to the function.
 
 .. code-block::
@@ -24,7 +24,7 @@ The endpoint and function arguments are UUIDs and the payload is a dictionary of
 
 
 When defining a funcX function to use within a flow it is recommended to define the specific kwargs that will be passed in as payload.
-If the kwargs are not known, a function can be defined to accept arbitrary kwargs using the `**` operator, e.g.:
+If the kwargs are not known, a function can be defined to accept arbitrary kwargs using the ``**`` operator, e.g.:
 
 .. code-block::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,11 +11,11 @@ funcx & funcx-endpoint v0.4.0a2
 Added
 ^^^^^
 
-- The `FuncXWebClient` now sends version information via `User-Agent` headers
-  through the `app_name` property exposed by `globus-sdk`
+- The ``FuncXWebClient`` now sends version information via ``User-Agent`` headers
+  through the ``app_name`` property exposed by ``globus-sdk``
 
   - Additionally, users can send custom metadata alongside this version
-    information with `user_app_name`
+    information with ``user_app_name``
 
 - The funcx-endpoint service now interfaces with RabbitMQ.
 
@@ -33,14 +33,14 @@ Removed
 Changed
 ^^^^^^^
 
-- The CLI interface for `funcx-endpoint` has been updated in several ways:
+- The CLI interface for ``funcx-endpoint`` has been updated in several ways:
 
-  - `-h` is supported as a help option
+  - ``-h`` is supported as a help option
 
-  - `funcx-endpoint --version` has been replaced with `funcx-endpoint version`
+  - ``funcx-endpoint --version`` has been replaced with ``funcx-endpoint version``
 
-- The `funcx` error module has been renamed from `funcx.utils.errors` to
-  `funcx.errors`
+- The ``funcx`` error module has been renamed from ``funcx.utils.errors`` to
+  ``funcx.errors``
 
 funcx & funcx-endpoint v0.4.0a1
 -------------------------------
@@ -48,13 +48,13 @@ funcx & funcx-endpoint v0.4.0a1
 Added
 ^^^^^
 
-* `TaskQueueSubscriber` class added that allows receiving tasks over RabbitMQ
-* `ResultQueuePublisher` class added that allows publishing results and status over RabbitMQ
-* `TaskQueuePublisher` class added for testing
-* `ResultQueueSubscriber` class added for testing
+* ``TaskQueueSubscriber`` class added that allows receiving tasks over RabbitMQ
+* ``ResultQueuePublisher`` class added that allows publishing results and status over RabbitMQ
+* ``TaskQueuePublisher`` class added for testing
+* ``ResultQueueSubscriber`` class added for testing
 * A bunch of tests are added that test the above classes described above
 
-- Implement Task Group reloading on the FuncXExecutor.  Look for `.reload_tasks()`
+- Implement Task Group reloading on the FuncXExecutor.  Look for ``.reload_tasks()``
 
 - FuncXExecutor.submit returns futures with a .task_id attribute
   that will contain the task ID of the corresponding FuncX task.
@@ -143,8 +143,8 @@ Bug Fixes
   In an example kubernetes setup, this can double throughput of
   5 second tasks on 6 workers.
 
-- Pin the version of `click` used by `funcx-endpoint`. This resolves issues
-  stemming from `typer` being incompatible with the latest `click` release.
+- Pin the version of ``click`` used by ``funcx-endpoint``. This resolves issues
+  stemming from ``typer`` being incompatible with the latest ``click`` release.
 
 Removed
 ^^^^^^^
@@ -198,10 +198,10 @@ Changed
   instead of funcx-* to clarify what these pods are to
   observers of 'kubectl get pods'
 
-- Logging for funcx-endpoint no longer writes to `~/.funcx/endpoint.log` at any point.
-  This file is considered deprecated. Use `funcx-endpoint --debug <command>` to
+- Logging for funcx-endpoint no longer writes to ``~/.funcx/endpoint.log`` at any point.
+  This file is considered deprecated. Use ``funcx-endpoint --debug <command>`` to
   get debug output written to stderr.
-- The output formatting of `funcx-endpoint` logging has changed slightly when
+- The output formatting of ``funcx-endpoint`` logging has changed slightly when
   writing to stderr.
 
 funcx & funcx-endpoint v0.3.6
@@ -237,7 +237,7 @@ Changed
   means that the errors no longer inherit from ``FuncxResponseError``. Update
   error handling code as follows:
 
-In prior versions of the `funcx` package:
+In prior versions of the ``funcx`` package:
 
 .. code-block:: python
 
@@ -358,9 +358,9 @@ Stephen Rosen <sirosen@globus.org>, and Yadu Nand Babuji <yadudoc1729@gmail.com>
 Bug Fixes
 ^^^^^^^^^
 
-* Updated requirements to exclude `pyzmq==22.3.0` due to unstable wheel. `Issue#577 <https://github.com/funcx-faas/funcX/issues/611>`_
+* Updated requirements to exclude ``pyzmq==22.3.0`` due to unstable wheel. `Issue#577 <https://github.com/funcx-faas/funcX/issues/611>`_
 
-* Updated requirements specification to `globus-sdk<3.0`
+* Updated requirements specification to ``globus-sdk<3.0``
 
 New Functionality
 ^^^^^^^^^^^^^^^^^
@@ -491,7 +491,7 @@ New Functionality
         async_future = fxc.run(endpoint_id=<ENDPOINT_ID>, function_id=fn_id)
         print("Result : ", await async_future)
 
-* A new ``FuncXExecutor`` class exposes funcX functionality using the familiar executor interface from the `concurrent.futures` library.
+* A new ``FuncXExecutor`` class exposes funcX functionality using the familiar executor interface from the ``concurrent.futures`` library.
 
   Here's an example:
 
@@ -517,7 +517,7 @@ New Functionality
 
 * Endpoint states have been renamed to ``running``, ``stopped``, and ``disconnected``. See `PR#525 <https://github.com/funcx-faas/funcX/pull/525>`_
 
-* Container routing behavior has been improved to support `soft` and `hard` routing strategies. See `PR#324 <https://github.com/funcx-faas/funcX/pull/324>`_
+* Container routing behavior has been improved to support ``soft`` and ``hard`` routing strategies. See `PR#324 <https://github.com/funcx-faas/funcX/pull/324>`_
 
 funcx & funcx-endpoint v0.2.3
 -----------------------------
@@ -578,9 +578,9 @@ Yadu Nand Babuji <yadudoc1729@gmail.com> and Zhuozhao Li <zhuozhao@uchicago.edu>
 Bug Fixes
 ^^^^^^^^^
 
-* Fixed a missing package in the `requirements.txt` file
+* Fixed a missing package in the ``requirements.txt`` file
 
-* Updated version requirements in `funcx-endpoint` to match the `funcx` version
+* Updated version requirements in ``funcx-endpoint`` to match the ``funcx`` version
 
 
 funcx & funcx-endpoint v0.2.1
@@ -612,7 +612,7 @@ Bug Fixes
 
 * Fixed an issue with poor error reporting when starting non-existent endpoints. Refer: `issue 432 <https://github.com/funcx-faas/funcX/issues/432>`_
 
-* Fixed a bug in incorrectly passing the `funcx_service_address` to the EndpointInterchange.
+* Fixed a bug in incorrectly passing the ``funcx_service_address`` to the EndpointInterchange.
 
 * Several updates to the docs for clarity.
 
@@ -631,7 +631,7 @@ Ariel Rokem <arokem@gmail.com>, Ben Blaiszik <blaiszik@uchicago.edu>, Ben Galews
 Known Issues
 ^^^^^^^^^^^^
 
-There is an ongoing stability issue with `pyzmq` wheels that causes endpoint crashes.
+There is an ongoing stability issue with ``pyzmq`` wheels that causes endpoint crashes.
 Read more about this `here <https://github.com/zeromq/libzmq/issues/3313>`_.
 To address this issue, we recommend the following:
 
@@ -742,4 +742,4 @@ New Functionality
         }
 
 
-* `get_batch_status` has been renamed to `get_batch_result`
+* ``get_batch_status`` has been renamed to ``get_batch_result``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Added
     information with `user_app_name`
 
 - The funcx-endpoint service now interfaces with RabbitMQ.
+
   - As previously, the endpoint registers with the FuncX web service upon
     startup, but now receives endpoint-specific RabbitMQ connection
     configuration.

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -4,10 +4,6 @@ funcX has been used on various systems around the world. Below are example confi
 for commonly used systems. If you would like to add your system to this list please
 contact the funcX team via Slack.
 
-
-.. contents:: :local:
-
-
 .. note::
    All configuration examples below must be customized for the user's
    allocation, Python environment, file system, etc.

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -14,8 +14,8 @@ Blue Waters (NCSA)
 .. image:: _static/images/blue-waters-supercomputer.jpg
 
 The following snippet shows an example configuration for executing remotely on Blue Waters, a supercomputer at the National Center for Supercomputing Applications.
-The configuration assumes the user is running on a login node, uses the `TorqueProvider` to interface
-with the scheduler, and uses the `AprunLauncher` to launch workers.
+The configuration assumes the user is running on a login node, uses the ``TorqueProvider`` to interface
+with the scheduler, and uses the ``AprunLauncher`` to launch workers.
 
 .. literalinclude:: configs/bluewaters.py
 
@@ -25,7 +25,7 @@ UChicago AI Cluster
 .. image:: _static/images/ai-science-web.jpeg
 
 The following snippet shows an example configuration for the University of Chicago's AI Cluster.
-The configuration assumes the user is running on a login node and uses the `SlurmProvider` to interface
+The configuration assumes the user is running on a login node and uses the ``SlurmProvider`` to interface
 with the scheduler and launch onto the GPUs.
 
 Link to `docs <https://howto.cs.uchicago.edu/slurm:ai>`_.
@@ -39,8 +39,8 @@ Midway (RCC, UChicago)
 
 The Midway cluster is a campus cluster hosted by the Research Computing Center at the University of Chicago.
 The snippet below shows an example configuration for executing remotely on Midway.
-The configuration assumes the user is running on a login node and uses the `SlurmProvider` to interface
-with the scheduler, and uses the `SrunLauncher` to launch workers.
+The configuration assumes the user is running on a login node and uses the ``SlurmProvider`` to interface
+with the scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/midway.py
 
@@ -67,8 +67,8 @@ Theta (ALCF)
 .. image:: _static/images/ALCF-Theta_111016-1000px.jpg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Theta** supercomputer. This example uses the `HighThroughputExecutor` and connects to Theta's Cobalt scheduler
-using the `CobaltProvider`. This configuration assumes that the script is being executed on the login nodes of Theta.
+**Theta** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Theta's Cobalt scheduler
+using the ``CobaltProvider``. This configuration assumes that the script is being executed on the login nodes of Theta.
 
 .. literalinclude:: configs/theta.py
 
@@ -83,8 +83,8 @@ Cooley (ALCF)
 .. image:: _static/images/31174D02-Cooley800.jpg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Cooley** cluster. This example uses the `HighThroughputExecutor` and connects to Cooley's Cobalt scheduler
-using the `CobaltProvider`. This configuration assumes that the script is being executed on the login nodes of Cooley.
+**Cooley** cluster. This example uses the ``HighThroughputExecutor`` and connects to Cooley's Cobalt scheduler
+using the ``CobaltProvider``. This configuration assumes that the script is being executed on the login nodes of Cooley.
 
 .. literalinclude:: configs/cooley.py
 
@@ -95,8 +95,8 @@ Polaris (ALCF)
 .. image:: images/ALCF_Polaris.jpeg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Polaris** cluster. This example uses the `HighThroughputExecutor` and connects to Polaris's PBS scheduler
-using the `PBSProProvider`. This configuration assumes that the script is being executed on the login node of Polaris (edtb-02).
+**Polaris** cluster. This example uses the ``HighThroughputExecutor`` and connects to Polaris's PBS scheduler
+using the ``PBSProProvider``. This configuration assumes that the script is being executed on the login node of Polaris (edtb-02).
 
 .. literalinclude:: configs/polaris.py
 
@@ -106,7 +106,7 @@ Cori (NERSC)
 
 .. image:: _static/images/Cori-NERSC.png
 
-The following snippet shows an example configuration for accessing NERSC's **Cori** supercomputer. This example uses the `HighThroughputExecutor` and connects to Cori's Slurm scheduler.
+The following snippet shows an example configuration for accessing NERSC's **Cori** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Cori's Slurm scheduler.
 It is configured to request 2 nodes configured with 1 TaskBlock per node. Finally, it includes override information to request a particular node type (Haswell) and to configure a specific Python environment on the worker nodes using Anaconda.
 
 .. literalinclude:: configs/cori.py
@@ -117,7 +117,7 @@ Perlmutter (NERSC)
 
 .. image:: _static/images/Nersc9-image-compnew-sizer7-group-type-4-1.jpg
 
-The following snippet shows an example configuration for accessing NERSC's **Perlmutter** supercomputer. This example uses the `HighThroughputExecutor` and connects to Perlmutters's Slurm scheduler.
+The following snippet shows an example configuration for accessing NERSC's **Perlmutter** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Perlmutters's Slurm scheduler.
 It is configured to request 2 nodes configured with 1 TaskBlock per node. Finally, it includes override information to request a particular node type (Haswell) and to configure a specific Python environment on the worker nodes using Anaconda.
 
 .. note:: Please run ``module load cgpu`` prior to executing ``funcx-endpoint start <endpoint_name>``
@@ -132,6 +132,6 @@ Frontera (TACC)
 .. image:: _static/images/frontera-banner-home.jpg
 
 The following snippet shows an example configuration for accessing the Frontera system at TACC. The configuration below assumes that the user is
-running on a login node, uses the `SlurmProvider` to interface with the scheduler, and uses the `SrunLauncher` to launch workers.
+running on a login node, uses the ``SlurmProvider`` to interface with the scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/frontera.py

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -2,7 +2,7 @@ Debugging
 =========
 
 To sidestep the FuncX web-service the endpoint can be forced to connect directly to a debug-forwarder.
-To enable this behavior update `~/.funcx/config` ::
+To enable this behavior update ``~/.funcx/config`` ::
 
 
   * 'broker_address' : Address at which the broker is listening, eg: "http://127.0.0.1:50005"

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -18,12 +18,12 @@ To install the funcX endpoint agent software ::
    Please note that the funcx endpoint is only supported on Linux and MacOS.
 
 After installing funcX endpoint, you be able to deploy new endpoints and interact
-with existing endpoints using the `funcx-endpoint` command.
+with existing endpoints using the ``funcx-endpoint`` command.
 
 First time setup
 ----------------
 
-You will be required to authenticate the first time you run `funcx-endpoint`.
+You will be required to authenticate the first time you run ``funcx-endpoint``.
 If you have authenticated previously, the endpoint will cache access tokens in
 the local configuration file.
 
@@ -35,9 +35,9 @@ To get started, you will first want to configure a new endpoint.  ::
 
   $ funcx-endpoint configure
 
-Once you've run this command, a directory will be created at `$HOME/.funcx` and a set of default configuration files will be generated.
+Once you've run this command, a directory will be created at ``$HOME/.funcx`` and a set of default configuration files will be generated.
 
-You can also set up auto-completion for the `funcx-endpoint` commands in your shell, by using the command ::
+You can also set up auto-completion for the ``funcx-endpoint`` commands in your shell, by using the command ::
 
   $ funcx-endpoint --install-completion [zsh bash fish ...]
 
@@ -57,8 +57,8 @@ To generate the appropriate directories and default configuration template, run 
 
   $ funcx-endpoint configure <ENDPOINT_NAME>
 
-This command will create a profile for your endpoint in `$HOME/.funcx/<ENDPOINT_NAME>/` and will instantiate a
-`config.py` file. This file should be updated with the appropriate configurations for the computational system you are
+This command will create a profile for your endpoint in ``$HOME/.funcx/<ENDPOINT_NAME>/`` and will instantiate a
+``config.py`` file. This file should be updated with the appropriate configurations for the computational system you are
 targeting before you start the endpoint.
 funcX is configured using a :class:`~funcx_endpoint.endpoint.utils.config.Config` object.
 funcX uses `Parsl <https://parsl-project.org>`_ to manage resources. For more information,
@@ -145,7 +145,7 @@ The funcX endpoint can run functions using independent Python processes or optio
 inside containers. funcX supports various container technologies (e.g., docker and singularity)
 and different routing mechanisms for different use cases.
 
-Raw worker processes (`worker_mode=no_container`):
+Raw worker processes (``worker_mode=no_container``):
 
 * Hard routing: All worker processes are of the same type "RAW". It this case, the funcx endpoint simply routes tasks to any available worker processes. This is the default mode of a funcx endpoint.
 * Soft routing: It is the same as hard routing.

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -1,11 +1,11 @@
 FuncX Executor
 ==============
 
-The `FuncXExecutor` provides a future based interface that simplifies both function submission
-and result tracking. The key functionality in the `FuncXExecutor` is the asynchronous event based
-result tracking that propagates new results to the user via the use of `Futures`.
-This asynchronous behavior is widely used in Python and the `FuncXExecutor` extends the popular executor
-interface from the `concurrent.futures.Executor` library.
+The ``FuncXExecutor`` provides a future based interface that simplifies both function submission
+and result tracking. The key functionality in the ``FuncXExecutor`` is the asynchronous event based
+result tracking that propagates new results to the user via the use of ``Futures``.
+This asynchronous behavior is widely used in Python and the ``FuncXExecutor`` extends the popular executor
+interface from the ``concurrent.futures.Executor`` library.
 
 
 Initializing the executor

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -32,12 +32,12 @@ Groups to facilitate sharing and to make authorization decisions.
 funcX allows endpoints and functions to be shared by associating a Globus Group.
 
 .. note:: funcX internally caches function, endpoint, and authorization lookups. Caches are based on user authentication tokens. To force refresh cached
-          entries, you can re-authenticate your client with `force_login=True`.
+          entries, you can re-authenticate your client with ``force_login=True``.
 
 Registering Functions
 ---------------------
 
-You can register a Python function with funcX via `register_function()`. Function registration serializes the
+You can register a Python function with funcX via ``register_function()``. Function registration serializes the
 function body and transmits it to funcX. Once the function is registered with funcX, it is assigned a
 UUID that can be used to manage and invoke the function.
 
@@ -60,8 +60,8 @@ is defined in the same way as any Python function before being registered with f
 Running Functions
 -----------------
 
-You can invoke a function using the UUID returned when registering the function. The `run()` function
-requires that you specify the function (`function_id`) and endpoint (`endpoint_id`) on which to execute
+You can invoke a function using the UUID returned when registering the function. The ``run()`` function
+requires that you specify the function (``function_id``) and endpoint (``endpoint_id``) on which to execute
 the function. funcX will return a UUID for the executing function (called a task) via which you can
 monitor status and retrieve results.
 
@@ -77,7 +77,7 @@ monitor status and retrieve results.
 
 Retrieving Results
 -------------------
-The result of your function's invocation can be retrieved using the `get_result()` function. This will either
+The result of your function's invocation can be retrieved using the ``get_result()`` function. This will either
 return the deserialized result of your invocation or raise an exception indicating that the
 task is still pending.
 
@@ -91,7 +91,7 @@ task is still pending.
     print("Exception: {}".format(e))
 
 .. note:: funcX caches results in the cloud until they have been retrieved. The SDK also caches results
-          during a session. However, calling `get_result()` from a new session will not be able to access the results.
+          during a session. However, calling ``get_result()`` from a new session will not be able to access the results.
 
 
 Arguments and data
@@ -100,7 +100,7 @@ Arguments and data
 funcX functions operate the same as any other Python function. You can pass arguments \*args and \**kwargs
 and return values from functions. The only constraint is that data passed to/from a funcX function must be
 serializable (e.g., via Pickle) and fall within service limits.
-Input arguments can be passed to the function using the `run()` function.
+Input arguments can be passed to the function using the ``run()`` function.
 The following example shows how strings can be passed to and from a function.
 
 .. code-block:: python
@@ -123,7 +123,7 @@ Sharing Functions
 You may share functions publicly (with anyone) or a set of users via a Globus Group.
 You can also add a function description such that it can be discovered by others.
 
-To share with a group, set `group=<globus_group_id>` when registering a function.
+To share with a group, set ``group=<globus_group_id>`` when registering a function.
 
 .. code-block:: python
 
@@ -132,7 +132,7 @@ To share with a group, set `group=<globus_group_id>` when registering a function
 
 Upon execution, funcX will check group membership to ensure that the user is authorized to execute the function.
 
-You can also set a function to be publicly accessible by setting `public=True` when registering the function.
+You can also set a function to be publicly accessible by setting ``public=True`` when registering the function.
 
 .. code-block:: python
 
@@ -144,7 +144,7 @@ Discovering Functions
 
 funcX maintains an access controlled search index of registered functions.
 You can look up your own functions, functions that have been shared with you,
-or publicly accessible functions via the `search_function()` function.
+or publicly accessible functions via the ``search_function()`` function.
 
 .. code-block:: python
 
@@ -175,7 +175,7 @@ corresponding to the functions in the batch with the ordering preserved.
 
 The batch result interface is useful to to fetch the results of a collection of task_ids.
 ``get_batch_result`` is called with a list of task_ids. It is non-blocking and returns
-a `dict` with task_ids as the keys and each value is a dict that contains status information
+a ``dict`` with task_ids as the keys and each value is a dict that contains status information
 and a result if it is available.
 
 .. code-block:: python


### PR DESCRIPTION
# Description

Addresses the following syntactical issues in docs:

* [Big red error box](https://funcx.readthedocs.io/en/latest/endpoints.html#example-configurations)
* [Funky indentation in changelog](https://funcx.readthedocs.io/en/latest/changelog.html#added) (and potential for it to happen when current changelogs are collected)
* Consistent misuse of `` ` `` which produces italics, instead of ``` `` ``` which produces inline code blocks
  * Some of the changes here will be subjective, and I intentionally left any single backticks that looked appropriately like italics instead of code. Let me know if I changed something I shouldn't have or should change something I didn't.

## Type of change

- Documentation maintenance/cleanup
