### PR TITLE
add logout to funcx endpoint

### DIFF
--- a/changelog.d/20220831_121901_LeiGlobus_funcx_endpoint_logout_sc_18074.rst
+++ b/changelog.d/20220831_121901_LeiGlobus_funcx_endpoint_logout_sc_18074.rst
@@ -1,0 +1,8 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+-----------------
+
+- Added logout command for funcx-endpoint to revoke cached tokens

--- a/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/tests/conftest.py
@@ -37,7 +37,7 @@ class FakeLoginManager:
     def ensure_logged_in(self) -> None:
         ...
 
-    def logout(self) -> None:
+    def logout(self) -> bool:
         ...
 
     def get_auth_client(self) -> globus_sdk.AuthClient:

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock
+
 import pytest
 from click.testing import CliRunner
 
-from funcx_endpoint.cli import app
+import funcx.sdk.login_manager
+from funcx_endpoint.cli import _do_logout_endpoints, app
 
 runner = CliRunner()
 
@@ -30,3 +33,44 @@ def test_non_configured_endpoint(mocker):
     result = runner.invoke(app, ["start", "newendpoint"])
     assert "newendpoint" in result.stdout
     assert "not configured" in result.stdout
+
+
+def test_endpoint_logout(monkeypatch):
+    # not forced, and no running endpoints
+    logout_true = Mock(return_value=True)
+    logout_false = Mock(return_value=False)
+    monkeypatch.setattr(funcx.sdk.login_manager.LoginManager, "logout", logout_true)
+    success, msg = _do_logout_endpoints(
+        False,
+        running_endpoints={},
+    )
+    logout_true.assert_called_once()
+    assert success
+
+    logout_true.reset_mock()
+
+    # forced, and no running endpoints
+    success, msg = _do_logout_endpoints(
+        True,
+        running_endpoints={},
+    )
+    logout_true.assert_called_once()
+    assert success
+
+    one_running = {
+        "default": {"status": "Running", "id": "123abcde-a393-4456-8de5-123456789abc"}
+    }
+
+    monkeypatch.setattr(funcx.sdk.login_manager.LoginManager, "logout", logout_false)
+    # not forced, with running endpoint
+    success, msg = _do_logout_endpoints(False, running_endpoints=one_running)
+    logout_false.assert_not_called()
+    assert not success
+
+    logout_true.reset_mock()
+
+    monkeypatch.setattr(funcx.sdk.login_manager.LoginManager, "logout", logout_true)
+    # forced, with running endpoint
+    success, msg = _do_logout_endpoints(True, running_endpoints=one_running)
+    logout_true.assert_called_once()
+    assert success

--- a/funcx_sdk/funcx/sdk/login_manager/manager.py
+++ b/funcx_sdk/funcx/sdk/login_manager/manager.py
@@ -78,14 +78,20 @@ class LoginManager:
 
         do_link_auth_flow(self._token_storage, scopes)
 
-    def logout(self) -> None:
+    def logout(self) -> bool:
+        """
+        Returns True if at least one set of tokens were found and revoked.
+        """
         auth_client = internal_auth_client()
-        for rs, tokendata in self._token_storage.get_by_resource_server().items():
+        tokens_revoked = False
+        for rs, token_data in self._token_storage.get_by_resource_server().items():
             for tok_key in ("access_token", "refresh_token"):
-                token = tokendata[tok_key]
+                token = token_data[tok_key]
                 auth_client.oauth2_revoke_token(token)
-
             self._token_storage.remove_tokens_for_resource_server(rs)
+            tokens_revoked = True
+
+        return tokens_revoked
 
     def ensure_logged_in(self) -> None:
         data = self._token_storage.get_by_resource_server()

--- a/funcx_sdk/funcx/sdk/login_manager/protocol.py
+++ b/funcx_sdk/funcx/sdk/login_manager/protocol.py
@@ -19,7 +19,7 @@ class LoginManagerProtocol(Protocol):
     def ensure_logged_in(self) -> None:
         ...
 
-    def logout(self) -> None:
+    def logout(self) -> bool:
         ...
 
     def get_auth_client(self) -> globus_sdk.AuthClient:


### PR DESCRIPTION
Added logout subcommand to funcx-endpoint.  See linked SC: https://app.shortcut.com/funcx/story/18074/support-funcx-endpoint-logout

There is a slight modification to funcx_sdk.funcx.sdk.login_manager.manager.logout to return bool instead, plus see the associated TODO comment.

I expect to remove the TODO in LoginManager.logout and funcx_endpoint.cli.logout_endpoint before merging (the TODOs are to ensure PR comment)

*EDIT* all the TODOs were removed along with most of the proposed (and rejected) extra logic/params.