### PR TITLE
Serialize access to sqlite

### DIFF
--- a/changelog.d/20220921_161549_kevin_serialize_access_to_sqlite.rst
+++ b/changelog.d/20220921_161549_kevin_serialize_access_to_sqlite.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- gh#907 - Enable concurrent access to the token store by manually serializing
+  access to the SQLite DB.

--- a/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
+++ b/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import sqlite3
 
 from globus_sdk.tokenstorage import SQLiteAdapter
 
@@ -77,4 +78,6 @@ def get_token_storage_adapter(*, environment: str | None = None) -> SQLiteAdapte
     if not os.path.exists(fname):
         invalidate_old_config()
     # namespace is equal to the current environment
-    return SQLiteAdapter(fname, namespace=_resolve_namespace(environment))
+    adapter = SQLiteAdapter(fname, namespace=_resolve_namespace(environment))
+    adapter._connection = sqlite3.connect(adapter.dbname, check_same_thread=False)
+    return adapter


### PR DESCRIPTION
# Description

SQLite helpfully defaults `check_same_thread` to `True`, which ensures that all access to the DB happens on the same thread that created the DB connection. But that's not *actually* the important bit.  What's important is that all transactions through that connection with the DB are *serialized*.  Serialized transaction calls are part of how SQLite guarantees that the underlying tables keep their integrity -- ensuring that all calls come from the same thread is a means to that end.  If we externally guarantee that our accesses to the DB are serialized, then we don't need SQLite to check that access are from the same thread.

Thus, we ensure that we do this for the important SQLite interactions with an access lock.

Fixes #907 ("Renewing auth token fails in multi-threaded applications")

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
