### PR TITLE
Refactor `Batch.add()` interface

### DIFF
--- a/changelog.d/20220930_151519_kevin_batch_add_interface_cleanup.rst
+++ b/changelog.d/20220930_151519_kevin_batch_add_interface_cleanup.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+- Refactor ``funcx.sdk.batch.Batch.add`` method interface.  ``function_id`` and
+  ``endpoint_id`` are now positional arguments, using language semantics to
+  enforce their use, rather than (internal) manual ``assert`` checks.  The
+  arguments (``args``) and keyword arguments (``kwargs``) arguments are no
+  longer varargs, and thus no longer prevent function use of ``function_id``
+  and ``endpoint_id``.

--- a/funcx_sdk/funcx/sdk/batch.py
+++ b/funcx_sdk/funcx/sdk/batch.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing as t
+
 from funcx.serialize import FuncXSerializer
 
 
@@ -12,32 +16,39 @@ class Batch:
         task_group_id : str
             UUID indicating the task group that this batch belongs to
         """
-        self.tasks = []
+        self.tasks: list[dict[str, str]] = []
         self.fx_serializer = FuncXSerializer()
         self.task_group_id = task_group_id
         self.create_websocket_queue = create_websocket_queue
 
-    def add(self, *args, endpoint_id=None, function_id=None, **kwargs):
-        """Add an function invocation to a batch submission
+    def add(
+        self,
+        function_id: str,
+        endpoint_id: str,
+        args: tuple[t.Any, ...] | None = None,
+        kwargs: dict[str, t.Any] | None = None,
+    ) -> None:
+        """Add a function invocation to a batch submission
 
         Parameters
         ----------
-        *args : Any
-            Args as specified by the function signature
-        endpoint_id : uuid str
-            Endpoint UUID string. Required
         function_id : uuid str
             Function UUID string. Required
-        asynchronous : bool
-            Whether or not to run the function asynchronously
+        endpoint_id : uuid str
+            Endpoint UUID string. Required
+        args : tuple[Any, ...]
+            Arguments as specified by the function signature
+        kwargs : dict[str, Any]
+            Keyword arguments as specified by the function signature
 
         Returns
         -------
         None
         """
-        assert endpoint_id is not None, "endpoint_id key-word argument must be set"
-        assert function_id is not None, "function_id key-word argument must be set"
-
+        if args is None:
+            args = ()
+        if kwargs is None:
+            kwargs = {}
         ser_args = self.fx_serializer.serialize(args)
         ser_kwargs = self.fx_serializer.serialize(kwargs)
         payload = self.fx_serializer.pack_buffers([ser_args, ser_kwargs])

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -365,7 +365,7 @@ class FuncXClient:
         assert function_id is not None, "function_id key-word argument must be set"
 
         batch = self.create_batch(create_websocket_queue=self.asynchronous)
-        batch.add(*args, endpoint_id=endpoint_id, function_id=function_id, **kwargs)
+        batch.add(function_id, endpoint_id, args, kwargs)
         r = self.batch_run(batch)
 
         return r[0]

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -322,12 +322,7 @@ class FuncXExecutor(concurrent.futures.Executor):
             create_websocket_queue=True,
         )
         for task in tasks:
-            batch.add(
-                *task.args,
-                **task.kwargs,
-                endpoint_id=task.endpoint_id,
-                function_id=task.function_id,
-            )
+            batch.add(task.function_id, task.endpoint_id, task.args, task.kwargs)
             log.debug(f"Adding task {task} to funcX batch")
         try:
             batch_tasks = self.funcx_client.batch_run(batch)

--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -161,8 +161,8 @@ def test_batch_created_websocket_queue(create_ws_queue):
     else:
         batch = fxc.create_batch(create_websocket_queue=create_ws_queue)
 
-    batch.add(1, endpoint_id=eid, function_id=fid)
-    batch.add(2, endpoint_id=eid, function_id=fid)
+    batch.add(fid, eid, (1,))
+    batch.add(fid, eid, (2,))
 
     fxc.batch_run(batch)
 


### PR DESCRIPTION
`function_id` and `endpoint_id` are now enforced by being positional arguments, rather than manually enforced kwargs.  This further enables typing of them (`str`).  After implementing, also remove vararg delineation of function args and kwargs, completely isolating them from the `Batch.add()` method's signature needs.

My read is that this class is mostly used internally, so this change, while technically breaking, should affect very few users in the wild.

## Type of change

- Breaking change
- Code maintenance/cleanup
