### PR TITLE
Add an @channel slack notification to test failures

### DIFF
--- a/.github/_support/github-slack-notify.py
+++ b/.github/_support/github-slack-notify.py
@@ -97,13 +97,13 @@ def check_status_changed(status):
 
 
 def get_failure_message():
-    return os.getenv("SLACK_FAILURE_MESSAGE", "@here tests failed")
+    return os.getenv("SLACK_FAILURE_MESSAGE", "@channel tests failed")
 
 
 def build_payload(status):
     context = f"{statusemoji(status)} build for {get_branchname()}: {status}"
     message = f"<{get_build_url()}|{get_message_title()}>"
-    if status == "failure":
+    if "fail" in status.lower():
         message = f"{message}: {get_failure_message()}"
 
     return {


### PR DESCRIPTION
# Description

Adds a channel notification to test failures. Also updated the message setting condition to catch fail within messages.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
