### PR TITLE
remove obsolete map_run and submit_batch

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -436,50 +436,6 @@ class FuncXClient:
 
         return task_uuids
 
-    def map_run(
-        self, *args, endpoint_id=None, function_id=None, asynchronous=False, **kwargs
-    ):
-        """Initiate an invocation
-
-        Parameters
-        ----------
-        *args : Any
-            Args as specified by the function signature
-        endpoint_id : uuid str
-            Endpoint UUID string. Required
-        function_id : uuid str
-            Function UUID string. Required
-        asynchronous : bool
-            Whether or not to run the function asynchronously
-
-        Returns
-        -------
-        task_id : str
-        UUID string that identifies the task
-        """
-        assert endpoint_id is not None, "endpoint_id key-word argument must be set"
-        assert function_id is not None, "function_id key-word argument must be set"
-
-        ser_kwargs = self.fx_serializer.serialize(kwargs)
-
-        batch_payload = []
-        iterator = args[0]
-        for arg in iterator:
-            ser_args = self.fx_serializer.serialize((arg,))
-            payload = self.fx_serializer.pack_buffers([ser_args, ser_kwargs])
-            batch_payload.append(payload)
-
-        data = {
-            "endpoints": [endpoint_id],
-            "func": function_id,
-            "payload": batch_payload,
-            "is_async": asynchronous,
-        }
-
-        # Send the data to funcX
-        r = self.web_client.submit_batch(data)
-        return r["task_uuids"]
-
     def register_endpoint(
         self, name, endpoint_id, metadata=None, endpoint_version=None
     ):

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -167,9 +167,6 @@ class FuncxWebClient(globus_sdk.BaseClient):
     def submit(self, batch: t.Dict[str, t.Any]) -> globus_sdk.GlobusHTTPResponse:
         return self.post("submit", data=batch)
 
-    def submit_batch(self, batch: t.Dict[str, t.Any]) -> globus_sdk.GlobusHTTPResponse:
-        return self.post("submit_batch", data=batch)
-
     def register_endpoint(
         self,
         endpoint_name: str,


### PR DESCRIPTION
Remove the map_run() method and associated /submit_batch post as they are obsoleted (and non-functional) with the new batch run API.