### PR TITLE
Remove test-flag in production code

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -279,9 +279,6 @@ class EndpointInterchange:
                 log.exception("Unhandled exception in main kernel.")
 
             self.quiesce()
-            # this check is solely for testing to force this loop to only run once
-            if self._test_start:
-                break
 
         self.cleanup()
         log.info("EndpointInterchange shutdown complete.")

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_interchange.py
@@ -53,8 +53,8 @@ class TestStart:
         mock_register_endpoint = mocker.patch(
             "funcx_endpoint.endpoint.interchange.register_endpoint"
         )
-        result_url = "amqp://localhost:5672"
-        task_url = "amqp://localhost:5672"
+        result_url = "amqp://a.sdf"  # just a filler text for this test; don't ...
+        task_url = "amqp://a.sdf"  # ... mistakenly potentially test the wrong thing
         mock_register_endpoint.return_value = (
             {
                 "exchange_name": "results",
@@ -92,11 +92,11 @@ class TestStart:
             reg_info=None,
             endpoint_id="mock_endpoint_id",
         )
+        ic._kill_event = mocker.Mock()
+        ic._kill_event.is_set.side_effect = (False, True)  # Loop only once
 
         ic.results_outgoing = mocker.Mock()
 
-        # this must be set to force the retry loop in the start method to only run once
-        ic._test_start = True
         ic.start()
         assert ic._task_puller_proc.is_alive()
         ic._quiesce_event.set()


### PR DESCRIPTION
Philosophy: In general, code under test should have no knowledge it is under test.  #dieselgate, anyone?

## Type of change

- Code maintenance/cleanup
