### PR TITLE
A cleaner endpoint quit from the CLI

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -258,6 +258,9 @@ class EndpointInterchange:
         log.info("Starting EndpointInterchange")
 
         signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGQUIT, self.handle_sigterm)  # hint: Ctrl+\
+        # Intentionally ignoring SIGINT for now, as we're unstable enough to
+        # warrant Python's default developer-friendly Ctrl+C handling
 
         self._quiesce_event.clear()
         self._kill_event.clear()


### PR DESCRIPTION
In the case of a `detach_endpoint=False` setup, a developer can now hit <kbd>Ctrl</kbd>+<kbd>\\</kbd> and have a traceback free `funcx-endpoint` quitting experience.  I do not feel comfortable replacing Python's default SIGINT handler at this time as there are some as-yet undiagnosed shutdown issues (though they may be mitigated by simply doing the same `kill_event` setting as here -- "but not today").

In short, motivated by a slightly OCD developer desire.

## Type of change

- Code maintenance/cleanup
