### PR TITLE
Report task ID, not repr(), in received task message

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -439,7 +439,7 @@ class Interchange:
             elif isinstance(msg, Heartbeat):
                 log.debug("Got heartbeat")
             else:
-                log.info(f"Received task:{msg}")
+                log.info(f"Received task: {msg.task_id}")
                 local_container = self.get_container(msg.container_id)
                 msg.set_local_container(local_container)
                 if local_container not in self.pending_task_queue:


### PR DESCRIPTION
Now:

  migrate_tasks_to_internal Received task: 9ce42865-b9b2-4ca8-8682-219cf4c2b038

Before:

  migrate_tasks_to_internal Received task:<funcx_endpoint.executors.high_throughput.messages.Task object at 0x7fc1bc19daf0>

## Type of change

- Code maintenance/cleanup
