### PR TITLE
Venv environment doc changes

### DIFF
--- a/docs/Tutorial.rst
+++ b/docs/Tutorial.rst
@@ -9,11 +9,13 @@ You can setup and use your own endpoint by following the `endpoint documentation
 funcX Python SDK
 ----------------
 
-The funcX Python SDK provides programming abstractions for interacting with the funcX service. Before running this tutorial you should first install the funcX SDK as follows:
+The funcX Python SDK provides programming abstractions for interacting with the funcX service. Before running this tutorial you should first install the funcX SDK in its own `venv <https://docs.python.org/3/tutorial/venv.html>`_ environment:
 
 .. code-block:: bash
 
-    $ pip install funcx
+    $ python3 -m venv path/to/funcx_venv
+    $ source path/to/funcx_venv/bin/activate
+    (funcx_venv) $ python3 -m pip install funcx
 
 The funcX SDK exposes a ``FuncXClient`` object for all interactions with the funcX service.
 In order to use the funcX service you must first authenticate using one of hundreds of supported identity provides (e.g., your institution, ORCID, Google).

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -9,16 +9,20 @@ or a Kubernetes cluster, for example.
 The endpoint requires outbound network connectivity. That is, it must be able to connect to
 funcX at `funcx.org <https://api2.funcx.org/v2>`_.
 
-To install the funcX endpoint agent software ::
+The funcX endpoint is available on pypi.org (and thus available via ``pip``).
+However, *we strongly recommend installing the funcX endpoint into an isolated virtual environment*.
+`Pipx <https://pypa.github.io/pipx/installation/>`_ automatically manages
+package-specific virtual environments for command line applications, so install funcX endpoint via::
 
-     $ python3 -m pip install funcx_endpoint
+     $ python3 -m pipx install funcx_endpoint
 
 .. note::
 
-   Please note that the funcx endpoint is only supported on Linux and MacOS.
+   Please note that the funcX endpoint is only supported on Linux.
 
-After installing funcX endpoint, you be able to deploy new endpoints and interact
-with existing endpoints using the ``funcx-endpoint`` command.
+
+After installing the funcX endpoint, use the ``funcx-endpoint`` command to manage existing endpoints.
+
 
 First time setup
 ----------------
@@ -45,11 +49,11 @@ You can also set up auto-completion for the ``funcx-endpoint`` commands in your 
 Configuring an Endpoint
 ----------------------------
 
-FuncX endpoints act as gateways to diverse computational resources, including clusters, clouds,
+funcX endpoints act as gateways to diverse computational resources, including clusters, clouds,
 supercomputers, and even your laptop. To make the best use of your resources, the endpoint must be
 configured to match the capabilities of the resource on which it is deployed.
 
-FuncX provides a Python class-based configuration model that allows you to specify the shape of the
+funcX provides a Python class-based configuration model that allows you to specify the shape of the
 resources (number of nodes, number of cores per worker, walltime, etc.) as well as allowing you to place
 limits on how funcX may scale the resources in response to changing workload demands.
 
@@ -79,8 +83,8 @@ To start a new endpoint run the following command::
 
 Starting an endpoint will perform a registration process with funcX.
 The registration process provides funcX with information regarding the endpoint.
-The endpoint establishes an outbound connection to RabbitMQ to retrieve tasks, send results, and communicate command information.
-Note that FuncX RabbitMQ outbound access is to default port 5672 and the endpoint also needs HTTPS 443.
+The endpoint also establishes an outbound connection to RabbitMQ to retrieve tasks, send results, and communicate command information.
+Thus, the funcX endpoint requires outbound access to the funcX services over HTTPS (port 443) and AMQPS (port 5671).
 
 Once started, the endpoint uses a daemon process to run in the background.
 

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -1,4 +1,4 @@
-FuncX Executor
+funcX Executor
 ==============
 
 The ``FuncXExecutor`` provides a future based interface that simplifies both function submission

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,7 @@ A funcX endpoint can be created by installing the funcX endpoint software
 and configuring it for the target resources. The following steps show
 how to download and configure an endpoint for local (multi-process) execution. ::
 
-  $ python3 -m pip install funcx_endpoint
+  $ python3 -m pipx install funcx_endpoint
 
   $ funcx-endpoint configure
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,30 +26,38 @@ To check if your endpoint/client have network access and can connect to the func
 
   >>> curl https://api2.funcx.org/v2/version
 
-This should return a version string, for example: ``"0.3.0"``
+This should return a version string, for example: ``"1.0.2"``
 
 .. note:: The funcx client is supported on MacOS, Linux, and Windows. The funcx-endpoint
    is only supported on Linux.
 
-Installation using Pip
-^^^^^^^^^^^^^^^^^^^^^^
+Installing funcX in a Virtual Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While ``pip`` and ``pip3`` can be used to install funcX we suggest the following approach
-for reliable installation when many Python environments are available.
+for reliable installation to avoid python package dependency conflicts.
 
-1. Install the funcX client::
+1. Install the funcX client in its own `venv <https://docs.python.org/3/tutorial/venv.html>`_ environment::
 
-     $ python3 -m pip install funcx
+    $ python3 -m venv path/to/funcx_venv
+    $ source path/to/funcx_venv/bin/activate
+    (funcx_venv) $ python3 -m pip install funcx
 
-To update a previously installed funcX to a newer version, use: ``python3 -m pip install -U funcx``
+  To update a previously installed funcX to a newer version in the virtual environment, use::
 
-2. Optionally install the funcX endpoint::
+    (funcx_venv) $ python3 -m pip install -U funcx``
 
-     $ python3 -m pip install funcx_endpoint
+2. (Optional) The funcX endpoint can be installed using `Pipx <https://pypa.github.io/pipx/installation/>`_ or using pip in the venv::
 
-3. Install Jupyter for Tutorial notebooks::
+     $ python3 -m pipx install funcx_endpoint
 
-     $ python3 -m pip install jupyter
+          or
+
+     (funcx_venv) $ python3 -m pip install funcx_endpoint
+
+3. (Optional) Install Jupyter for Tutorial notebooks in the venv::
+
+     (funcx_venv) $ python3 -m pip install jupyter
 
 
 .. note:: For more detailed info on setting up Jupyter with Python3.5 go `here <https://jupyter.readthedocs.io/en/latest/install.html>`_

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -1,4 +1,4 @@
-FuncX SDK User Guide
+funcX SDK User Guide
 ====================
 
 The **funcX SDK** provides a programmatic interface to funcX from Python.


### PR DESCRIPTION
Update readthedocs to mention pipx and venv instead of using pip to install funcx and funcx_endpoint