### PR TITLE
Use HighThroughputExecutor constructor arg to specify location for worker Dirs

### DIFF
--- a/changelog.d/20220803_105233_ben_working_dir_for_workers.rst
+++ b/changelog.d/20220803_105233_ben_working_dir_for_workers.rst
@@ -1,0 +1,32 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+ Bug Fixes
+ ^^^^^^^^^
+
+ - Now using the correct HighThroughputExecutor constructor arg to set the log dir for workers
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+..  Changed
+..  ^^^^^^^
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -24,6 +24,7 @@ data:
                 container_type='docker',
                 scheduler_mode='hard',
                 worker_debug={{- ternary "True" "False" .Values.workerDebug }},
+                working_dir='{{ .Values.logDir }}',
                 provider=KubernetesProvider(
                     init_blocks={{ .Values.initBlocks }},
                     min_blocks={{ .Values.minBlocks }},
@@ -44,7 +45,6 @@ data:
         ],
         heartbeat_period=15,
         heartbeat_threshold=200,
-        log_dir='{{ .Values.logDir }}',
         funcx_service_address="{{ .Values.funcXServiceAddress }}/v2",
         detach_endpoint={{- ternary "True" "False" .Values.detachEndpoint }}
     )


### PR DESCRIPTION
# Problem
There is no way to specify the log directory for workers in a Kubernetes endpoint. This results in permission errors in docker images that aren't running a root user. 

# Approach
Thanks to @benclifford we see that this needs to be specified in the `working_dir` property in the`HighThroughputExecutor` constructor.

Moved this value from an ignored property in the `KubernetesProvider`