### PR TITLE
Use non-deprecated RMQ health check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
         ports:
           - 5672:5672
         # needed because the rabbitmq container does not provide a healthcheck
-        options: --health-cmd "rabbitmqctl node_health_check" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
         python-version: ["3.7", "3.10"]


### PR DESCRIPTION
Not an issue *yet*, but noting the following message on the CLI, take the opportunity to update the health checks:

    $ docker run --rm -ti --health-cmd "rabbitmqctl node_health_check" ... bitnami/rabbitmq:3...
    ...
    rabbitmqctl node_health_check and its HTTP API counterpart are DEPRECATED. See https://www.rabbitmq.com/monitoring.html#health-checks for replacement options.
    ...

## Type of change

- Code maintenance/cleanup