### PR TITLE
Use FuncxTaskExecutionFailed in executor mode

### DIFF
--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -15,6 +15,7 @@ from websockets.exceptions import (
     InvalidStatusCode,
 )
 
+from funcx.errors import FuncxTaskExecutionFailed
 from funcx.sdk.asynchronous.funcx_future import FuncXFuture
 from funcx.sdk.asynchronous.funcx_task import FuncXTask
 
@@ -225,10 +226,7 @@ class WebSocketPollingTask:
                     self.funcx_client.fx_serializer.deserialize(task_data["result"])
                 )
             elif "exception" in task_data:
-                r_exception = self.funcx_client.fx_serializer.deserialize(
-                    task_data["exception"]
-                )
-                task_fut.set_exception(dill.loads(r_exception.e_value))
+                task_fut.set_exception(FuncxTaskExecutionFailed(task_data["exception"], task_data["completion_t"]))
             else:
                 msg = f"Data contained neither result nor exception: {task_data}"
                 task_fut.set_exception(Exception(msg))

--- a/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/ws_polling_task.py
@@ -4,8 +4,6 @@ import logging
 import typing as t
 from asyncio import AbstractEventLoop
 
-import dill
-
 # import from `websockets.client`, see:
 #   https://github.com/aaugustin/websockets/issues/940
 import websockets.client
@@ -226,7 +224,11 @@ class WebSocketPollingTask:
                     self.funcx_client.fx_serializer.deserialize(task_data["result"])
                 )
             elif "exception" in task_data:
-                task_fut.set_exception(FuncxTaskExecutionFailed(task_data["exception"], task_data["completion_t"]))
+                task_fut.set_exception(
+                    FuncxTaskExecutionFailed(
+                        task_data["exception"], task_data["completion_t"]
+                    )
+                )
             else:
                 msg = f"Data contained neither result nor exception: {task_data}"
                 task_fut.set_exception(Exception(msg))

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -19,6 +19,7 @@ REQUIRES = [
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
     "funcx-common==0.0.14",
+    "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [
     "sphinx<5",


### PR DESCRIPTION
Prior to this, the code still tried to deserialise
exceptions in expectation of a RemoteExceptionWrapper,
which was changed in PR #814.

This PR makes FuncxTaskExecutionFailed exceptions
in executor mode in the same way as the allegedly
deprecated polling mode.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
