### PR TITLE
[DRAFT] Capture timing information and report

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -45,7 +45,7 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
             "task_id": uuid.UUID(unpacked["task_id"]),
         }
         if "task_statuses" in unpacked:
-            kwargs["statuses"] = unpacked["statuses"]
+            kwargs["task_statuses"] = unpacked["task_statuses"]
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]
             code, user_message = unpacked["error_details"]

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -41,8 +41,6 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
             task_statuses=unpacked.task_statuses,
         )
     elif isinstance(unpacked, dict):
-        # exec_start|end_ms is not currently being used in prod and also
-        # may not be present
         kwargs = {
             "task_id": uuid.UUID(unpacked["task_id"]),
         }

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -45,25 +45,11 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         # may not be present
         kwargs = {
             "task_id": uuid.UUID(unpacked["task_id"]),
-<<<<<<< HEAD
-<<<<<<< HEAD
             "exec_start_ms": unpacked.get("exec_start_ms", 0),
             "exec_end_ms": unpacked.get("exec_end_ms", 0),
-=======
->>>>>>> e27c9da0 (Black)
         }
         if "statuses" in unpacked:
             kwargs["statuses"] = unpacked["statuses"]
-=======
-        }
-<<<<<<< HEAD
-        if "times" in unpacked:
-            kwargs["times"] = unpacked["times"]
->>>>>>> 3c7dbdbe (Black)
-=======
-        if "statuses" in unpacked:
-            kwargs["statuses"] = unpacked["statuses"]
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]
             code, user_message = unpacked["error_details"]

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -46,13 +46,24 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         kwargs = {
             "task_id": uuid.UUID(unpacked["task_id"]),
 <<<<<<< HEAD
+<<<<<<< HEAD
             "exec_start_ms": unpacked.get("exec_start_ms", 0),
             "exec_end_ms": unpacked.get("exec_end_ms", 0),
 =======
 >>>>>>> e27c9da0 (Black)
         }
+        if "statuses" in unpacked:
+            kwargs["statuses"] = unpacked["statuses"]
+=======
+        }
+<<<<<<< HEAD
         if "times" in unpacked:
             kwargs["times"] = unpacked["times"]
+>>>>>>> 3c7dbdbe (Black)
+=======
+        if "statuses" in unpacked:
+            kwargs["statuses"] = unpacked["statuses"]
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]
             code, user_message = unpacked["error_details"]

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -45,10 +45,8 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         # may not be present
         kwargs = {
             "task_id": uuid.UUID(unpacked["task_id"]),
-            "exec_start_ms": unpacked.get("exec_start_ms", 0),
-            "exec_end_ms": unpacked.get("exec_end_ms", 0),
         }
-        if "statuses" in unpacked:
+        if "task_statuses" in unpacked:
             kwargs["statuses"] = unpacked["statuses"]
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -45,9 +45,14 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         # may not be present
         kwargs = {
             "task_id": uuid.UUID(unpacked["task_id"]),
+<<<<<<< HEAD
             "exec_start_ms": unpacked.get("exec_start_ms", 0),
             "exec_end_ms": unpacked.get("exec_end_ms", 0),
+=======
+>>>>>>> e27c9da0 (Black)
         }
+        if "times" in unpacked:
+            kwargs["times"] = unpacked["times"]
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]
             code, user_message = unpacked["error_details"]

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -241,7 +241,7 @@ class Manager:
         self.next_worker_q: list[str] = []  # FIFO queue for spinning up workers.
         self.worker_procs: dict[str, subprocess.Popen] = {}
 
