### PR TITLE
Move error handling code, use for task cancel

### DIFF
--- a/funcx_endpoint/funcx_endpoint/exception_handling.py
+++ b/funcx_endpoint/funcx_endpoint/exception_handling.py
@@ -1,0 +1,60 @@
+"""
+This module provides helpers for constructing the internal dict objects which get passed
+around and ultimately converted into funcx_common.messagepack.Result objects
+
+IDEALLY this would be refactored to produce and return Result objects directly, which
+could then be passed around internally instead of raw dicts
+but we don't have time to do that (even though it would be better (a lot better))
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+import types
+import typing as t
+
+from funcx.errors import MaxResultSizeExceeded
+from funcx_endpoint.exceptions import CouldNotExecuteUserTaskError
+
+INTERNAL_ERROR_CLASSES: tuple[type[Exception], ...] = (
+    CouldNotExecuteUserTaskError,
+    MaxResultSizeExceeded,
+)
+
+
+def _typed_excinfo() -> tuple[type[Exception], Exception, types.TracebackType]:
+    return t.cast(
+        t.Tuple[t.Type[Exception], Exception, types.TracebackType],
+        sys.exc_info(),
+    )
+
+
+def _inner_traceback(tb: types.TracebackType, levels: int = 2) -> types.TracebackType:
+    while levels > 0:
+        tb = tb.tb_next if tb.tb_next is not None else tb
+        levels -= 1
+    return tb
+
+
+def get_error_string(*, tb_levels: int = 2) -> str:
+    exc_info = _typed_excinfo()
+    exc_type, exc, tb = exc_info
+    if isinstance(exc, INTERNAL_ERROR_CLASSES):
+        return repr(exc)
+    return "".join(
+        traceback.format_exception(
+            exc_type, exc, _inner_traceback(tb, levels=tb_levels)
+        )
+    )
+
+
+def get_result_error_details() -> tuple[str, str]:
+    _, error, _ = _typed_excinfo()
+    # code, user_message
+    if isinstance(error, INTERNAL_ERROR_CLASSES):
+        return (error.__class__.__name__, f"remote error: {error}")
+    return (
+        "RemoteExecutionError",
+        "An error occurred during the execution of this task",
+    )

--- a/funcx_endpoint/funcx_endpoint/exceptions.py
+++ b/funcx_endpoint/funcx_endpoint/exceptions.py
@@ -1,0 +1,5 @@
+class CouldNotExecuteUserTaskError(Exception):
+    """
+    generic exception class for errors while attempting to setup and run the user
+    function but which does not come from the user function itself failing
+    """

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -20,10 +20,10 @@ import dill
 import psutil
 import zmq
 from funcx_common.tasks import TaskState
-from parsl.app.errors import RemoteExceptionWrapper
 from parsl.version import VERSION as PARSL_VERSION
 
 from funcx.serialize import FuncXSerializer
+from funcx_endpoint.exception_handling import get_error_string, get_result_error_details
 from funcx_endpoint.executors.high_throughput.container_sched import naive_scheduler
 from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 from funcx_endpoint.executors.high_throughput.messages import (
@@ -405,9 +405,8 @@ class Manager:
                             result_package = {
                                 "task_id": task_id,
                                 "container_id": worker_type,
-                                "exception": self.serializer.serialize(
-                                    RemoteExceptionWrapper(*sys.exc_info())
-                                ),
+                                "error_details": get_result_error_details(e),
+                                "exception": get_error_string(tb_levels=0),
                             }
                             self.pending_result_queue.put(dill.dumps(result_package))
 


### PR DESCRIPTION
- new modules for error handling code in the worker
- use the code for error handling (identical to the worker) for task cancel

---

I didn't test this because tests failed for me and I don't work on funcx really anymore. So watch CI and see if this works.