### PR TITLE
Update the ManagerLost error handling to mimic function exceptions

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -50,7 +50,7 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         }
         if "exception" in unpacked:
             kwargs["data"] = unpacked["exception"]
-            code, user_message = unpacked["error_details"]
+            code, user_message = unpacked.get("error_details", ("Unknown", "Unknown"))
             kwargs["error_details"] = OutgoingResultErrorDetails(
                 code=code, user_message=user_message
             )

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py
@@ -62,7 +62,8 @@ class ResultQueuePublisher:
         self.status = RabbitPublisherStatus.connected
 
     def publish(self, message: bytes) -> None:
-        """Publish message to RabbitMQ with the routing key to identify the message source
+        """Publish message to RabbitMQ with the routing key to identify the message
+        source.
         The channel specifies confirm_delivery and with `mandatory=True` this call
         will *block* until a delivery confirmation is received.
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -17,11 +17,11 @@ import daemon
 import dill
 import zmq
 from funcx_common.tasks import TaskState
-from parsl.app.errors import RemoteExceptionWrapper
 from parsl.version import VERSION as PARSL_VERSION
 
 from funcx.sdk.client import FuncXClient
 from funcx.serialize import FuncXSerializer
+from funcx_endpoint.exception_handling import get_error_string, get_result_error_details
 from funcx_endpoint.executors.high_throughput.interchange_task_dispatch import (
     naive_interchange_task_dispatch,
 )
@@ -1009,9 +1009,8 @@ class Interchange:
                         except Exception:
                             result_package = {
                                 "task_id": tid,
-                                "exception": self.serializer.serialize(
-                                    RemoteExceptionWrapper(*sys.exc_info())
-                                ),
+                                "exception": get_error_string(),
+                                "error_details": get_result_error_details(),
                             }
                             pkl_package = dill.dumps(result_package)
                             bad_manager_msgs.append(pkl_package)


### PR DESCRIPTION
# Description

The update to message packing broke the management of ManagerLost exceptions. This PR changes the interchange's managerlost handling to reflect the message pack updates. We now mimic function exceptions using the two builtin get_error_string and get_error_message functions.

Fixes #890

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)