### PR TITLE
Callbacks and retries for TaskQueueSubscriber

### DIFF
--- a/funcx_endpoint/tests/test_rabbit_mq/rabbitmqadmin.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/rabbitmqadmin.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import logging
+import os
+import typing as t
+from urllib.parse import quote_plus
+
+import requests
+
+
+class RabbitMQAdmin:
+    """
+    A wrapper around the RabbitMQ administrative API.[1]  Only a small number of the
+    admin API endpoints are implemented.
+
+    The class requires either an explicit baseuri during instantiation, or the
+    environment variable RABBITMQ_ADMIN_URI to be set.  Example:
+
+        >>> os.environ["RABBITMQ_ADMIN_URI"]
+        'http://adminuser:adminpass@localhost:15672'
+        >>> rmqa = RabbitMQAdmin()
+
+    Alternatively, the baseuri may be specified manually:
+
+        >>> rmqa = RabbitMQAdmin(baseuri="http://adminuser:adminpass@localhost:15672")
+
+    All methods internally use the `requests` module, and raise_for_status().
+
+    [1] rabbitmq_fqdn:15672/api/index.html ; also linked from
+        https://www.rabbitmq.com/management.html#http-api
+    """
+
+    def __init__(self, baseuri: str | None = None):
+        if not baseuri:
+            baseuri = os.environ["RABBITMQ_ADMIN_URI"]
+            if not baseuri:
+                raise ValueError("RABBITMQ_ADMIN_URI must be a valid connection url")
+        self.baseuri = baseuri.rstrip("/") + "/api"
+
+    @staticmethod
+    def _request(method: str, url, **kwargs):
+        res = requests.request(method, url, **kwargs)
+        try:
+            res.raise_for_status()
+        except Exception as exc:
+            # At least one consumer of this method intentionally ignores
+            # a particular failure, so only emit if actively debugging.  No
+            # sense in needlessly catching attention of log trawlers.
+            logging.debug(
+                f"Failed to {method.upper()}.  Exception text: {exc}",
+                extra={
+                    "url": f"{res.request.url}",
+                    "headers": f"{res.request.headers}",
+                    "body": f"{res.request.body!r}",
+                },
+            )
+            raise
+        return res
+
+    def _post(self, path: str, payload):
+        url = self.baseuri + path
+        return self._request("post", url, json=payload)
+
+    def _put(self, path: str, payload):
+        url = self.baseuri + path
+        return self._request("put", url, json=payload)
+
+    def _get(self, path: str):
+        url = self.baseuri + path
+        return self._request("get", url)
+
+    def _delete(self, path: str):
+        url = self.baseuri + path
+        return self._request("delete", url)
+
+    def list_connections(self) -> list:
+        response = self._get("/connections")
+        return response.json()
+
+    def delete_connections(self) -> int:
+        """Deletes active connections and returns count of connections deleted"""
+        connections = self.list_connections()
+        count = 0
+        for conn in connections:
+            conn_name = conn["name"]
+            logging.warning(f"Trying to delete conn: {conn_name}")
+            self._delete(f"/connections/{conn_name}")
+            count += 1
+        return count
+
+    def delete_users(self, usernames: t.Iterable[str]) -> requests.Response:
+        """
+        Implements POST /api/users/bulk-delete
+
+        Parameters
+        ----------
+        usernames : Iterable[str]
+            A list of RMQ usernames
+
+        Returns
+        -------
+        request.Response
+        """
+        api_endpoint = "/users/bulk-delete"
+        payload = {"users": list(usernames)}
+        return self._post(api_endpoint, payload=payload)
+
+    def create_user(
+        self,
+        username: str,
+        password: str | None = None,
+        password_hash: str | None = None,
+        tags: list[str] | None = None,
+    ) -> requests.Response:
+        """
+        Implements PUT /api/users/<username>
+
+        Parameters
+        ----------
+        username : str
+            A username for RMQ to create
+        password : str | None
+            (Optional) A password for the new RMQ user (xor `password_hash`)
+        password_hash: str | None
+            (Optional) A password has for the new RMQ user (xor `password`)
+        tags : list[str] | None
+            (Optional) List of RMQ user tags
+
+        Returns
+        -------
+        request.Response
+        """
+        api_endpoint = f"/users/{username}"
+        payload = {}
+        if password_hash is not None:
+            payload["password_hash"] = password_hash
+        elif password:
+            payload["password"] = password
+
+        payload["tags"] = tags and ",".join(map(str, tags)) or ""
+
+        return self._put(api_endpoint, payload=payload)
+
+    def set_user_vhost_permissions(
+        self,
+        username: str,
+        vhost: str = "/",
+        configure_re: str = r"^$",
+        write_re: str = r"^$",
+        read_re: str = r"^$",
+    ) -> requests.Response:
+        """
+        Implements PUT /api/permissions/<vhost>/<username>
+
+        For more information on specific parameters, consult the official RMQ
+        documentation.  Reference the Admin API documentation and
+            https://www.rabbitmq.com/access-control.html#authorisation
+
+        Parameters
+        ----------
+        username : str
+            An RMQ username
+        vhost : str (default: "/")
+            Operate on selected vhost for username
+        configure_re: str (default: "^$")
+            The configuration regex (see RMQ documentation for more info)
+        write_re : str (default: "^$")
+            The write regex (see RMQ documentation for more info)
+        read_re : str (default: "^$")
+            The read regex (see RMQ documentation for more info)
+
+        Returns
+        -------
+        request.Response
+        """
+        vhost = quote_plus(vhost)
+        api_endpoint = f"/permissions/{vhost}/{username}"
+        payload = {"configure": configure_re, "write": write_re, "read": read_re}
+        return self._put(api_endpoint, payload=payload)
+
+    def set_user_vhost_topic_permissions(
+        self,
+        username: str,
+        topic: str,
+        vhost: str = "/",
+        write_re: str = "^$",
+        read_re: str = "^$",
+    ) -> requests.Response:
+        """
+        Implements PUT /api/topic-permissions/<vhost>/<username>
+
+        Parameters
+        ----------
+        username : str
+            An RMQ username
+        topic: str,
+            Also called "exchange name"
+        vhost : str (default: "/")
+            Operate on selected vhost for username and topic
+        write_re : str (default: "^$")
+            The write regex (see RMQ documentation for more info)
+        read_re : str (default: "^$")
+            The read regex (see RMQ documentation for more info)
+
+        Returns
+        -------
+        request.Response
+        """
+        vhost = quote_plus(vhost)
+        api_endpoint = f"/topic-permissions/{vhost}/{username}"
+        payload = {"exchange": topic, "write": write_re, "read": read_re}
+        return self._put(api_endpoint, payload=payload)
+
+
+if __name__ == "__main__":
+
+    rmq_admin = RabbitMQAdmin()
+
+    print(rmq_admin.list_connections())

