### PR TITLE
Teach endpoint new Task state data structure

### DIFF
--- a/changelog.d/20220715_160834_kevin_update_status_delta_per_fx_common_change.rst
+++ b/changelog.d/20220715_160834_kevin_update_status_delta_per_fx_common_change.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- Alter the FuncXEndpoint to include a timestamp with each task state change.
+  This is mostly for the development team so as to support retrospective log
+  analyses of where tasks get stuck in the pipeline.

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -240,7 +240,7 @@ class Manager:
         self.next_worker_q: list[str] = []  # FIFO queue for spinning up workers.
         self.worker_procs: dict[str, subprocess.Popen] = {}
 
-        self.task_status_deltas: dict[str, TaskState] = {}
+        self.task_status_deltas: dict[str, tuple[float, TaskState]] = {}
 
         self._kill_event = threading.Event()
         self._result_pusher_thread = threading.Thread(
@@ -646,7 +646,8 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            self.task_status_deltas[task.task_id] = TaskState.RUNNING
+            ts = (time.monotonic(), TaskState.RUNNING)
+            self.task_status_deltas[task.task_id] = ts
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,
                 "task_type": task_type,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -339,7 +339,7 @@ class Interchange:
 
         self.task_cancel_running_queue: queue.Queue = queue.Queue()
         self.task_cancel_pending_trap: dict[str, str] = {}
-        self.task_status_deltas: dict[str, TaskState] = {}
+        self.task_status_deltas: dict[str, tuple[float, TaskState]] = {}
         self.container_switch_count: dict[str, int] = {}
 
     def load_config(self):
@@ -398,7 +398,7 @@ class Interchange:
             log.info("Scaling ...")
             self.scale_out(self.provider.init_blocks)
 
-    def migrate_tasks_to_internal(self, kill_event, status_request):
+    def migrate_tasks_to_internal(self, kill_event, status_request=None):
         """Pull tasks from the incoming tasks 0mq pipe onto the internal
         pending task queue
 
@@ -457,7 +457,8 @@ class Interchange:
                     }
                 )
                 self.total_pending_task_count += 1
-                self.task_status_deltas[msg.task_id] = TaskState.WAITING_FOR_NODES
+                ts = (time.monotonic(), TaskState.WAITING_FOR_NODES)
+                self.task_status_deltas[msg.task_id] = ts
                 log.debug(
                     f"[TASK_PULL_THREAD] task {msg.task_id} is now WAITING_FOR_NODES"
                 )
@@ -889,9 +890,8 @@ class Interchange:
                             self.task_cancel_pending_trap.pop(task_id)
                         else:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
-                            self.task_status_deltas[
-                                task_id
-                            ] = TaskState.WAITING_FOR_LAUNCH
+                            ts = (time.monotonic(), TaskState.WAITING_FOR_LAUNCH)
+                            self.task_status_deltas[task_id] = ts
 
             # Receive any results and forward to client
             if (

--- a/funcx_endpoint/tests/unit/test_funcx_manager_unit.py
+++ b/funcx_endpoint/tests/unit/test_funcx_manager_unit.py
@@ -1,0 +1,28 @@
+import time
+import uuid
+from unittest import mock
+
+from funcx_common.tasks import TaskState
+
+from funcx_endpoint.executors.high_throughput.funcx_manager import Manager as FXManager
+from funcx_endpoint.executors.high_throughput.messages import Task
+
+
+@mock.patch("funcx_endpoint.executors.high_throughput.funcx_manager.zmq")
+class TestFuncxManager:
+    def test_task_to_worker_status_change(self, randomstring):
+        task_type = randomstring()
+        task_id = str(uuid.uuid4())
+        task = Task(task_id, "RAW", b"")
+
+        mgr = FXManager(uid="some_uid", worker_type=task_type)
+        mgr.worker_map = mock.Mock()
+        mgr.worker_map.get_worker.return_value = "some_work_id"
+        mgr.task_queues[task_type].put(task)
+        mgr.send_task_to_worker(task_type)
+
+        assert task_id in mgr.task_status_deltas
+
+        ts, state = mgr.task_status_deltas[task_id]
+        assert time.monotonic() - ts < 20, "Expecting a timestamp"
+        assert state == TaskState.RUNNING


### PR DESCRIPTION
To support retrospective log analysis ("What went wrong??!?!"), ensure that each task state change includes a timestamp.

## Type of change

- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
