### PR TITLE
Fix endpoint configuration docstring default

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -20,8 +20,9 @@ class Config(RepresentationMixin):
 
     environment: str
         Environment the endpoint should connect to. Sets funcx_service_address and
-        results_ws_uri unless they are also specified.
-        Default: "prod"
+        results_ws_uri unless they are also specified. If not specified, the endpoint
+        connects to production.
+        Default: None
 
     funcx_service_address: str | None
         URL address string of the funcX service to which the Endpoint should connect.


### PR DESCRIPTION
# Description

Not only was this misleading - stating that the default was `"prod"` when it meant that it defaulted to `None` which was converted to `"prod"` eventually - the eventual string it reported was wrong. If you trace the code all the way through, it's actually `"production"`. 

## Type of change

- Documentation update
