### PR TITLE
Don't require users to pass in a `FuncXClient` when creating a `FuncXExecutor`

### DIFF
--- a/changelog.d/20220907_150940_chris_dont_require_client_argument.rst
+++ b/changelog.d/20220907_150940_chris_dont_require_client_argument.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- The `funcx_client` argument to `FuncXExecutor()` has been made optional. If nothing
+  is passed in, the `FuncXExecutor` now creates a `FuncXClient` for itself.

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -89,7 +89,7 @@ class FuncXExecutor(concurrent.futures.Executor):
 
     def __init__(
         self,
-        funcx_client: FuncXClient,
+        funcx_client: FuncXClient | None = None,
         label: str = "FuncXExecutor",
         batch_enabled: bool = True,
         batch_interval: float = 1.0,
@@ -107,7 +107,10 @@ class FuncXExecutor(concurrent.futures.Executor):
             Default: 'FuncXExecutor'
         """
 
-        self.funcx_client: FuncXClient = funcx_client
+        if funcx_client:
+            self.funcx_client = funcx_client
+        else:
+            self.funcx_client = FuncXClient()
 
         self.label = label
         self.batch_enabled = batch_enabled


### PR DESCRIPTION
# Description

Motivated by recent work on updating the tutorial notebook.

If we want to push the executor as the default interface to use, we shouldn't muddy the waters by also requiring users to create a `FuncXClient` and pass it in, if we can assume a sensible default.

## Type of change

- New feature (non-breaking change that adds functionality)
