### PR TITLE
Colorize console logs

### DIFF
--- a/changelog.d/20220824_221225_kevin_log_to_console.rst
+++ b/changelog.d/20220824_221225_kevin_log_to_console.rst
@@ -1,5 +1,0 @@
-New Functionality
-^^^^^^^^^^^^^^^^^
-
-- Add a `--log-to-console` flag to the endpoint -- helpful for certain
-  development styles on the hot-path.

--- a/changelog.d/20220825_211818_kevin_colorize_console_at_debug.rst
+++ b/changelog.d/20220825_211818_kevin_colorize_console_at_debug.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- funcX Endpoint: Implement ANSI escape codes ("color") for log lines emitted
+  to the console.  This is currently targeted to aid the development and
+  debugging process, so color is strictly to the console, not to logs.  Use
+  the `--log-to-console` and `--debug` flags together.

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -149,7 +149,12 @@ class Endpoint:
         return endpoint_uuid
 
     def start_endpoint(
-        self, name, endpoint_uuid, endpoint_config, log_to_console: bool
+        self,
+        name,
+        endpoint_uuid,
+        endpoint_config,
+        log_to_console: bool,
+        no_color: bool,
     ):
         self.name = name
 
@@ -292,8 +297,12 @@ class Endpoint:
 
         with context:
             setup_logging(
-                logfile=logfile, debug=self.debug, console_enabled=log_to_console
+                logfile=logfile,
+                debug=self.debug,
+                console_enabled=log_to_console,
+                no_color=no_color,
             )