-        self.task_status_deltas: dict[str, tuple[float, TaskState, ActorName]] = {}
+        self.task_status_deltas: dict[str, TaskTransition] = {}
 
         self._kill_event = threading.Event()
         self._result_pusher_thread = threading.Thread(
@@ -646,12 +646,12 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            ts = TaskTransition(
+            tt = TaskTransition(
                 timestamp=time.time_ns(),
                 state=TaskState.RUNNING,
                 actor=ActorName.MANAGER,
             )
-            self.task_status_deltas[task.task_id] = ts
+            self.task_status_deltas[task.task_id] = tt
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,
                 "task_type": task_type,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -645,7 +645,7 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            ts = (time.monotonic(), TaskState.RUNNING, ActorName.MANAGER)
+            ts = (time.time_ns(), TaskState.RUNNING, ActorName.MANAGER)
             self.task_status_deltas[task.task_id] = ts
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -19,6 +19,7 @@ from typing import Any
 import dill
 import psutil
 import zmq
+from funcx_common.messagepack.message_type import TaskTransition
 from funcx_common.tasks import ActorName, TaskState
 from parsl.version import VERSION as PARSL_VERSION
 
@@ -645,7 +646,11 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            ts = (time.time_ns(), TaskState.RUNNING, ActorName.MANAGER)
+            ts = TaskTransition(
+                timestamp=time.time_ns(),
+                state=TaskState.RUNNING,
+                actor=ActorName.MANAGER,
+            )
             self.task_status_deltas[task.task_id] = ts
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -19,7 +19,7 @@ from typing import Any
 import dill
 import psutil
 import zmq
-from funcx_common.tasks import TaskState
+from funcx_common.tasks import ActorName, TaskState
 from parsl.version import VERSION as PARSL_VERSION
 
 from funcx.serialize import FuncXSerializer
@@ -240,7 +240,7 @@ class Manager:
         self.next_worker_q: list[str] = []  # FIFO queue for spinning up workers.
         self.worker_procs: dict[str, subprocess.Popen] = {}
 
-        self.task_status_deltas: dict[str, tuple[float, TaskState]] = {}
+        self.task_status_deltas: dict[str, tuple[float, TaskState, ActorName]] = {}
 
         self._kill_event = threading.Event()
         self._result_pusher_thread = threading.Thread(
@@ -645,7 +645,7 @@ class Manager:
         self.worker_map.update_worker_idle(task_type)
         if task.task_id != "KILL":
             log.debug(f"Set task {task.task_id} to RUNNING")
-            ts = (time.monotonic(), TaskState.RUNNING)
+            ts = (time.monotonic(), TaskState.RUNNING, ActorName.MANAGER)
             self.task_status_deltas[task.task_id] = ts
             self.task_worker_map[task.task_id] = {
                 "worker_id": worker_id,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -19,7 +19,7 @@ from typing import Any
 import dill
 import psutil
 import zmq
-from funcx_common.messagepack.message_type import TaskTransition
+from funcx_common.messagepack.message_types import TaskTransition
 from funcx_common.tasks import ActorName, TaskState
 from parsl.version import VERSION as PARSL_VERSION
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -10,6 +10,11 @@ import time
 import dill
 import zmq
 from funcx_common import messagepack
+<<<<<<< HEAD
+from funcx_common.tasks import ActorName, TaskState
+=======
+from funcx_common.tasks import TaskState
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
 
 from funcx.errors import MaxResultSizeExceeded
 from funcx.serialize import FuncXSerializer
@@ -124,17 +129,55 @@ class FuncXWorker:
 
     def execute_task(self, task_id: str, task_body: bytes) -> dict:
         log.debug("executing task task_id='%s'", task_id)
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+        exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
+=======
         exec_times = {"exec_start_ms": _now_ms()}
+>>>>>>> cbd5779a (Black)
+=======
+        exec_times = {"exec_start_ms": _now_ms()}
+>>>>>>> d375e5fc (Black)
+=======
+        exec_start = (_now_ms(), TaskState.EXEC_START)
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
 
         try:
             result = self.call_user_function(task_body)
         except Exception:
             log.exception("Caught an exception while executing user function")
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
+=======
             exec_times["exec_end_ms"] = _now_ms()
+>>>>>>> cbd5779a (Black)
+=======
+            exec_times["exec_end_ms"] = _now_ms()
+>>>>>>> d375e5fc (Black)
+=======
+            exec_end = (_now_ms(), TaskState.EXEC_END)
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
                 error_details=get_result_error_details(),
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+                statuses=[exec_start, exec_end],
+            )
+        else:
+            log.debug("Execution completed without exception")
+            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
+            result_message = dict(
+                task_id=task_id,
+                data=result,
+                statuses=[exec_start, exec_end],
+=======
                 times=exec_times,
             )
         else:
@@ -144,12 +187,58 @@ class FuncXWorker:
                 task_id=task_id,
                 data=result,
                 times=exec_times,
+>>>>>>> cbd5779a (Black)
+=======
+                times=exec_times,
+=======
+                status=[exec_start, exec_end],
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+                statuses=[exec_start, exec_end],
+>>>>>>> facc8945 (Correct time difference and statuses)
+            )
+        else:
+            log.debug("Execution completed without exception")
+            exec_end = (_now_ms(), TaskState.EXEC_END)
+            result_message = dict(
+                task_id=task_id,
+                data=result,
+<<<<<<< HEAD
+<<<<<<< HEAD
+                times=exec_times,
+>>>>>>> d375e5fc (Black)
+=======
+                status=[exec_start, exec_end],
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+                statuses=[exec_start, exec_end],
+>>>>>>> facc8945 (Correct time difference and statuses)
             )
 
         log.debug(
             "task %s completed in %d ms",
             task_id,
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            (exec_end[0] - exec_start[0]),
+=======
             (exec_times["exec_end_ms"] - exec_times["exec_start_ms"]),
+>>>>>>> cbd5779a (Black)
+=======
+            (exec_times["exec_end_ms"] - exec_times["exec_start_ms"]),
+>>>>>>> d375e5fc (Black)
+=======
+            (exec_end - exec_start),
+>>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+            (exec_end[0] - exec_start[1]),
+>>>>>>> facc8945 (Correct time difference and statuses)
+=======
+            (exec_end[0] - exec_start[0]),
+>>>>>>> d504dffe (typo)
         )
         return result_message
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -13,6 +13,10 @@ from funcx_common import messagepack
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+from funcx_common.messagepack.message_types import TaskTransition
+>>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
 from funcx_common.tasks import ActorName, TaskState
 =======
 from funcx_common.tasks import TaskState
@@ -138,6 +142,7 @@ class FuncXWorker:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
 =======
         exec_times = {"exec_start_ms": _now_ms()}
@@ -154,6 +159,11 @@ class FuncXWorker:
 =======
         exec_start = (time.time_ns(), TaskState.EXEC_START, ActorName.WORKER)
 >>>>>>> 5b5e6865 (Switch to time_ns())
+=======
+        exec_start = TaskTransition(
+            timestamp=time.time_ns(), state=TaskState.EXEC_START, actor=ActorName.WORKER
+        )
+>>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
 
         try:
             result = self.call_user_function(task_body)
@@ -164,6 +174,7 @@ class FuncXWorker:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
 =======
             exec_times["exec_end_ms"] = _now_ms()
@@ -180,6 +191,13 @@ class FuncXWorker:
 =======
             exec_end = (time.time_ns(), TaskState.EXEC_END, ActorName.WORKER)
 >>>>>>> 5b5e6865 (Switch to time_ns())
+=======
+            exec_end = TaskTransition(
+                timestamp=time.time_ns(),
+                state=TaskState.EXEC_END,
+                actor=ActorName.WORKER,
+            )
+>>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
@@ -188,6 +206,7 @@ class FuncXWorker:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
                 statuses=[exec_start, exec_end],
             )
         else:
@@ -240,11 +259,27 @@ class FuncXWorker:
 =======
                 statuses=[exec_start, exec_end],
 >>>>>>> facc8945 (Correct time difference and statuses)
+=======
+                transitions=[exec_start, exec_end],
+            )
+        else:
+            log.debug("Execution completed without exception")
+            exec_end = TaskTransition(
+                timestamp=time.time_ns(),
+                state=TaskState.EXEC_END,
+                actor=ActorName.WORKER,
+            )
+            result_message = dict(
+                task_id=task_id,
+                data=result,
+                transitions=[exec_start, exec_end],
+>>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
             )
 
         log.debug(
-            "task %s completed in %d ms",
+            "task %s completed in %d ns",
             task_id,
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -266,6 +301,9 @@ class FuncXWorker:
 =======
             (exec_end[0] - exec_start[0]),
 >>>>>>> d504dffe (typo)
+=======
+            (exec_end.timestamp - exec_start.timestamp),
+>>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
         )
         return result_message
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -10,23 +10,8 @@ import time
 import dill
 import zmq
 from funcx_common import messagepack
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 from funcx_common.messagepack.message_types import TaskTransition
->>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
 from funcx_common.tasks import ActorName, TaskState
