### PR TITLE
Endpoint Helm Chart Uses Correct funcx-endpoint-uuid command line arg

### DIFF
--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -8,7 +8,7 @@ cp /funcx/credentials/storage.db ~/.funcx/
 if [ -z "$2" ]; then
   funcx-endpoint start $1
 else
-  funcx-endpoint start $1 --endpoint-id $2
+  funcx-endpoint start $1 --endpoint-uuid $2
 fi
 
 while pgrep funcx-endpoint >/dev/null;


### PR DESCRIPTION
# Description
The command line argument for `funcx-endpoint start` command changed. The helm chart deployment was throwing an error: 
```
Usage: funcx-endpoint start [OPTIONS] [NAME]

Error: No such option: --endpoint-id Did you mean --endpoint-uuid?
```

Updated the shell script that launches the endpoint to use the correct command line argument

## Type of change
- Bug fix (non-breaking change that fixes an issue)
