### PR TITLE
Fix endpoint status report

### DIFF
--- a/changelog.d/20220819_150602_chris_fix_endpoint_status_report.rst
+++ b/changelog.d/20220819_150602_chris_fix_endpoint_status_report.rst
@@ -1,0 +1,16 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Endpoints now report their online status immediately on startup (previously,
+  endpoints waited ``heartbeat_period`` seconds before reporting their status).
+
+- In order to support the new endpoint status format, endpoints now report their
+  heartbeat period as part of their status report package.
+
+Changed
+^^^^^^^
+
+- Changed the way that endpoint status is stored in the services - instead of storing a
+  list of the most recent status reports, we now store the single most recent status
+  report with a TTL set to the endpoint's heartbeat period. This affects the formatting
+  of the return value of ``FuncXClient.get_endpoint_status``.

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -568,7 +568,7 @@ class Interchange:
         log.debug("Status reporting loop starting")
         log.info(f"Endpoint id: {self.endpoint_id}")
 
-        while not kill_event.wait(self.heartbeat_period):
+        while True:
             log.trace(  # type: ignore[attr-defined]
                 f"Endpoint id : {self.endpoint_id}, {type(self.endpoint_id)}"
             )
@@ -578,6 +578,9 @@ class Interchange:
             log.debug("Sending status report to executor, and clearing task deltas.")
             status_report_queue.put(msg.pack())
             self.task_status_deltas.clear()
+
+            if kill_event.wait(self.heartbeat_period):
+                break
 
     def _command_server(self, kill_event):
         """Command server to run async command to the interchange

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -1078,6 +1078,7 @@ class Interchange:
                 "min_blocks": self.provider.min_blocks,
                 "max_workers_per_node": self.max_workers_per_node,
                 "nodes_per_block": self.provider.nodes_per_block,
+                "heartbeat_period": self.heartbeat_period,
             },
         }
 


### PR DESCRIPTION
# Description

Contains frontend changes to support https://github.com/globusonline/funcx-services/pull/130. Also updates the status report loop so that EPs report their status on startup, instead of waiting `heartbeat_period` seconds.

Fixes [sc-17576]

## Type of change

- New feature (non-breaking change that adds functionality)
