### PR TITLE
Updates to funcx for 1.0.0a0 release updates

### DIFF
--- a/funcx_sdk/funcx/version.py
+++ b/funcx_sdk/funcx/version.py
@@ -4,7 +4,7 @@ from funcx.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.4.0a2"
+__version__ = "1.0.0a0"
 
 
 def compare_versions(

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
-    "funcx-common==0.0.14",
+    "funcx-common==0.0.15",
     "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [


### PR DESCRIPTION
# Description

Only version updates here.
Updating funcx version to 1.0.0a0 and funcx-common from 0.0.14 to 0.0.15