### PR TITLE
Correct smoke test slack notification condition

### DIFF
--- a/.github/_support/github-slack-notify.py
+++ b/.github/_support/github-slack-notify.py
@@ -118,11 +118,15 @@ def build_payload(status):
 
 def on_main_repo():
     """check if running from a fork"""
-    return os.environ["GITHUB_REPOSITORY"] == "funcx-faas/funcx"
+    res = os.environ["GITHUB_REPOSITORY"].lower() == "funcx-faas/funcx"
+    print(f"Checking main repo: {res}")
+    return res
 
 
 def should_notify(status):
-    return check_status_changed(status) and on_main_repo() and not is_pr_build()
+    res = check_status_changed(status) and on_main_repo() and not is_pr_build()
+    print(f"Should notify: {res}")
+    return res
 
 
 def main():


### PR DESCRIPTION
# Description

The slack notification condition was comparing the repo name to funcx, not funcX. This change corrects that and adds two additional print statements to aid in debugging whether the notification is sent.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