-=======
-from funcx_common.tasks import TaskState
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-from funcx_common.tasks.constants import ActorName, TaskState
->>>>>>> 5bd67dfa (Include actor name as part of status update.)
-=======
-from funcx_common.tasks import ActorName, TaskState
->>>>>>> 4149165f (Fix import line)
 
 from funcx.errors import MaxResultSizeExceeded
 from funcx.serialize import FuncXSerializer
@@ -137,131 +122,26 @@ class FuncXWorker:
 
     def execute_task(self, task_id: str, task_body: bytes) -> dict:
         log.debug("executing task task_id='%s'", task_id)
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
-=======
-        exec_times = {"exec_start_ms": _now_ms()}
->>>>>>> cbd5779a (Black)
-=======
-        exec_times = {"exec_start_ms": _now_ms()}
->>>>>>> d375e5fc (Black)
-=======
-        exec_start = (_now_ms(), TaskState.EXEC_START)
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-        exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
->>>>>>> ac98dda4 (Fix missing actor name in exec start timestamp)
-=======
-        exec_start = (time.time_ns(), TaskState.EXEC_START, ActorName.WORKER)
->>>>>>> 5b5e6865 (Switch to time_ns())
-=======
         exec_start = TaskTransition(
             timestamp=time.time_ns(), state=TaskState.EXEC_START, actor=ActorName.WORKER
         )
