### PR TITLE
Refactor class variable name

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -203,7 +203,7 @@ class EndpointInterchange:
             task_q_proc = TaskQueueSubscriber(
                 queue_info=connection_params,
                 external_queue=pending_task_queue,
-                kill_event=quiesce_event,
+                quiesce_event=quiesce_event,
                 endpoint_id=endpoint_uuid,
             )
             task_q_proc.start()

--- a/funcx_endpoint/tests/test_rabbit_mq/conftest.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/conftest.py
@@ -128,13 +128,13 @@ def start_task_q_subscriber(
         *,
         endpoint_id: str | None = None,
         queue: multiprocessing.Queue | None = None,
-        kill_event: EventType | None = None,
+        quiesce_event: EventType | None = None,
         override_params: pika.connection.Parameters | None = None,
     ):
         if endpoint_id is None:
             endpoint_id = default_endpoint_id
-        if kill_event is None:
-            kill_event = multiprocessing.Event()
+        if quiesce_event is None:
+            quiesce_event = multiprocessing.Event()
         if queue is None:
             queue = multiprocessing.Queue()
         q_info = task_queue_info if override_params is None else override_params
@@ -143,7 +143,7 @@ def start_task_q_subscriber(
         task_q = TaskQueueSubscriber(
             queue_info=q_info,
             external_queue=queue,
-            kill_event=kill_event,
+            quiesce_event=quiesce_event,
             endpoint_id=endpoint_id,
         )
         task_q.start()

--- a/funcx_endpoint/tests/test_rabbit_mq/test_rabbit_e2e.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_rabbit_e2e.py
@@ -26,7 +26,7 @@ def test_simple_roundtrip(
     result_pub.publish(task_message)
     result_message = result_q.get(timeout=2)
 
-    task_sub.kill_event.set()
+    task_sub.quiesce_event.set()
     result_sub.kill_event.set()
 
     expected = (result_pub.queue_info["test_routing_key"], message)

--- a/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
+++ b/funcx_endpoint/tests/test_rabbit_mq/test_task_q.py
@@ -41,8 +41,8 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
 
     # Listen for 10 messages
     tasks_out = multiprocessing.Queue()
-    kill_event = multiprocessing.Event()
-    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
+    quiesce_event = multiprocessing.Event()
+    proc = start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
     logging.warning("Proc started")
     for i in range(10):
         message = tasks_out.get()
@@ -64,8 +64,8 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
         messages.append(b_message)
 
     # Listen for the messages on a new connection
-    kill_event.clear()
-    proc = start_task_q_subscriber(queue=tasks_out, kill_event=kill_event)
+    quiesce_event.clear()
+    proc = start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
 
     logging.warning("Replacement proc started")
     for i in range(10):


### PR DESCRIPTION
This is a slightly confusing muddling of a variable's purposes in two different contexts.  In the parent process, the `quiesce` event is utilized to signal a need to restart ("reload"; "reboot") the communication setup of the funcx endpoint.  (Shutdown the task queue watcher and result publisher, then restart them again.)  In the child process, that semantic is lost and the point is just "time to shutdown."  Meanwhile, while tracing through, the change in name from `quiesce` to `kill` has proven difficult to follow mentally.  So, choose the path of (apparent) least resistance and refactor it based on the development team's preferences.

## Type of change

- Code maintenance/cleanup
