### PR TITLE
Adding client login and modifying login logic

### DIFF
--- a/changelog.d/20220727_115011_rchard_client_login.rst
+++ b/changelog.d/20220727_115011_rchard_client_login.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add logic to support Globus Auth client credentials. This allows users to
+  specify FUNCX_SDK_CLIENT_ID and FUNCX_SDK_CLIENT_SECRET environment variables
+  to use a client credential.

--- a/funcx_sdk/funcx/sdk/login_manager/client_login.py
+++ b/funcx_sdk/funcx/sdk/login_manager/client_login.py
@@ -1,0 +1,51 @@
+"""
+Logic for using client identities with the funcX SDK.
+
+This is based on the Globus CLI client login:
+https://github.com/globus/globus-cli/blob/main/src/globus_cli/login_manager/client_login.py
+"""
+from __future__ import annotations
+
+import os
+
+import globus_sdk
+
+
+def _get_client_creds_from_env() -> tuple[str | None, str | None]:
+    client_id = os.getenv("FUNCX_SDK_CLIENT_ID")
+    client_secret = os.getenv("FUNCX_SDK_CLIENT_SECRET")
+    return client_id, client_secret
+
+
+def is_client_login() -> bool:
+    """
+    Return True if the correct env variables have been set to use a
+    client identity with the funcX SDK
+    """
+    client_id, client_secret = _get_client_creds_from_env()
+
+    if bool(client_id) ^ bool(client_secret):
+        raise ValueError(
+            "Both FUNCX_SDK_CLIENT_ID and FUNCX_SDK_CLIENT_SECRET must "
+            "be set to use a client identity. Either set both environment "
+            "variables, or unset them to use a normal login."
+        )
+
+    else:
+        return bool(client_id) and bool(client_secret)
+
+
+def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
+    """
+    Return the ConfidentialAppAuthClient for the client identity
+    logged into the SDK
+    """
+    if not is_client_login():
+        raise ValueError("No client is logged in")
+
+    client_id, client_secret = _get_client_creds_from_env()
+
+    return globus_sdk.ConfidentialAppAuthClient(
+        client_id=str(client_id),
+        client_secret=str(client_secret),
+    )

--- a/funcx_sdk/funcx/sdk/login_manager/client_login.py
+++ b/funcx_sdk/funcx/sdk/login_manager/client_login.py
@@ -6,9 +6,13 @@ https://github.com/globus/globus-cli/blob/main/src/globus_cli/login_manager/clie
 """
 from __future__ import annotations
 
+import logging
 import os
+import uuid
 
 import globus_sdk
+
+log = logging.getLogger(__name__)
 
 
 def _get_client_creds_from_env() -> tuple[str | None, str | None]:
@@ -31,8 +35,7 @@ def is_client_login() -> bool:
             "variables, or unset them to use a normal login."
         )
 
-    else:
-        return bool(client_id) and bool(client_secret)
+    return bool(client_id) and bool(client_secret)
 
 
 def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
@@ -45,6 +48,12 @@ def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
 
     client_id, client_secret = _get_client_creds_from_env()
 
+    try:
+        uuid.UUID(client_id)
+    except ValueError:
+        log.warning(
+            "VERY LIKELY INVALID CLIENT ID (did you copy the username and not the id?"
+        )
     return globus_sdk.ConfidentialAppAuthClient(
         client_id=str(client_id),
         client_secret=str(client_secret),

--- a/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
+++ b/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
@@ -7,6 +7,7 @@ import pathlib
 from globus_sdk.tokenstorage import SQLiteAdapter
 
 from .._environments import _get_envname
+from .client_login import get_client_login, is_client_login
 from .globus_auth import internal_auth_client
 
 
@@ -50,14 +51,22 @@ def _get_storage_filename():
 
 def _resolve_namespace(environment: str | None) -> str:
     """
-    For now, the following namespace will always be used:
+    Return the namespace used to save tokens. This will check
+    if a client login is being used and return either:
       user/<envname>
