### PR TITLE
Remove credentials from logs

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -74,8 +74,6 @@ class TaskQueueSubscriber(multiprocessing.Process):
         logger.debug("Init done")
 
     def _connect(self) -> pika.SelectConnection:
-        logger.info("Connecting to %s", self.queue_info)
-
         pika_params = pika.URLParameters(self.queue_info["connection_url"])
         return pika.SelectConnection(
             pika_params,

--- a/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
@@ -54,7 +54,8 @@ def register_endpoint(
     if reg_info.get("endpoint_id") != endpoint_uuid:
         raise ValueError("Unexpected response from server: mismatched endpoint id.")
 
-    log_reg_info = re.subn(r"://.*?@", r"://u:p@", repr(reg_info))  # sanitize password
+    # sanitize passwords in logs
+    log_reg_info = re.subn(r"://.*?@", r"://***:***@", repr(reg_info))
     log.info(f"Registration returned: {log_reg_info}")
 
     # NOTE: While all registration info is saved to endpoint.json, only the


### PR DESCRIPTION
There is no need to emit the connection information here anyway as we already share all information (but properly redacted) when we register with the web services.

Relatedly, update redaction text per a loosely related verbal conversation: `***:***` is likely more recognizable as "intentionally redacted" than `u:p` which could possibly be considered a mistake by a log trawler.

## Type of change

- Documentation update
- Code maintenance/cleanup
