### PR TITLE
Remove unnecessary data structure

### DIFF
--- a/changelog.d/20220920_114304_kevin_refactor_executor_task_future_association.rst
+++ b/changelog.d/20220920_114304_kevin_refactor_executor_task_future_association.rst
@@ -1,0 +1,7 @@
+Deprecated
+^^^^^^^^^^
+
+- The `batch_interval` keyword argument to the FuncXExecutor is no longer
+  utilized.  Internally, the executor no longer waits to coalesce tasks.
+  Instead, it pulls them as fast as possible until either the input queue lags
+  or the count of tasks in the batch reaches `batch_size`.

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -35,12 +35,12 @@ def test_task_submission_info_stringification():
     ep_id = "bar_ep"
 
     info = TaskSubmissionInfo(
-        future_id=fut_id, function_id=func_id, endpoint_id=ep_id, args=(), kwargs={}
+        task_num=fut_id, function_id=func_id, endpoint_id=ep_id, args=(), kwargs={}
     )
     as_str = str(info)
     assert as_str.startswith("TaskSubmissionInfo(")
     assert as_str.endswith("args=..., kwargs=...)")
-    assert "future_id=10" in as_str
+    assert "task_num=10" in as_str
     assert "function_id='foo_func'" in as_str
     assert "endpoint_id='bar_ep'" in as_str
 


### PR DESCRIPTION
The Tasks and associated futures are created at the same time and can always be co-located.  There's no need to artificially separate them, and then have to look up one or the other.  Keep them together through the queue, and remove the unnecessary dict.

Meanwhile, with the change to `.get(block=False)` there's no more need for the coalesce delay.  Outside of egregious limits (e.g., a *very* high batch_size or a *very* small time limit), the timeout check is useless.

## Type of change

- Code maintenance/cleanup