->>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
 
         try:
             result = self.call_user_function(task_body)
         except Exception:
             log.exception("Caught an exception while executing user function")
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
-=======
-            exec_times["exec_end_ms"] = _now_ms()
->>>>>>> cbd5779a (Black)
-=======
-            exec_times["exec_end_ms"] = _now_ms()
->>>>>>> d375e5fc (Black)
-=======
-            exec_end = (_now_ms(), TaskState.EXEC_END)
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
->>>>>>> 5bd67dfa (Include actor name as part of status update.)
-=======
-            exec_end = (time.time_ns(), TaskState.EXEC_END, ActorName.WORKER)
->>>>>>> 5b5e6865 (Switch to time_ns())
-=======
             exec_end = TaskTransition(
                 timestamp=time.time_ns(),
                 state=TaskState.EXEC_END,
                 actor=ActorName.WORKER,
             )
->>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
                 error_details=get_result_error_details(),
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                statuses=[exec_start, exec_end],
+                task_statuses=[exec_start, exec_end],
             )
-        else:
-            log.debug("Execution completed without exception")
-<<<<<<< HEAD
-            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
-<<<<<<< HEAD
-            result_message = dict(
-                task_id=task_id,
-                data=result,
-                statuses=[exec_start, exec_end],
-=======
-                times=exec_times,
-            )
-        else:
-            log.debug("Execution completed without exception")
-            exec_times["exec_end_ms"] = _now_ms()
-=======
-            exec_end = (time.time_ns(), TaskState.EXEC_END, ActorName.WORKER)
->>>>>>> 5b5e6865 (Switch to time_ns())
-            result_message = dict(
-                task_id=task_id,
-                data=result,
-                times=exec_times,
->>>>>>> cbd5779a (Black)
-=======
-                times=exec_times,
-=======
-                status=[exec_start, exec_end],
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-                statuses=[exec_start, exec_end],
->>>>>>> facc8945 (Correct time difference and statuses)
-            )
-        else:
-            log.debug("Execution completed without exception")
-            exec_end = (_now_ms(), TaskState.EXEC_END)
-=======
->>>>>>> 5bd67dfa (Include actor name as part of status update.)
-            result_message = dict(
-                task_id=task_id,
-                data=result,
-<<<<<<< HEAD
-<<<<<<< HEAD
-                times=exec_times,
->>>>>>> d375e5fc (Black)
-=======
-                status=[exec_start, exec_end],
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-                statuses=[exec_start, exec_end],
->>>>>>> facc8945 (Correct time difference and statuses)
-=======
-                transitions=[exec_start, exec_end],
-            )
+
         else:
             log.debug("Execution completed without exception")
             exec_end = TaskTransition(
@@ -272,38 +152,13 @@ class FuncXWorker:
             result_message = dict(
                 task_id=task_id,
                 data=result,
-                transitions=[exec_start, exec_end],
->>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
+                task_statuses=[exec_start, exec_end],
             )
 
         log.debug(
             "task %s completed in %d ns",
             task_id,
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            (exec_end[0] - exec_start[0]),
-=======
-            (exec_times["exec_end_ms"] - exec_times["exec_start_ms"]),
->>>>>>> cbd5779a (Black)
-=======
-            (exec_times["exec_end_ms"] - exec_times["exec_start_ms"]),
->>>>>>> d375e5fc (Black)
-=======
-            (exec_end - exec_start),
->>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
-=======
-            (exec_end[0] - exec_start[1]),
->>>>>>> facc8945 (Correct time difference and statuses)
-=======
-            (exec_end[0] - exec_start[0]),
->>>>>>> d504dffe (typo)
-=======
             (exec_end.timestamp - exec_start.timestamp),
->>>>>>> 38ff67fd (Converting status updates to TaskTransition messages)
         )
         return result_message
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -130,30 +130,23 @@ class FuncXWorker:
             result = self.call_user_function(task_body)
         except Exception:
             log.exception("Caught an exception while executing user function")
-            exec_end = TaskTransition(
-                timestamp=time.time_ns(),
-                state=TaskState.EXEC_END,
-                actor=ActorName.WORKER,
-            )
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
                 error_details=get_result_error_details(),
-                task_statuses=[exec_start, exec_end],
             )
 
         else:
             log.debug("Execution completed without exception")
