### PR TITLE
Fixes for serialization module

### DIFF
--- a/changelog.d/20220817_134952_yadudoc1729_serialization_fixes.rst
+++ b/changelog.d/20220817_134952_yadudoc1729_serialization_fixes.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+Bug Fixes
+^^^^^^^^^
+
+- DillCodeSource updated to use dill's lstrip option to serialize
+  function definitions in nested contexts.
+
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- DillCodeSource will now be used ahead of DillCode
+
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -43,7 +43,7 @@ class DillCodeSource(SerializeBase):
 
     def serialize(self, data):
         name = data.__name__
-        body = dill.source.getsource(data)
+        body = dill.source.getsource(data, lstrip=True)
         x = codecs.encode(dill.dumps((name, body)), "base64").decode()
         return self.identifier + x
 
@@ -136,8 +136,8 @@ class DillCode(SerializeBase):
 
 METHODS_MAP_CODE = OrderedDict(
     [
-        (DillCode.identifier, DillCode),
         (DillCodeSource.identifier, DillCodeSource),
+        (DillCode.identifier, DillCode),
         (DillCodeTextInspect.identifier, DillCodeTextInspect),
         (PickleCode.identifier, PickleCode),
     ]


### PR DESCRIPTION
# Description

We've recently seen smoke-tests fail with serialization errors where the serialized function body refers to modules by name. 
This looks mostly like a failure in serialization where the function refers to test function it is invoked from when it really shouldn't. Why this happens definitely could use more investigation. A potential fix here is to prioritize `DillCodeSource` that serializes via copying the source over. The one caveat here used to be that `DillCodeSource` has issues with code indentation when the target function definition is in a nested context. This PR addresses these two bits:

* Update `DillCodeSource` to `lstrip=True` to adjust code indentation (affects nested fn definitions)
* Change the serialization order to use DillCodeSource before DillCode.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)