### PR TITLE
v1.0.0a0-release updates

### DIFF
--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.4.0a2"
+__version__ = "1.0.0a0"
 
 # TODO: remove after a `funcx` release
 # this variable is needed because it's imported by `funcx` to do the version check

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -5,8 +5,8 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
-    "funcx==0.4.0a2",
-    "funcx-common==0.0.14",
+    "funcx==1.0.0a0",
+    "funcx-common==0.0.15",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer
@@ -35,7 +35,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the funcx-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl@git+https://github.com/parsl/parsl@efb75b7644f17c89af6c4dbe4e0499030efd103e",
+    "parsl>=1.3.0dev0",
     "pika>=1.2.0",
 ]
 

--- a/funcx_sdk/funcx/version.py
+++ b/funcx_sdk/funcx/version.py
@@ -4,7 +4,7 @@ from funcx.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.4.0a2"
+__version__ = "1.0.0a0"
 
 
 def compare_versions(

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
-    "funcx-common==0.0.14",
+    "funcx-common==0.0.15",
     "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [


### PR DESCRIPTION
# Description

Updating versions for prepping an alpha for release testing.

Updating parsl>=1.3.0dev0, funcx-common==0.0.15 and funcx==1.0.0a0
