### PR TITLE
Use correct variable: period, not threshold

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -110,7 +110,6 @@ class EndpointInterchange:
             self.initial_registration_complete = True
 
         self.heartbeat_period = self.config.heartbeat_period
-        self.heartbeat_threshold = self.config.heartbeat_threshold
 
         self.pending_task_queue: multiprocessing.Queue = multiprocessing.Queue()
 
@@ -386,7 +385,7 @@ class EndpointInterchange:
             result_processor_thread.start()
 
             last_t, last_r = 0, 0
-            while not self._quiesce_event.wait(self.heartbeat_threshold):
+            while not self._quiesce_event.wait(self.heartbeat_period):
                 # Possibly TOCTOU here, but we don't need to be super precise.  The
                 # point here is to mention "still alive" and that we're still working
                 num_t, num_r = num_tasks_forwarded, num_results_forwarded


### PR DESCRIPTION
Nominally a thinko when transitioning the intertwined kernel to multiple threads: we want a heartbeat every period, not on the threshold of timing out.

In doing so, remove the only usage of threshold, and so also remove the threshold class variable.  It looks like the last legitimate use of this variable was removed in Apr:

    commit 08eba06bc1ff365f0b932d9b09bd4c1eb01493f1
    Date:   Thu Apr 7 15:29:25 2022 -0500

        Integrate rabbitmq with endpoint [RMQ Series #3] (#703)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
