### PR TITLE
Show error-level logs in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: run tests
         run: |
           cd funcx_endpoint
-          tox -e py
+          tox -e py -- --log-cli-level=ERROR
       - name: Collect Docker Logs
         if: failure()
         uses: jwalton/gh-docker-logs@v2.2.0


### PR DESCRIPTION
After finally, *finally* tracking down the cause of failure in a recent test, it became clear that the problem could have been identified much sooner if we had access to the information the _production_ code already handles gracefully.  The test was in error, but the core issue was very elusive until the error-level logs were emitted.  Attempt to avoid that experience going forward.

For reference, this will add stanzas like these to the CI test log output:
```
tests/unit/test_funcx_worker.py::test_execute_failing_function 
----------------------------------------------------------- live log call -----------------------------------------------------------
ERROR    funcx_endpoint.executors.high_throughput.funcx_worker:funcx_worker.py:132 Caught an exception while executing user function
Traceback (most recent call last):
  File "[venv]/funcx_endpoint/executors/high_throughput/funcx_worker.py", line 130, in execute_task
    result = self.call_user_function(task_body)
  File "[venv]/funcx_endpoint/executors/high_throughput/funcx_worker.py", line 174, in call_user_function
    result_data = f(*args, **kwargs)
  File "<string>", line 3, in failing_function
KeyError: 'foo'
PASSED                                                                                                                                                                [ 86%]
```

## Type of change

- Code maintenance/cleanup