+
             self.daemon_launch(
                 endpoint_uuid,
                 endpoint_dir,

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -6,6 +6,8 @@ import logging
 import logging.config
 import logging.handlers
 import os
+import re
+import sys
 import typing as t
 
 log = logging.getLogger(__name__)
@@ -15,6 +17,31 @@ DEFAULT_FORMAT = (
     "%(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s "
     "%(message)s"
 )
+
+_ital = "\033[3m"
+_redb = "\033[41m"
+_teal = "\033[32m"
+_yel = "\033[33m"
+_byel = "\033[93m"
+_yelb = "\033[43m"
+_purp = "\033[35m"
+_cyan = "\033[36m"
+_gray = "\033[37m"
+_grayonb = "\033[37;40m"
+_r = "\033[m"
+_C_BASE = (
+    f"{_teal}%(created)f{_r} {_yel}%(asctime)s{_r} {_ital}%(levelname)s{_r}"
+    " %(processName)s-%(process)d %(threadName)s-%(thread)d"
+    f" %(name)s:{_cyan}%(lineno)d{_r} {_purp}%(funcName)s{_r}"
+)
+COLOR_ERROR = _redb
+COLOR_WARNING = _yelb
+COLOR_INFO = _gray
+COLOR_DEBUG = _grayonb
+C_ERROR_FMT = _C_BASE + f" {COLOR_ERROR}%(message)s{_r}"
+C_WARNING_FMT = _C_BASE + f" {COLOR_WARNING}%(message)s{_r}"
+C_INFO_FMT = _C_BASE + f" {COLOR_INFO}%(message)s{_r}"
+C_DEBUG_FMT = _C_BASE + f" {COLOR_DEBUG}%(message)s{_r}"
 
 
 class FuncxConsoleFormatter(logging.Formatter):
@@ -30,30 +57,93 @@ class FuncxConsoleFormatter(logging.Formatter):
         all messages are given the full format
     """
 
+    _u = "[0-9A-Fa-f]"  # convenience
+    _uuid_re = f"{_u}{{8}}-{_u}{{4}}-{_u}{{4}}-{_u}{{4}}-{_u}{{12}}"
+    # match uuids for colorization that have not otherwise already been colorized
+    uuid_re = re.compile(rf"(?<!\dm)({_uuid_re})")
+
     def __init__(
         self,
         debug: bool = False,
-        fmt: str = DEFAULT_FORMAT,
+        no_color: bool = False,
+        fmt: str = "",
         datefmt: str = "%Y-%m-%d %H:%M:%S",
     ) -> None:
         super().__init__()
 
-        self._warning_formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
+        self.use_color = debug and not no_color and sys.stderr.isatty()
+
+        if fmt:
+            d_fmt, i_fmt, w_fmt, e_fmt = fmt, fmt, fmt, fmt
+        else:
+            d_fmt, i_fmt, w_fmt, e_fmt = (
+                C_DEBUG_FMT,
+                C_INFO_FMT,
+                C_DEBUG_FMT,
+                C_ERROR_FMT,
+            )
+
+        if not self.use_color:
+            ansi_re = re.compile("\033.*?m")
+            d_fmt = ansi_re.sub("", d_fmt)
+            i_fmt = ansi_re.sub("", i_fmt)
+            w_fmt = ansi_re.sub("", w_fmt)
+            e_fmt = ansi_re.sub("", e_fmt)
+
         if debug:
-            self._info_formatter = self._warning_formatter
+            self._error_formatter = logging.Formatter(fmt=e_fmt, datefmt=datefmt)
+            self._warning_formatter = logging.Formatter(fmt=w_fmt, datefmt=datefmt)
+            self._debug_formatter = logging.Formatter(fmt=d_fmt, datefmt=datefmt)
+            self._info_formatter = logging.Formatter(fmt=i_fmt, datefmt=datefmt)
         else:
             self._info_formatter = logging.Formatter(fmt="> %(message)s")
+            self._warning_formatter = logging.Formatter(fmt=w_fmt, datefmt=datefmt)
+            self._error_formatter = self._warning_formatter
+            self._debug_formatter = self._warning_formatter
 
-    def format(self, record):
-        if record.levelno > logging.INFO:
+    def format(self, record: logging.LogRecord):
+        if self.use_color:
+            # Highlight all UUIDs
+            if record.levelno > logging.WARNING:
+                end_coloring = COLOR_ERROR
+            elif record.levelno > logging.INFO:
+                end_coloring = COLOR_WARNING
+            elif record.levelno > logging.DEBUG:
+                end_coloring = COLOR_INFO
+            else:
+                end_coloring = COLOR_DEBUG
+
+            repl = f"{_byel}\\1{end_coloring}"
+            try:
+                record.msg = self.uuid_re.sub(repl, record.msg)
+                if isinstance(record.args, dict):
+                    for k, v in record.args.items():
+                        record.args[k] = self.uuid_re.sub(repl, str(v))
+                elif record.args:
+                    args = tuple(self.uuid_re.sub(repl, str(a)) for a in record.args)
+                    record.args = args
+            except Exception as exc:
+                # Basically, inform, but ignore
+                print(f"Unable to colorize log message: {exc}")
+
+        if record.levelno > logging.WARNING:
+            return self._error_formatter.format(record)
+        elif record.levelno > logging.INFO:
             return self._warning_formatter.format(record)
-        return self._info_formatter.format(record)
+        elif record.levelno > logging.DEBUG:
+            return self._info_formatter.format(record)
+        return self._debug_formatter.format(record)
 
 
-def _get_file_dict_config(logfile: str, console_enabled: bool, debug: bool) -> dict:
+def _get_file_dict_config(
+    logfile: str, console_enabled: bool, debug: bool, no_color: bool
+) -> dict:
     # ensure that the logdir exists
     logdir = os.path.dirname(logfile)
     os.makedirs(logdir, exist_ok=True)
+    log_handlers = ["logfile"]
+    if console_enabled:
+        log_handlers.append("console")
 
     return {
         "version": 1,
@@ -61,6 +151,7 @@ def _get_file_dict_config(logfile: str, console_enabled: bool, debug: bool) -> d
             "streamfmt": {
                 "()": "funcx_endpoint.logging_config.FuncxConsoleFormatter",
                 "debug": debug,
+                "no_color": no_color,
             },
             "filefmt": {
                 "format": DEFAULT_FORMAT,
@@ -85,24 +176,25 @@ def _get_file_dict_config(logfile: str, console_enabled: bool, debug: bool) -> d
         "loggers": {
             "funcx_endpoint": {
                 "level": "DEBUG" if debug else "INFO",
-                "handlers": ["console", "logfile"] if console_enabled else ["logfile"],
+                "handlers": log_handlers,
             },
             # configure for the funcx SDK as well
             "funcx": {
                 "level": "DEBUG" if debug else "WARNING",
-                "handlers": ["logfile", "console"] if console_enabled else ["logfile"],
+                "handlers": log_handlers,
             },
         },
     }
 
 
-def _get_stream_dict_config(debug: bool) -> dict:
+def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:
     return {
         "version": 1,
         "formatters": {
             "streamfmt": {
                 "()": "funcx_endpoint.logging_config.FuncxConsoleFormatter",
                 "debug": debug,
+                "no_color": no_color,
             },
         },
         "handlers": {
@@ -151,14 +243,14 @@ def setup_logging(
     *,
     logfile: t.Optional[str] = None,
     console_enabled: bool = True,
-    debug: bool = False
+    debug: bool = False,
+    no_color: bool = False,
 ) -> None:
-
     add_trace_level()
 
     if logfile is not None:
-        config = _get_file_dict_config(logfile, console_enabled, debug)
+        config = _get_file_dict_config(logfile, console_enabled, debug, no_color)
     else:
-        config = _get_stream_dict_config(debug)
+        config = _get_stream_dict_config(debug, no_color)
 
     logging.config.dictConfig(config)

--- a/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -310,7 +310,10 @@ class TestStart:
             "missing executor definitions",
         ):
             log_to_console = False
-            manager.start_endpoint("mock_endpoint", None, mock_load(), log_to_console)
+            no_color = True
+            manager.start_endpoint(
+                "mock_endpoint", None, mock_load(), log_to_console, no_color
+            )
 
     @pytest.mark.skip("This test doesn't make much sense")
     def test_daemon_launch(self, mocker):


### PR DESCRIPTION
In order to more quickly draw attention to the relevant parts of the log lines, implement ANSI color escape codes.  The idea is not artistic perfection, but a simple approach to "syntax highlight" the console (*strictly* console, not log files).  To that end, the "header" of each line (i.e., time, runtime info, code line, method name) is the same, but the actual message is slightly different for DEBUG, INFO, WARNING, and ERROR logs.

In addition, since we are so heavily UUID based, also highlight any UUIDs.

For those who want to log to the console and do not want color, there is also a `--no-color` argument.

## Type of change

- New feature (non-breaking change that adds functionality)