### PR TITLE
Update mac_safe_queue import for new Parsl version

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
@@ -1,7 +1,7 @@
 import platform
 
 if platform.system() == "Darwin":
-    from parsl.executors.high_throughput.mac_safe_queue import MacSafeQueue as mpQueue
+    from parsl.multiprocessing import MacSafeQueue as mpQueue
 else:
     from multiprocessing import Queue as mpQueue
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/mac_safe_queue.py
@@ -1,4 +1,8 @@
+import multiprocessing as mp
 import platform
+import typing as t
+
+mpQueue: t.Type[mp.Queue]
 
 if platform.system() == "Darwin":
     from parsl.multiprocessing import MacSafeQueue as mpQueue


### PR DESCRIPTION
# Description

Fixes our import of `mac_safe_queue` to accommodate the new location in Parsl, following the Parsl upgrade.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
