### PR TITLE
Bump versions and changelog for release 1.0.4

### DIFF
--- a/changelog.d/20220831_210735_kevin_add_submitted_task_counter.rst
+++ b/changelog.d/20220831_210735_kevin_add_submitted_task_counter.rst
@@ -1,6 +1,0 @@
-New Functionality
-^^^^^^^^^^^^^^^^^
-
-- Add `.task_count_submitted` member to FuncXExecutor.  This value is useful
-  for determining in client code how many tasks have *actually* made it to the
-  funcX Web Services.

--- a/changelog.d/20220907_150940_chris_dont_require_client_argument.rst
+++ b/changelog.d/20220907_150940_chris_dont_require_client_argument.rst
@@ -1,5 +1,0 @@
-Changed
-^^^^^^^
-
-- The `funcx_client` argument to `FuncXExecutor()` has been made optional. If nothing
-  is passed in, the `FuncXExecutor` now creates a `FuncXClient` for itself.

--- a/changelog.d/20220920_114304_kevin_refactor_executor_task_future_association.rst
+++ b/changelog.d/20220920_114304_kevin_refactor_executor_task_future_association.rst
@@ -1,7 +1,0 @@
-Deprecated
-^^^^^^^^^^
-
-- The `batch_interval` keyword argument to the FuncXExecutor is no longer
-  utilized.  Internally, the executor no longer waits to coalesce tasks.
-  Instead, it pulls them as fast as possible until either the input queue lags
-  or the count of tasks in the batch reaches `batch_size`.

--- a/changelog.d/20220921_161549_kevin_serialize_access_to_sqlite.rst
+++ b/changelog.d/20220921_161549_kevin_serialize_access_to_sqlite.rst
@@ -1,5 +1,0 @@
-Bug Fixes
-^^^^^^^^^
-
-- gh#907 - Enable concurrent access to the token store by manually serializing
-  access to the SQLite DB.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,38 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-1.0.4:
+
+funcx & funcx-endpoint v1.0.4
+-----------------------------
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add `.task_count_submitted` member to FuncXExecutor.  This value is useful
+  for determining in client code how many tasks have *actually* made it to the
+  funcX Web Services.
+
+Bug Fixes
+^^^^^^^^^
+
+- gh#907 - Enable concurrent access to the token store by manually serializing
+  access to the SQLite DB.
+
+Deprecated
+^^^^^^^^^^
+
+- The `batch_interval` keyword argument to the FuncXExecutor is no longer
+  utilized.  Internally, the executor no longer waits to coalesce tasks.
+  Instead, it pulls them as fast as possible until either the input queue lags
+  or the count of tasks in the batch reaches `batch_size`.
+
+Changed
+^^^^^^^
+
+- The `funcx_client` argument to `FuncXExecutor()` has been made optional. If nothing
+  is passed in, the `FuncXExecutor` now creates a `FuncXClient` for itself.
+
 .. _changelog-1.0.3:
 
 funcx & funcx-endpoint v1.0.3

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 # TODO: remove after a `funcx` release
 # this variable is needed because it's imported by `funcx` to do the version check

--- a/funcx_sdk/funcx/version.py
+++ b/funcx_sdk/funcx/version.py
@@ -4,7 +4,7 @@ from funcx.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def compare_versions(


### PR DESCRIPTION
Release 1.0.4

(to be released to dev as 1.0.4a0 first)