### PR TITLE
Update the example config for Polaris

### DIFF
--- a/docs/configs/polaris.py
+++ b/docs/configs/polaris.py
@@ -14,6 +14,8 @@ user_opts = {
         # Node setup: activate necessary conda environment and such.
         'worker_init': '',
         'scheduler_options': '',
+        # ALCF allocation to use
+        'account': '',
     }
 }
 
@@ -25,6 +27,7 @@ config = Config(
             address=address_by_hostname(),
             provider=PBSProProvider(
                 launcher=SingleNodeLauncher(),
+                account=user_opts['polaris']['account'],
                 queue='preemptable',
                 cpus_per_node=32,
                 select_options='ngpus=4',

--- a/docs/configs/polaris.py
+++ b/docs/configs/polaris.py
@@ -1,3 +1,4 @@
+from parsl.addresses import address_by_hostname
 from parsl.launchers import SingleNodeLauncher
 from parsl.providers import PBSProProvider
 
@@ -12,8 +13,6 @@ user_opts = {
     'polaris': {
         # Node setup: activate necessary conda environment and such.
         'worker_init': '',
-        # PBS directives (header lines): for array jobs pass '-J' option
-        # Set ncpus=32, otherwise it defaults to 1 on Polaris
         'scheduler_options': '',
     }
 }
@@ -23,21 +22,19 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=1,
             strategy=SimpleStrategy(max_idletime=300),
-            # IP of Polaris testbed login node
-            address='10.230.2.72',
+            address=address_by_hostname(),
             provider=PBSProProvider(
                 launcher=SingleNodeLauncher(),
-                queue='workq',
-                scheduler_options=user_opts['polaris']['scheduler_options'],
-                # Command to be run before starting a worker, such as:
-                # 'module load Anaconda; source activate parsl_env'.
-                worker_init=user_opts['polaris']['worker_init'],
+                queue='preemptable',
                 cpus_per_node=32,
+                select_options='ngpus=4',
+                worker_init=user_opts['polaris']['worker_init'],
+                scheduler_options=user_opts['polaris']['scheduler_options'],
                 walltime='01:00:00',
                 nodes_per_block=1,
                 init_blocks=0,
                 min_blocks=0,
-                max_blocks=1,
+                max_blocks=2,
             ),
         )
     ],


### PR DESCRIPTION
# Description

Updates the example config for the Polaris machine. The networking issue requiring an IP address has been fixed and can be replaced with address_by_hostname(). Also, requests specifying fewer than 32 cores seem to fail. Adding in the `select='ngpus=4'` to demonstrate how that works too.

## Type of change

- Documentation update
