### PR TITLE
Add filesystem options to the Polaris example config.

### DIFF
--- a/docs/configs/polaris.py
+++ b/docs/configs/polaris.py
@@ -13,7 +13,7 @@ user_opts = {
     'polaris': {
         # Node setup: activate necessary conda environment and such.
         'worker_init': '',
-        'scheduler_options': '',
+        'scheduler_options': '#PBS -l filesystems=home:grand:eagle',
         # ALCF allocation to use
         'account': '',
     }

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -96,7 +96,7 @@ Polaris (ALCF)
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
 **Polaris** cluster. This example uses the ``HighThroughputExecutor`` and connects to Polaris's PBS scheduler
-using the ``PBSProProvider``. This configuration assumes that the script is being executed on the login node of Polaris (edtb-02).
+using the ``PBSProProvider``. This configuration assumes that the script is being executed on the login node of Polaris.
 
 .. literalinclude:: configs/polaris.py
 


### PR DESCRIPTION
# Description

Includes the filesystems to mount in Polaris jobs. This is important when one is down and it needs to be removed for jobs to start.

Also removes an obsolete reference to EDTB login nodes that is no longer useful.

## Type of change

- Documentation update
