### PR TITLE
Implement convenience for RMQ administrator

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -50,6 +50,7 @@ class ResultQueuePublisher:
 
     def connect(self) -> ResultQueuePublisher:
         pika_params = pika.URLParameters(self.queue_info["connection_url"])
+        pika_params.client_properties = {"connection_name": "ep_result"}
         pika_params.heartbeat = 0  # result_q is blocking; no heartbeats warranted
         conn = pika.BlockingConnection(pika_params)
         channel = conn.channel()

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -77,6 +77,7 @@ class TaskQueueSubscriber(multiprocessing.Process):
         logger.info("Connecting to %s", self.queue_info)
 
         pika_params = pika.URLParameters(self.queue_info["connection_url"])
+        pika_params.client_properties = {"connection_name": "ep_task"}
         return pika.SelectConnection(
             pika_params,
             on_open_callback=self._on_connection_open,


### PR DESCRIPTION
Enable the developer and/or RMQ admin to distinguish in the RMQ admin interface
which connection is which from an endpoint.

## Type of change

- New feature (non-breaking change that adds functionality)