### PR TITLE
Remove inappropriate parsl ScalingFailed exception usage

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -18,7 +18,6 @@ import dill
 import zmq
 from funcx_common.tasks import TaskState
 from parsl.app.errors import RemoteExceptionWrapper
-from parsl.executors.errors import ScalingFailed
 from parsl.version import VERSION as PARSL_VERSION
 
 from funcx.sdk.client import FuncXClient
@@ -1114,11 +1113,9 @@ class Interchange:
                     internal_block = self.provider.submit(launch_cmd, 1, task_type)
                 log.debug(f"Launched block {external_block_id}->{internal_block}")
                 if not internal_block:
-                    raise (
-                        ScalingFailed(
-                            self.provider.label,
-                            "Attempts to provision nodes via provider has failed",
-                        )
+                    raise RuntimeError(
+                        "Attempt to provision nodes via provider "
+                        f"{self.provider.label} has failed"
                     )
                 self.blocks[external_block_id] = internal_block
                 self.block_id_map[internal_block] = external_block_id


### PR DESCRIPTION
Parsl's ScalingFailed is based around the structure of parsl's
executors and providers scaling mechanism, which is not used in
funcX - that makes ScalingFailed the wrong kind of exception to
raise here.

Prior to this PR, that exception is misconstructed with a string
where a ParslExecutor is expected, which results in further exceptions
when attempting to render the exception (experienced by @ryanchard
for example).

This commit changes this to a RuntimeException, pending bikeshedding
about proper error types.

A second use of ScalingFailed, also incorrect, exists in what appears
to be dead code in funcx_endpoint/executors/high_throughput/executor.py.
Because that appears to be dead code, this commit does not attempt
to interfere there.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