-            exec_end = TaskTransition(
-                timestamp=time.time_ns(),
-                state=TaskState.EXEC_END,
-                actor=ActorName.WORKER,
-            )
-            result_message = dict(
-                task_id=task_id,
-                data=result,
-                task_statuses=[exec_start, exec_end],
-            )
+            result_message = dict(task_id=task_id, data=result)
+
+        exec_end = TaskTransition(
+            timestamp=time.time_ns(),
+            state=TaskState.EXEC_END,
+            actor=ActorName.WORKER,
+        )
+        
+        result_message['task_statuses'] = [exec_start, exec_end]
 
         log.debug(
             "task %s completed in %d ns",

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -37,10 +37,6 @@ DEFAULT_RESULT_SIZE_LIMIT_MB = 10
 DEFAULT_RESULT_SIZE_LIMIT_B = DEFAULT_RESULT_SIZE_LIMIT_MB * 1024 * 1024
 
 
-def _now_ms() -> int:
-    return int(time.time() * 1000)
-
-
 class FuncXWorker:
     """The FuncX worker
     Parameters
@@ -141,6 +137,7 @@ class FuncXWorker:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
 =======
         exec_times = {"exec_start_ms": _now_ms()}
@@ -154,11 +151,15 @@ class FuncXWorker:
 =======
         exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
 >>>>>>> ac98dda4 (Fix missing actor name in exec start timestamp)
+=======
+        exec_start = (time.time_ns(), TaskState.EXEC_START, ActorName.WORKER)
+>>>>>>> 5b5e6865 (Switch to time_ns())
 
         try:
             result = self.call_user_function(task_body)
         except Exception:
             log.exception("Caught an exception while executing user function")
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -176,6 +177,9 @@ class FuncXWorker:
 =======
             exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
 >>>>>>> 5bd67dfa (Include actor name as part of status update.)
+=======
+            exec_end = (time.time_ns(), TaskState.EXEC_END, ActorName.WORKER)
+>>>>>>> 5b5e6865 (Switch to time_ns())
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
@@ -188,6 +192,7 @@ class FuncXWorker:
             )
         else:
             log.debug("Execution completed without exception")
+<<<<<<< HEAD
             exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
 <<<<<<< HEAD
             result_message = dict(
@@ -200,6 +205,9 @@ class FuncXWorker:
         else:
             log.debug("Execution completed without exception")
             exec_times["exec_end_ms"] = _now_ms()
+=======
+            exec_end = (time.time_ns(), TaskState.EXEC_END, ActorName.WORKER)
+>>>>>>> 5b5e6865 (Switch to time_ns())
             result_message = dict(
                 task_id=task_id,
                 data=result,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py
@@ -11,10 +11,18 @@ import dill
 import zmq
 from funcx_common import messagepack
 <<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
 from funcx_common.tasks import ActorName, TaskState
 =======
 from funcx_common.tasks import TaskState
 >>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+from funcx_common.tasks.constants import ActorName, TaskState
+>>>>>>> 5bd67dfa (Include actor name as part of status update.)
+=======
+from funcx_common.tasks import ActorName, TaskState
+>>>>>>> 4149165f (Fix import line)
 
 from funcx.errors import MaxResultSizeExceeded
 from funcx.serialize import FuncXSerializer
@@ -132,6 +140,7 @@ class FuncXWorker:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
 =======
         exec_times = {"exec_start_ms": _now_ms()}
@@ -142,11 +151,15 @@ class FuncXWorker:
 =======
         exec_start = (_now_ms(), TaskState.EXEC_START)
 >>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+        exec_start = (_now_ms(), TaskState.EXEC_START, ActorName.WORKER)
+>>>>>>> ac98dda4 (Fix missing actor name in exec start timestamp)
 
         try:
             result = self.call_user_function(task_body)
         except Exception:
             log.exception("Caught an exception while executing user function")
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -160,6 +173,9 @@ class FuncXWorker:
 =======
             exec_end = (_now_ms(), TaskState.EXEC_END)
 >>>>>>> baa726ea (Use list of tuples with updated TaskState fields to capture EXEC_START and EXEC_END times)
+=======
+            exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
+>>>>>>> 5bd67dfa (Include actor name as part of status update.)
             result_message = dict(
                 task_id=task_id,
                 exception=get_error_string(),
@@ -173,6 +189,7 @@ class FuncXWorker:
         else:
             log.debug("Execution completed without exception")
             exec_end = (_now_ms(), TaskState.EXEC_END, ActorName.WORKER)
+<<<<<<< HEAD
             result_message = dict(
                 task_id=task_id,
                 data=result,
@@ -200,6 +217,8 @@ class FuncXWorker:
         else:
             log.debug("Execution completed without exception")
             exec_end = (_now_ms(), TaskState.EXEC_END)
+=======
+>>>>>>> 5bd67dfa (Include actor name as part of status update.)
             result_message = dict(
                 task_id=task_id,
                 data=result,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -340,7 +340,7 @@ class Interchange:
 
         self.task_cancel_running_queue: queue.Queue = queue.Queue()
         self.task_cancel_pending_trap: dict[str, str] = {}
-        self.task_status_deltas: dict[str, tuple[float, TaskState, ActorName]] = {}
+        self.task_status_deltas: dict[str, TaskTransition] = {}
         self.container_switch_count: dict[str, int] = {}
 
     def load_config(self):
@@ -458,12 +458,12 @@ class Interchange:
                     }
                 )
                 self.total_pending_task_count += 1
-                ts = TaskTransition(
+                tt = TaskTransition(
                     timestamp=time.time_ns(),
                     state=TaskState.WAITING_FOR_NODES,
                     actor=ActorName.INTERCHANGE,
                 )
-                self.task_status_deltas[msg.task_id] = ts
+                self.task_status_deltas[msg.task_id] = tt
                 log.debug(
                     f"[TASK_PULL_THREAD] task {msg.task_id} is now WAITING_FOR_NODES"
                 )
@@ -900,12 +900,12 @@ class Interchange:
                             self.task_cancel_pending_trap.pop(task_id)
                         else:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
-                            ts = TaskTransition(
+                            tt = TaskTransition(
                                 timestamp=time.time_ns(),
                                 state=TaskState.WAITING_FOR_LAUNCH,
                                 actor=ActorName.INTERCHANGE,
                             )
-                            self.task_status_deltas[task_id] = ts
+                            self.task_status_deltas[task_id] = tt
 
             # Receive any results and forward to client
             if (

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -16,7 +16,7 @@ from typing import Any, Sequence
 import daemon
 import dill
 import zmq
-from funcx_common.tasks import TaskState
+from funcx_common.tasks import ActorName, TaskState
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.errors import ScalingFailed
 from parsl.version import VERSION as PARSL_VERSION
@@ -339,7 +339,7 @@ class Interchange:
 
         self.task_cancel_running_queue: queue.Queue = queue.Queue()
         self.task_cancel_pending_trap: dict[str, str] = {}
-        self.task_status_deltas: dict[str, tuple[float, TaskState]] = {}
+        self.task_status_deltas: dict[str, tuple[float, TaskState, ActorName]] = {}
         self.container_switch_count: dict[str, int] = {}
 
     def load_config(self):
@@ -457,7 +457,11 @@ class Interchange:
                     }
                 )
                 self.total_pending_task_count += 1
-                ts = (time.monotonic(), TaskState.WAITING_FOR_NODES)
+                ts = (
+                    time.monotonic(),
+                    TaskState.WAITING_FOR_NODES,
+                    ActorName.INTERCHANGE,
+                )
                 self.task_status_deltas[msg.task_id] = ts
                 log.debug(
                     f"[TASK_PULL_THREAD] task {msg.task_id} is now WAITING_FOR_NODES"
@@ -895,7 +899,11 @@ class Interchange:
                             self.task_cancel_pending_trap.pop(task_id)
                         else:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
-                            ts = (time.monotonic(), TaskState.WAITING_FOR_LAUNCH)
+                            ts = (
+                                time.monotonic(),
+                                TaskState.WAITING_FOR_LAUNCH,
+                                ActorName.INTERCHANGE,
+                            )
                             self.task_status_deltas[task_id] = ts
 
             # Receive any results and forward to client

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -16,6 +16,7 @@ from typing import Any, Sequence
 import daemon
 import dill
 import zmq
+from funcx_common.messagepack.message_types import TaskTransition
 from funcx_common.tasks import ActorName, TaskState
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.errors import ScalingFailed
@@ -457,10 +458,10 @@ class Interchange:
                     }
                 )
                 self.total_pending_task_count += 1
-                ts = (
-                    time.time_ns(),
-                    TaskState.WAITING_FOR_NODES,
-                    ActorName.INTERCHANGE,
+                ts = TaskTransition(
+                    timestamp=time.time_ns(),
+                    state=TaskState.WAITING_FOR_NODES,
+                    actor=ActorName.INTERCHANGE,
                 )
                 self.task_status_deltas[msg.task_id] = ts
                 log.debug(
@@ -899,10 +900,10 @@ class Interchange:
                             self.task_cancel_pending_trap.pop(task_id)
                         else:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
-                            ts = (
-                                time.time_ns(),
-                                TaskState.WAITING_FOR_LAUNCH,
-                                ActorName.INTERCHANGE,
+                            ts = TaskTransition(
+                                timestamp=time.time_ns(),
+                                state=TaskState.WAITING_FOR_LAUNCH,
+                                actor=ActorName.INTERCHANGE,
                             )
                             self.task_status_deltas[task_id] = ts
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -458,7 +458,7 @@ class Interchange:
                 )
                 self.total_pending_task_count += 1
                 ts = (
-                    time.monotonic(),
+                    time.time_ns(),
                     TaskState.WAITING_FOR_NODES,
                     ActorName.INTERCHANGE,
                 )
@@ -900,7 +900,7 @@ class Interchange:
                         else:
                             log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
                             ts = (
-                                time.monotonic(),
+                                time.time_ns(),
                                 TaskState.WAITING_FOR_LAUNCH,
                                 ActorName.INTERCHANGE,
                             )

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/messages.py
@@ -192,9 +192,9 @@ class EPStatusReport(Message):
         jsonified = msg.decode("ascii")
         ep_status, statuses = json.loads(jsonified)
         task_statuses = {}
-        for tid, ts in statuses.items():
+        for tid, tt in statuses.items():
             task_statuses[tid] = TaskTransition(
-                timestamp=ts["timestamp"], actor=ts["actor"], state=ts["state"]
+                timestamp=tt["timestamp"], actor=tt["actor"], state=tt["state"]
             )
         return cls(endpoint_id, ep_status, task_statuses)
 

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
     "funcx>=1.0.0",
-    "funcx-common==0.0.15",
+    "funcx-common==0.0.17",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
-    "funcx-common==0.0.15",
+    "funcx-common==0.0.17",
     "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [


### PR DESCRIPTION
# Description

This adds support to capture and report timestamp information throughout the endpoint. These status updates are reported to the web service to be logged and persisted.

There are a few changes here, including:
- Add status reports for exec start and exec end
- Include status updates in the manager updates to the endpoint
- Include the status reports in the status update messages the endpoint sends to the web service

These changes depend on changes to funcx-common and funcx-service to appropriately log them.

Fixes #  [sc-17571]

## Type of change

- New feature (non-breaking change that adds functionality)
