### PR TITLE
Forget the acked results

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -361,6 +361,7 @@ class EndpointInterchange:
                     # results will be a packed EPStatusReport or a packed Result
                     log.debug(f"Publishing message {message}")
                     results_publisher.publish(message)
+                    self.results_ack_handler.ack(task_id)  # no error; RMQ has it now
                 except queue.Empty:
                     pass
 


### PR DESCRIPTION
# Description

When an endpoint is restarted, it attempts to send any unsent results to RMQ.  This is a problem if the endpoint never forgets a result -- it will resend already-sent results.  In the ad-nauseum case, and endpoint with lots-o-stored-results can take an hour or two to resend these messages to RMQ.

Fixes: SC-17609

## Type of change

- Bug fix (non-breaking change that fixes an issue)