--- a/funcx_endpoint/tests/test_rabbit_mq/task_queue_publisher.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/task_queue_publisher.py
@@ -63,5 +63,8 @@ class TaskQueuePublisher:
 
     def close(self):
         """Close the connection and channels"""
-        self._connection.close()
+        try:
+            self._connection.close()
+        except pika.exceptions.ConnectionWrongStateError:
+            logger.warning("Connection is already closed")
         self.status = RabbitPublisherStatus.closed

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -1,8 +1,12 @@
 import json
 import logging
 import multiprocessing
+import os
 import time
 import uuid
+
+import pytest
+from rabbitmqadmin import RabbitMQAdmin
 
 
 def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
@@ -20,8 +24,7 @@ def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
     logging.warning(f"Published {count} messages, closing task_q_pub")
     logging.warning("Starting task_q_subscriber")
 
-    tasks_out = multiprocessing.Queue()
-    start_task_q_subscriber(queue=tasks_out)
+    task_q, tasks_out = start_task_q_subscriber()
     for i in range(count):
         message = tasks_out.get()
         assert messages[i] == message
@@ -40,9 +43,8 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
         messages.append(b_message)
 
     # Listen for 10 messages
-    tasks_out = multiprocessing.Queue()
     kill_event = multiprocessing.Event()
-    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
+    proc, tasks_out = start_task_q_subscriber(kill_event=kill_event)
     logging.warning("Proc started")
     for i in range(10):
         message = tasks_out.get()
@@ -65,7 +67,7 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
 
     # Listen for the messages on a new connection
     kill_event.clear()
-    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
+    proc, tasks_out = start_task_q_subscriber(kill_event=kill_event)
 
     logging.warning("Replacement proc started")
     for i in range(10):
@@ -81,9 +83,9 @@ def test_exclusive_subscriber(start_task_q_publisher, start_task_q_subscriber):
 
     # Start two subscribers on the same rabbit queue
     tasks_out_1, tasks_out_2 = multiprocessing.Queue(), multiprocessing.Queue()
-    start_task_q_subscriber(queue=tasks_out_1)
+    _, tasks_out_1 = start_task_q_subscriber()
     time.sleep(1)
-    start_task_q_subscriber(queue=tasks_out_2)
+    _, tasks_out_2 = start_task_q_subscriber()
 
     logging.warning("TEST: Launching messages")
     # Launch 10 messages
