### PR TITLE
Switch to recent parsl master

### DIFF
--- a/changelog.d/20220720_141209_benc_benc_parsl_dep_master.rst
+++ b/changelog.d/20220720_141209_benc_benc_parsl_dep_master.rst
@@ -1,0 +1,40 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- The Parsl dependency has been upgraded to a more recent
+  parsl master, from the older parsl 1.1 release.
+  This allows recent changes to provider functionality to
+  be accessed by funcX endpoint administrators.
+
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -313,6 +313,7 @@ class HighThroughputExecutor(RepresentationMixin):
         self.interchange_local = interchange_local
         self.passthrough = passthrough
         self.task_status_queue = task_status_queue
+        self.tasks = {}
 
         self.outgoing_q: zmq_pipes.TasksOutgoing | None = None
         self.incoming_q: zmq_pipes.ResultsIncoming | None = None

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -19,7 +19,6 @@ import daemon
 import dill
 from parsl.dataflow.error import ConfigurationError
 from parsl.executors.errors import BadMessage, ScalingFailed
-from parsl.executors.status_handling import StatusHandlingExecutor
 from parsl.providers import LocalProvider
 from parsl.utils import RepresentationMixin
 
@@ -50,7 +49,7 @@ BUFFER_THRESHOLD = 1024 * 1024
 ITEM_THRESHOLD = 1024
 
 
-class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
+class HighThroughputExecutor(RepresentationMixin):
     """Executor designed for cluster-scale
 
     The HighThroughputExecutor system has the following components:
@@ -270,8 +269,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         task_status_queue=None,
     ):
         log.debug("Initializing HighThroughputExecutor")
-        StatusHandlingExecutor.__init__(self, provider)
-
+        self.provider = provider
         self.label = label
         self.launch_cmd = launch_cmd
         self.worker_debug = worker_debug

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the funcx-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==1.1.0",
+    "parsl@git+https://github.com/parsl/parsl@efb75b7644f17c89af6c4dbe4e0499030efd103e",
     "pika>=1.2.0",
 ]
 


### PR DESCRIPTION
This commit removes an unnecessary dependency on a
parsl executor superclass that has been restructured
since the previously used parsl release. It turns out
that only one line from that superclass was needed,
to store the specified provider, and this PR moves
that line directly into the FuncX version of HTEX.

This allows a PBS contribution to parsl from Ryan Chard
to be used in FuncX endpoints.

This should also allow more easy updating of the
parsl dependency as/when desired.

## Type of change

- New feature (non-breaking change that adds functionality)
