### PR TITLE
Reset after highlight

### DIFF
--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -113,7 +113,7 @@ class FuncxConsoleFormatter(logging.Formatter):
             else:
                 end_coloring = COLOR_DEBUG
 
-            repl = f"{_byel}\\1{end_coloring}"
+            repl = f"{_byel}\\1{_r}{end_coloring}"
             try:
                 record.msg = self.uuid_re.sub(repl, record.msg)
                 if isinstance(record.args, dict):


### PR DESCRIPTION
Ensure that the foreground color is *also* reset -- for example, in the case of an error message, which in the current scheme, only changes the background color.

<img src="https://user-images.githubusercontent.com/99676336/190049711-bd140c04-868b-41d5-b5ed-4fb4d15154d5.png" alt="foreground color not reset after syntax highlighting" width="600"/>


## Type of change

- Bug fix (non-breaking change that fixes an issue)