@@ -112,8 +114,7 @@ def test_perf_combined_pub_sub_latency(start_task_q_publisher, start_task_q_subs
     """Confirm that messages published are received."""
     task_q_pub = start_task_q_publisher()
 
-    tasks_out = multiprocessing.Queue()
-    start_task_q_subscriber(queue=tasks_out)
+    _, tasks_out = start_task_q_subscriber()
 
     latency = []
     for i in range(100):
@@ -140,8 +141,8 @@ def test_perf_combined_pub_sub_throughput(
 ):
     """Confirm that messages published are received."""
     task_q_pub = start_task_q_publisher()
-    tasks_out = multiprocessing.Queue()
-    start_task_q_subscriber(queue=tasks_out)
+
+    _, tasks_out = start_task_q_subscriber()
 
     num_messages = 1000
 
@@ -171,3 +172,90 @@ def test_perf_combined_pub_sub_throughput(
         # been introduced
         assert sent_per_second > 500
         assert messages_per_second > 500
+
+
+def test_task_subscriber_stop_and_restart(
+    start_task_q_subscriber, start_task_q_publisher
+):
+    """This test confirms that messages sent are received after a stop and reset"""
+    task_q_pub = start_task_q_publisher()
+
+    for i in range(3):
+        task_q_sub, tasks_out = start_task_q_subscriber(max_reconnect_retry_count=0)
+        pid = task_q_sub.pid
+
+        b_message = f"Hello {i}".encode()
+        task_q_pub.publish(b_message)
+
+        received_message = tasks_out.get()
+        assert b_message == received_message
+
+        task_q_sub.stop()
+        # Check if process is still alive by trying to kill it
+        with pytest.raises(OSError):
+            os.kill(pid, 0)
+
+    logging.warning("All done")
+
+
+def test_task_subscriber_restart_broker_initiated(
+    start_task_q_subscriber, start_task_q_publisher, rabbitmq_conn_url
+):
+    """This test confirms that messages sent are received after a stop and reset"""
+    task_q_pub = start_task_q_publisher()
+
+    rmq_admin = RabbitMQAdmin()
+    task_q_sub, tasks_out = start_task_q_subscriber(max_reconnect_retry_count=2)
+
+    # b_message = f'Hello {i}'.encode()
+    b_message = b"Hello 1337"
+    task_q_pub.publish(b_message)
+
+    received_message = tasks_out.get()
+    assert b_message == received_message
+
+    logging.warning("Sleeping for 30 s")
+    time.sleep(30)
+    logging.warning(rmq_admin.list_connections())
+    count = rmq_admin.delete_connections()
+    assert count > 0
+    try:
+        task_q_pub.close()
+        task_q_sub.stop()
+    except Exception:
+        logging.exception("Caught exception at close")
+    logging.warning("All done")
+
+
+def test_task_subscriber_auto_reconnect(
+    start_task_q_subscriber, start_task_q_publisher
+):
+    task_q_pub = start_task_q_publisher()
+    kill_event = multiprocessing.Event()
+    rmq_admin = RabbitMQAdmin()
+    task_q_sub, tasks_out = start_task_q_subscriber(
+        kill_event=kill_event, max_reconnect_retry_count=20
+    )
+
+    b_message = b"Hello"
+    task_q_pub.publish(b_message)
+
+    received_message = tasks_out.get()
+    assert b_message == received_message
+    assert task_q_sub.connected.is_set() is True
+
+    # Delete connections
+    logging.warning(f"Connections : {rmq_admin.list_connections()}")
+    count = rmq_admin.delete_connections()
+    assert count > 0
+
+    task_q_sub.connected.wait(timeout=120)
+
+    time.sleep(50)
+    assert task_q_sub.connected.is_set() is True
+    # print("Status of task_q_sub : {}".format(task_q_sub.status))
+    # assert task_q_sub._cleanup_complete.is_set()
+
+    # Confirm that a message sent can still be received following disconnect
+    task_q_pub.publish(b_message)
+    assert tasks_out.get(timeout=10) == b_message

--- a/funcx_endpoint/tox.ini
+++ b/funcx_endpoint/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 passenv =
     RABBITMQ_INTEGRATION_TEST_URI
+    RABBITMQ_ADMIN_URI
 extras = test
 usedevelop = true
 commands =


### PR DESCRIPTION
# Description

This PR contains 2 main changes:
* `TaskQueueSubscriber` will now use an `external_callback` instead of an `external_queue`. Upon receiving a message from RMQ, the callback is invoked with the message body, followed by ACK'ing.
* `TaskQueueSubscriber` now has a configurable retry mechanism that transparently does retries on disconnects.

