### PR TITLE
Default to None to let lib choose default

### DIFF
--- a/changelog.d/20220816_152320_kevin_default_to_spoa_namespace.rst
+++ b/changelog.d/20220816_152320_kevin_default_to_spoa_namespace.rst
@@ -1,0 +1,7 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fix bug where stored credentials would fail to be loaded (manifesting in an
+  EOF error for background processes while unnecessarily attempting to
+  recollect credentials)
+

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from parsl.utils import RepresentationMixin
 
 from funcx_endpoint.executors import HighThroughputExecutor
@@ -67,7 +69,7 @@ class Config(RepresentationMixin):
         # Execution backed
         executors: list = _DEFAULT_EXECUTORS,
         # Connection info
-        environment="prod",
+        environment: str | None = None,
         funcx_service_address=None,
         results_ws_uri=None,
         warn_about_url_mismatch=False,


### PR DESCRIPTION
This constructor default argument represents a second point of authority for the eventual token namespace -- the cause of a bug on v1.0.0 release day.  Instead, default to `None`, and let the library choose the correct namespace via its internal logic.

## Type of change

- Bug fix (non-breaking change that fixes an issue)