### PR TITLE
Enable logging to console

### DIFF
--- a/changelog.d/20220820_232432_kevin_log_to_console.rst
+++ b/changelog.d/20220820_232432_kevin_log_to_console.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add `--log-to-console` CLI flag to the endpoint.  This is mostly to entertain
+  additional development styles, but may also be useful for some end-user
+  workflows.

--- a/changelog.d/20220824_221225_kevin_log_to_console.rst
+++ b/changelog.d/20220824_221225_kevin_log_to_console.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add a `--log-to-console` flag to the endpoint -- helpful for certain
+  development styles on the hot-path.

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -6,6 +6,7 @@ import pathlib
 import shutil
 import signal
 import sys
+import typing
 import uuid
 from string import Template
 
@@ -147,7 +148,9 @@ class Endpoint:
             endpoint_uuid = str(uuid.uuid4())
         return endpoint_uuid
 
-    def start_endpoint(self, name, endpoint_uuid, endpoint_config):
+    def start_endpoint(
+        self, name, endpoint_uuid, endpoint_config, log_to_console: bool
+    ):
         self.name = name
 
         endpoint_dir = os.path.join(self.funcx_dir, self.name)
@@ -194,10 +197,10 @@ class Endpoint:
         # If we are running a full detached daemon then we will send the output to
         # log files, otherwise we can piggy back on our stdout
         if endpoint_config.config.detach_endpoint:
-            stdout = open(
+            stdout: typing.TextIO = open(
                 os.path.join(endpoint_dir, endpoint_config.config.stdout), "a+"
             )
-            stderr = open(
+            stderr: typing.TextIO = open(
                 os.path.join(endpoint_dir, endpoint_config.config.stderr), "a+"
             )
         else:
@@ -288,7 +291,9 @@ class Endpoint:
         )
 
         with context:
-            setup_logging(logfile=logfile, debug=self.debug, console_enabled=False)
+            setup_logging(
+                logfile=logfile, debug=self.debug, console_enabled=log_to_console
+            )
             self.daemon_launch(
                 endpoint_uuid,
                 endpoint_dir,

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -162,5 +162,3 @@ def setup_logging(
         config = _get_stream_dict_config(debug)
 
     logging.config.dictConfig(config)
-    if debug:
-        log.debug("debug logging enabled")

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -309,7 +309,8 @@ class TestStart:
             match=f"Endpoint config file at {config_dir} is "
             "missing executor definitions",
         ):
-            manager.start_endpoint("mock_endpoint", None, mock_load())
+            log_to_console = False
+            manager.start_endpoint("mock_endpoint", None, mock_load(), log_to_console)
 
     @pytest.mark.skip("This test doesn't make much sense")
     def test_daemon_launch(self, mocker):


### PR DESCRIPTION
For quick iteration and testing, eliminate the need to change terminals and/or reload the endpoint.log file: just spew the lines to the terminal.  Immediate feedback can often lead to different insights.

## Type of change

- New feature (non-breaking change that adds functionality)