+    or
+      clientprofile/<envname>/<clientid>
 
     e.g.
 
       user/production
     """
     env = environment if environment is not None else _get_envname()
+
+    if is_client_login():
+        client_id = get_client_login().client_id
+        return f"clientprofile/{env}/{client_id}"
+
     return f"user/{env}"
 
 

--- a/funcx_sdk/tests/unit/test_login_manager.py
+++ b/funcx_sdk/tests/unit/test_login_manager.py
@@ -1,18 +1,129 @@
+import os
+import uuid
+from unittest import mock
+
+import globus_sdk
 import pytest
 
+from funcx.sdk._environments import _get_envname
+from funcx.sdk.login_manager.client_login import (
+    _get_client_creds_from_env,
+    get_client_login,
+    is_client_login,
+)
 from funcx.sdk.login_manager.manager import LoginManager
+from funcx.sdk.login_manager.tokenstore import _resolve_namespace
+
+CID_KEY = "FUNCX_SDK_CLIENT_ID"
+CSC_KEY = "FUNCX_SDK_CLIENT_SECRET"
+MOCK_BASE = "funcx.sdk.login_manager"
 
 
 @pytest.fixture
 def logman(mocker, tmp_path):
-    home = mocker.patch("funcx.sdk.login_manager.tokenstore._home")
+    home = mocker.patch(f"{MOCK_BASE}.tokenstore._home")
     home.return_value = tmp_path
     return LoginManager()
 
 
+def test_get_client_creds_from_env(randomstring):
+    for expected_cid, expected_csc in (
+        (randomstring(), randomstring()),
+        ("", None),
+        (None, ""),
+        (None, None),
+    ):
+        env = {}
+        if expected_cid is not None:
+            env[CID_KEY] = expected_cid
+        if expected_csc is not None:
+            env[CSC_KEY] = expected_csc
+        with mock.patch.dict(os.environ, env):
+            found_cid, found_csc = _get_client_creds_from_env()
+
+        assert expected_cid == found_cid
+        assert expected_csc == found_csc
+
+
+def test_is_client_login():
+    env = {CID_KEY: "some_id", CSC_KEY: "some_secret"}
+    with mock.patch.dict(os.environ, env):
+        assert is_client_login()
+
+    for cid, csc in (("", ""), ("", None), (None, ""), (None, None)):
+        env = {}
+        if cid is not None:
+            env[CID_KEY] = cid
+        if csc is not None:
+            env[CSC_KEY] = csc
+        with mock.patch.dict(os.environ, env):
+            assert not is_client_login()
+
+    for cid, csc in (
+        ("some_id", ""),
+        ("some_id", None),
+        ("", "some_secret"),
+        (None, "some_secret"),
+    ):
+        env = {}
+        if cid is not None:
+            env[CID_KEY] = cid
+        if csc is not None:
+            env[CSC_KEY] = csc
+        with mock.patch.dict(os.environ, env):
+            with pytest.raises(ValueError) as err:
+                is_client_login()
+
+    assert "Both FUNCX_SDK_CLIENT_ID and FUNCX_SDK_CLIENT_SECRET" in str(err)
+
+
+def test_get_client_login(caplog, randomstring):
+    for cid, csc in (("", ""), ("", None), (None, ""), (None, None)):
+        env = {}
+        if cid is not None:
+            env[CID_KEY] = cid
+        if csc is not None:
+            env[CSC_KEY] = csc
+        with mock.patch.dict(os.environ, env):
+            with pytest.raises(ValueError) as err:
+                get_client_login()
+
+    assert "No client is logged in" in str(err)
+
+    env = {CID_KEY: str(uuid.uuid4()), CSC_KEY: "some_secret"}
+    with mock.patch.dict(os.environ, env):
+        rv = get_client_login()
+
+    assert isinstance(rv, globus_sdk.ConfidentialAppAuthClient)
+    assert "VERY LIKELY" not in caplog.text
+
+    env = {CID_KEY: randomstring(), CSC_KEY: randomstring()}
+    with mock.patch.dict(os.environ, env):
+        rv = get_client_login()
+
+    assert isinstance(rv, globus_sdk.ConfidentialAppAuthClient)
+    assert "VERY LIKELY INVALID CLIENT ID" in caplog.text
+    assert rv.client_id == env[CID_KEY]
+    assert rv.authorizer.password == env[CSC_KEY]
+
+
+def test_resolve_namespace(randomstring):
+    client_id = str(uuid.uuid4())
+    env = {CID_KEY: client_id, CSC_KEY: randomstring()}
+
+    for ns_env in (randomstring, "", "123", None):
+        ns = _resolve_namespace(ns_env)
+        ns_env = _get_envname() if ns_env is None else ns_env
+        assert ns == f"user/{ns_env}"
+
+        with mock.patch.dict(os.environ, env):
+            ns = _resolve_namespace(ns_env)
+            assert ns == f"clientprofile/{ns_env}/{client_id}"
+
+
 def test_link_login_flow_requires_stdin(mocker, logman):
-    mocker.patch("funcx.sdk.login_manager.manager.do_link_auth_flow")
-    mock_stdin = mocker.patch("funcx.sdk.login_manager.manager.sys.stdin")
+    mocker.patch(f"{MOCK_BASE}.manager.do_link_auth_flow")
+    mock_stdin = mocker.patch(f"{MOCK_BASE}.manager.sys.stdin")
     mock_stdin.isatty.return_value = False
     with pytest.raises(RuntimeError) as err:
         logman.run_login_flow()
@@ -23,3 +134,28 @@ def test_link_login_flow_requires_stdin(mocker, logman):
     mock_stdin.isatty.return_value = True
     mock_stdin.closed = False
     logman.run_login_flow()
+
+
+def test_run_login_flow_ignored_if_client_login(mocker, logman):
+    mock_laf = mocker.patch(f"{MOCK_BASE}.manager.do_link_auth_flow")
+    mock_stdin = mocker.patch(f"{MOCK_BASE}.manager.sys.stdin")
+    mock_stdin.isatty.return_value = True
+    mock_stdin.closed = False
+    env = {CID_KEY: str(uuid.uuid4()), CSC_KEY: "some_secret"}
+    with mock.patch.dict(os.environ, env):
+        logman.run_login_flow()
+    mock_laf.assert_not_called()
+
+    logman.run_login_flow()
+    mock_laf.assert_called()
+
+
+def test_get_authorizer(mocker, logman):
+    mock_gsdk = mocker.patch(f"{MOCK_BASE}.manager.globus_sdk")
+    env = {CID_KEY: str(uuid.uuid4()), CSC_KEY: "some_secret"}
+    with mock.patch.dict(os.environ, env):
+        logman._get_authorizer("some_resource_server")
+    mock_gsdk.ClientCredentialsAuthorizer.assert_called()
+
+    with pytest.raises(LookupError):
+        logman._get_authorizer("some_resource_server")


### PR DESCRIPTION
# Description

Add's login logic to support Globus Auth client credentials. This change lets users export FUNCX_SDK_CLIENT_ID and FUNCX_SDK_CLIENT_SECRET environment variables to bypass the native app login flow and instead use the client credentials.

Fixes # [sc-17447]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
