### PR TITLE
Avoid traceback if RMQ closes connection

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -324,7 +324,7 @@ class EndpointInterchange:
             queue_info=self.result_q_info,
         )
 
-        with results_publisher.connect():
+        with results_publisher:
             executor = list(self.executors.values())[0]
 
             num_tasks_forwarded = 0


### PR DESCRIPTION
If the RMQ service closes the connection, the class state is stale.  Instead, rely on the _connection_ state to determine if a close() is necessary.  Meanwhile, no need to shut down the channel -- closing the connection will take care of that automatically.

Easy recreation: close the `ep_result` connection from the RMQ admin console (_Connections_ tab).

Example traceback (that this PR avoids):

```python
[TIMESTAMP] ERROR ....endpoint.interchange:279 start Unhandled exception in main kernel.
Traceback (most recent call last):
  File "VENV/endpoint/interchange.py", line 277, in start
    self._start_threads_and_main()
  File "VENV/endpoint/interchange.py", line 303, in _start_threads_and_main
    self._main_loop()
  File "VENV/endpoint/interchange.py", line 327, in _main_loop
    with results_publisher.connect():
  File "VENV/endpoint/rabbit_mq/result_queue_publisher.py", line 49, in __exit__
    self.close()
  File "VENV/endpoint/rabbit_mq/result_queue_publisher.py", line 88, in close
    self._channel.close()
  File "VENV/pika/adapters/blocking_connection.py", line 1513, in close
    self._impl._raise_if_not_open()
  File "VENV/pika/channel.py", line 1393, in _raise_if_not_open
    raise exceptions.ChannelWrongStateError('Channel is closed.')
pika.exceptions.ChannelWrongStateError: Channel is closed.
```

## Type of change

- Bug fix (non-breaking change that fixes an issue)