### PR TITLE
Note when unacked result sending has completed

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -324,10 +324,12 @@ class EndpointInterchange:
                     len(resend_results_messages),
                 )
 
-            for results in resend_results_messages:
-                # TO-DO: Republishing backlogged/unacked messages is not supported
-                # until the types are sorted out
-                results_publisher.publish(try_convert_to_messagepack(results))
+                for results in resend_results_messages:
+                    # TO-DO: Republishing backlogged/unacked messages is not supported
+                    # until the types are sorted out
+                    results_publisher.publish(try_convert_to_messagepack(results))
+
+                log.info("Resent previously unacked results")
 
             executor = list(self.executors.values())[0]
             last = time.time()


### PR DESCRIPTION
Sending unacked results can take several minutes, during which
the endpoint will not accept tasks. This log statement makes it
clearer when that process has completed.

## Type of change

- Code maintenance/cleanup
