### PR TITLE
Heavy FuncXExecutor refactor

### DIFF
--- a/changelog.d/20221015_134646_kevin_refactor_executor_constructor_signature.rst
+++ b/changelog.d/20221015_134646_kevin_refactor_executor_constructor_signature.rst
@@ -1,0 +1,38 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added ``.get_result_amqp_url()`` to ``FuncXClient`` to acquire user
+  credentials to the AMQP service.  Globus credentials are first verified
+  before user-specific AMQP credentials are (re)created and returned.  The only
+  expected use of this method comes from ``FuncXExecutor``.
+
+Bug Fixes
+^^^^^^^^^
+
+- General and specific attention to the ``FuncXExecutor``, especially around
+  non-happy path interactions
+    - Addressed the often-hanging end-of-script problem
+    - Address web-socket race condition (GH#591)
+
+Deprecated
+^^^^^^^^^^
+
+- ``batch_enabled`` argument to ``FuncXExecutor`` class; batch communication is
+  now enforced transparently.  Simply use ``.submit()`` normally, and the class
+  will batch the tasks automatically.  ``batch_size`` remains available.
+
+- ``asynchronous``, ``results_ws_uri``, and ``loop`` arguments to
+  ``FuncXClient`` class; use ``FuncXExecutor`` instead.
+
+Changed
+^^^^^^^
+
+- ``FuncXExecutor`` no longer creates a web socket connection; instead it
+  communicates directly with the backing AMQP service.  This removes an
+  internal round trip and is marginally more performant.
+
+- ``FuncXExecutor`` now much more faithfully implements the
+  ``_concurrent.futures.Executor`` interface.  In particular, the
+  ``endpoint_id`` and ``container_id`` items are specified on the executor
+  _object_ and not per ``.submit()`` invocation.  See the class documentation
+  for more information.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
+autoclass_content = "both"
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -1,79 +1,352 @@
 funcX Executor
 ==============
 
-The ``FuncXExecutor`` provides a future based interface that simplifies both function submission
-and result tracking. The key functionality in the ``FuncXExecutor`` is the asynchronous event based
-result tracking that propagates new results to the user via the use of ``Futures``.
-This asynchronous behavior is widely used in Python and the ``FuncXExecutor`` extends the popular executor
-interface from the ``concurrent.futures.Executor`` library.
+The |FuncXExecutor|_ class, a subclass of Python's |Executor|_, is the
+preferred approach to collecting results from the funcX web services.  Over
+polling (the historical approach) where the web service must be repeatedly
+queried for the status of tasks and results eventually collected in bulk, the
+|FuncXExecutor|_ class instantiates an AMQPS connection that streams results
+directly -- and immediately -- as they arrive at the server.  This is a far
+more efficient paradigm, simultaneously in terms of bytes over the wire, time
+spent waiting for results, and boilerplate code to check for results.
 
+For most "simple" interactions with funcX, this class will likely be the
+quickest and easiest avenue to submit tasks and acquire results.  An
+example interaction:
 
-Initializing the executor
--------------------------
+.. code-block:: python
+    :caption: funcxexecutor_basic_example.py
+
+    from funcx import FuncXExecutor
+
+    def double(x):
+        return x * 2
+
+    tutorial_endpoint_id = '4b116d3c-1703-4f8f-9f6f-39921e5864df'
+    with FuncXExecutor(endpoint_id=tutorial_endpoint_id) as fxe:
+        fut = fxe.submit(double, 7)
+
+        print(fut.result())
+
+This example is only a quick-reference, showing the basic mechanics of how to
+use the |FuncXExecutor|_ class and submitting a single task.  However, there
+are a number of details to observe.  The first is that a |FuncXExecutor|_
+instance is associated with a specific endpoint.  We use the "well-known"
+tutorial endpoint in this example, but that can point to any endpoint to which
+you have access.
+
+.. note::
+    A friendly FYI: the tutorial endpoint is public -- available for any
+    (authenticated) user.  You are welcome to use it, but please limit the size
+    and number of functions you send to this endpoint as it is a shared
+    resource that is (intentionally) not very powerful.  It's primary intended
+    purpose is for an introduction to the funcX toolset.
+
+Second, the waiting -- or "blocking" -- for a result is automatic.  The
+|.submit()|_ call returns a |Future|_ immediately; the actual HTTP call to the
+funcX web-services will not have occurred yet, and neither will the task even
+been executed (remotely), much less a result received.  The |.result()|_ call
+blocks ("waits") until all of that has completed, and the result has been
+received from the upstream services.
+
+Third, |FuncXExecutor|_ objects can be used as context managers (the ``with``
+statement).  Underneath the hood, the |FuncXExecutor|_ class uses threads to
+implement the asynchronous interface -- a thread to coalesce and submit tasks,
+and a thread to watch for incoming results.  The |FuncXExecutor|_ logic cannot
+determine when it will no longer receive tasks (i.e., no more |.submit()|_
+calls) and so cannot prematurely shutdown.  Thus, it must be told, either
+explicitly with a call to |.shutdown()|_, or implicitly when used as a context
+manager.
+
+Multiple Function Invocations
+-----------------------------
+
+Building on the asynchronous behavior of |.submit()|_, we can easily create
+multiple tasks and wait for them all.  The simplest case is a for-loop over
+submission and results.  As an example, consider the `Collatz conjecture`_,
+alternatively known as the :math:`3n + 1` problem.  The conjecture is that
+given a starting integer and two generation rules, the outcome sequence will
+always end with 1.  The rules are:
+
+- If :math:`N_i` is even, then :math:`N_{i+1} = N_i / 2`
+- If :math:`N_i` is odd, then :math:`N_{i+1} = 3 N_i + 1`
+
+To verify all of the sequences through 100, one brute-force approach is:
+
+.. code-block:: python
+    :caption: funcxexecutor_collatz.py
+
+    from funcx import FuncXExecutor
+
+    def generate_collatz_sequence(N: int, sequence_limit = 10_000):
+        seq = [N]
+        while N != 1 and len(seq) < sequence_limit:
+            if N % 2:
+                N = 3 * N + 1
+            else:
+                N //= 2  # okay because guaranteed integer result
+            seq.append(N)
+        return seq
+
+    ep_id = "<your_endpoint_id>"
+
+    generate_from = 1
+    generate_through = 100
+    futs, results, disproof_candidates = [], [], []
+    with FuncXExecutor(endpoint_id=ep_id) as fxe:
+        for n in range(generate_from, generate_through + 1):
+            futs.append(fxe.submit(generate_collatz_sequence, n))
+        print("Tasks all submitted; waiting for results")
+
+    # The futures were appended to the `futs` list in order, so one could wait
+    # for each result in turn to get a submission-ordered set of results:
+    for f in futs:
+        r = f.result()
+        results.append(r)
+        if r[-1] != 1:
+            # of course, given the conjecture, we don't expect this branch
+            disproof_candidates.append(r[0])
+
+    print(f"All sequences generated (from {generate_from} to {generate_through})")
+    for res in results:
+        print(res)
+
+    if disproof_candidates:
+        print("Possible conjecture disproving integers:", disproof_candidates)
+
+Checking the Status of a Result
+-------------------------------
+
+Sometimes, it is desirable not to wait for a result, but just to check on the
+status.  Futures make this simple with the |.done()|_ method:
 
 .. code-block:: python
 
-   from funcx import FuncXExecutor
+    ...
+    future = fxe.submit(generate_collatz_sequence, 1234567890)
 
-   fx = FuncXExecutor(endpoint_id=endpoint_id)
-
-
-Running functions
------------------
-
-.. code-block:: python
-
-   def double(x):
-       return x * 2
-
-   future = fx.submit(double, x)  # will execute on endpoint_id
-
-   # Use the .done() method to check the status of the function without blocking;
-   # this will return a Bool indicating whether the result is ready
-   print("Status : ", future.done())
-
-   # Alternatively, the .result() method will block, not returning until the
-   # function's result is available.  If the function instead fails, it will
-   # raise an exception.
-   print("Result : ", future.result())
-
-   # When done with the executor, shut down the background threads via .shutdown():
-   fx.shutdown()
+    # Use the .done() method to check the status of the function without
+    # blocking; this will return a Bool indicating whether the result is ready
+    print("Status: ", future.done())
 
 
-More complex cases
-------------------
+Handling Exceptions
+-------------------
+
+Assuming that a future will always have a result will lead to broken scripts.
+Exceptions happen, whether from a condition the task function does not handle
+or from an external execution error.  To robustly handle task exceptions, wrap
+|.result()|_ calls in a ``try`` block.  The following code has updated the
+sequence generator to throw an exception after ``sequence_limit`` steps rather
+than summarily return, and the specific number chosen starts a sequence that
+takes more than 100 steps to complete.
 
 .. code-block:: python
+    :caption: funcxexecutor_handle_result_exceptions.py
 
-   import concurrent.futures
+    from funcx import FuncXExecutor
 
-   # The FuncXExecutor also works as a `with` statement, avoiding the need
-   # to remember to shut it down:
-   with FuncXExecutor(endpoint_id=endpoint_id) as fx:
+    def generate_collatz_sequence(N: int, sequence_limit=100):
+        seq = [N]
+        while N != 1 and len(seq) < sequence_limit:
+            if N % 2:
+                N = 3 * N + 1
+            else:
+                N //= 2  # okay because guaranteed integer result
+            seq.append(N)
+        if N != 1:
+            raise ValueError(f"Sequence not terminated in {sequence_limit} steps")
+        return seq
 
-       def double(x):
-           return f"{x} -> {x * 2}"
+    with FuncXExecutor(endpoint_id=ep_id) as fxe:
+        future = fxe.submit(generate_collatz_sequence, 1234567890)
 
-       # Launching several function invocations is the same as launching
-       # one: .submit()
+    try:
+        print(future.result())
+    except Exception as exc:
+        print(f"Oh no!  The task raised an exception: {exc})
 
-       futs = []
-       for i in range(10):
-           futs.append(fx.submit(double, i))
 
-       # The futures were appended to the `futs` list in order, so one could
-       # wait for each result in turn to get an ordered set:
-       print("Results:", [f.result() for f in futs])
+Receiving Results Out of Order
+------------------------------
 
-       # But often acting on the results *as they arrive* is more desirable
-       # as results are NOT guaranteed to arrive in the order they were
-       # submitted:
-       def slow_double(x):
-           import random, time
-           time.sleep(x * random.random())
-           return f"{x} -> {x * 2}"
+So far, we've shown simple iteration through the list of Futures, but that's
+not generally the most performant approach for overall workflow completion.
+In the previous examples, a result may return early at the end of the list, but
+the script will not recognize it until it "gets there," waiting in the meantime
+for the other tasks to complete.  (Task functions are not guaranteed to be
+scheduled in order, nor are they guaranteed to take the same amount of time to
+finish.)  There are a number of ways to work with results as they arrive; this
+example uses `concurrent.futures.as_completed`_:
 
-       futs = [fx.submit(slow_double, i) for i in range(10, 20)]
-       for f in concurrent.futures.as_completed(futs):
-           print("Received:", f.result())
+.. code-block:: python
+    :caption: funcxexecutor_results_as_arrived.py
+
+    import concurrent.futures
+
+    def double(x):
+        return f"{x} -> {x * 2}"
+
+    def slow_double(x):
+        import random, time
+        time.sleep(x * random.random())
+        return f"{x} -> {x * 2}"
+
+    with FuncXExecutor(endpoint_id=endpoint_id) as fxe:
+        futs = [fxe.submit(double, i) for i in range(10)]
+
+        # The futures were appended to the `futs` list in order, so one could
+        # wait for each result in turn to get an ordered set:
+        print("Results:", [f.result() for f in futs])
+
+        # But often acting on the results *as they arrive* is more desirable
+        # as results are NOT guaranteed to arrive in the order they were
+        # submitted.
+        #
+        # NOTA BENE: handling results "as they arrive" must happen before the
+        # executor is shutdown.  Since this executor was used in a `with`
+        # statement, then to stream results, we must *stay* within the `with`
+        # statement.  Otherwise, at the unindent, `.shutdown()` will be
+        # implicitly invoked (with default arguments) and the script will not
+        # continue until *all* of the futures complete.
+        futs = [fx.submit(slow_double, i) for i in range(10, 20)]
+        for f in concurrent.futures.as_completed(futs):
+            print("Received:", f.result())
+
+Reloading Tasks
+---------------
+Waiting for incoming results with the |FuncXExecutor|_ requires an active
+connection -- which is often at odds with closing a laptop clamshell (e.g.,
+heading home for the weekend).  For longer running jobs like this, the
+|FuncXExecutor|_ offers the |.reload_tasks()|_ method.  This method will reach
+out to the funcX web-services to collect all of the tasks associated with the
+|.task_group_id|_, create a list of associated futures, finish
+(call |.set_result()|_) any previously finished tasks, and watch the unfinished
+futures.  Consider the following (contrived) example:
+
+.. code-block:: python
+    :caption: funcxexecutor_reload_tasks.py
+
+    # execute initially as:
+    # $ python funcxexecutor_reload_tasks.py
+    #  ... this Task Group ID: <TG_UUID_STR>
+    #  ...
+    # Then run with the Task Group ID as an argument:
+    # $ python funcxexecutor_reload_tasks.py <TG_UUID_STR>
+
+    import os, signal, sys, time, typing as t
+    from funcx import FuncXExecutor
+    from funcx.sdk.executor import FuncXFuture
+
+    task_group_id = sys.argv[1] if len(sys.argv) > 1 else None
+
+    def task_kernel(num):
+        return f"your funcx logic result, from task: {num}"
+
+    ep_id = "<YOUR_ENDPOINT_UUID>"
+    with FuncXExecutor(endpoint_id=ep_id) as fxe:
+        futures: t.Iterable[FuncXFuture]
+        if task_group_id:
+            print(f"Reloading tasks from Task Group ID: {task_group_id}")
+            fxe.task_group_id = task_group_id
+            futures = fxe.reload_tasks()
+
+        else:
+            # Save the task_group_id somewhere.  Perhaps in a file, or less
+            # robustly "as mere text" on your console:
+            print(
+                "New session; creating funcX tasks; if this script dies, rehydrate"
+                f" futures with this Task Group ID: {fxe.task_group_id}"
+            )
+            num_tasks = 5
+            futures = [fxe.submit(task_kernel, i + 1) for i in range(num_tasks)]
+
+            # Ensure all tasks have been sent upstream ...
+            while fxe.task_count_submitted < num_tasks:
+                time.sleep(1)
+                print(f"Tasks submitted upstream: {fxe.task_count_submitted}")
+
+            # ... before script death for [silly reason; did you lose power!?]
+            bname = sys.argv[0]
+            if sys.argv[0] != sys.orig_argv[0]:
+                bname = f"{sys.orig_argv[0]} {bname}"
+
+            print("Simulating unexpected process death!  Now reload the session")
+            print("by rerunning this script with the task_group_id:\n")
+            print(f"  {bname} {fxe.task_group_id}\n")
+            os.kill(os.getpid(), signal.SIGKILL)
+            exit(1)  # In case KILL takes split-second to process
+
+    # Get results:
+    results, exceptions = [], []
+    for f in futures:
+        try:
+            results.append(f.result(timeout=10))
+        except Exception as exc:
+            exceptions.append(exc)
+    print("Results:\n ", "\n  ".join(results))
+
+For a slightly more advanced usage, one could manually submit a batch of tasks
+with the |FuncXClient|_, and wait for the results at a future time.  Submitting
+the results might look like:
+
+.. code-block:: python
+    :caption: funcxclient_submit_batch.py
+
+    from funcx import FuncXClient
+
+    def expensive_task(task_arg):
+        import time
+        time.sleep(3600 * 24)  # 24 hours
+        return "All done!"
+
+    ep_id = "<endpoint_id>"
+    fxc = FuncXClient()
+
+    print(f"Task Group ID for later reloading: {fxc.session_task_group_id}")
+    fn_id = fxc.register_function(expensive_task)
+    batch = fxc.create_batch()
+    for task_i in range(10):
+        batch.add(fn_id, ep_id, args=(task_i,))
+    self.funcx_client.batch_run(batch)
+
+And ~24 hours later, could reload the tasks with the executor to continue
+processing:
+
+.. code-block:: python
+    :caption: funcxexecutor_reload_batch.py
+
+    from funcx import FuncXExecutor
+
+    ep_id = "<endpoint_id>"
+    tg_id = "Saved task group id from 'yesterday'"
+    with FuncxExecutor(endpoint_id=ep_id, task_group_id=tg_id) as fxe:
+        futures = fxe.reload_tasks())
+        for f in concurrent.futures.as_completed(futs):
+            print("Received:", f.result())
+
+
+.. |FuncXClient| replace:: ``FuncXClient``
+.. _FuncXClient: reference/client.html
+.. |FuncXExecutor| replace:: ``FuncXExecutor``
+.. _FuncXExecutor: reference/executor.html
+.. |Future| replace:: ``Future``
+.. _Future: https://docs.python.org/3/library/concurrent.futures.html#future-objects
+.. |Executor| replace:: ``Executor``
+.. _Executor: https://docs.python.org/3/library/concurrent.futures.html#executor-objects
+.. |.shutdown()| replace:: ``.shutdown()``
+.. _.shutdown(): reference/executor.html#funcx.FuncXExecutor.shutdown
+.. |.submit()| replace:: ``.submit()``
+.. _.submit(): reference/executor.html#funcx.FuncXExecutor.submit
+.. |.result()| replace:: ``.result()``
+.. _.result(): https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result
+.. |.done()| replace:: ``.done()``
+.. _.done(): https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.done
+.. |.set_result()| replace:: ``.set_result()``
+.. _.set_result(): https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.set_result
+.. |.reload_tasks()| replace:: ``.reload_tasks()``
+.. _.reload_tasks(): reference/executor.html#funcx.FuncXExecutor.reload_tasks
+.. |.task_group_id| replace:: ``.task_group_id``
+.. _.task_group_id: reference/executor.html#funcx.FuncXExecutor.task_group_id
+.. _Collatz conjecture: https://en.wikipedia.org/wiki/Collatz_conjecture
+.. _concurrent.futures.as_completed: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.as_completed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,25 +47,20 @@ Using funcX
 ^^^^^^^^^^^^^^^^^^
 
 funcX offers a Python SDK for registering, sharing, and executing functions.
-The following code shows how funcX can be used to register and run a "hello world"
-function on a remote endpoint.
-
+The following code block examples how funcX can be used to execute a "hello
+world" function on a remote endpoint.
 
 .. code-block:: python
 
-    from funcx.sdk.client import FuncXClient
-
-    fxc = FuncXClient()
+    from funcx import FuncXExecutor
 
     def hello_world():
-      return "Hello World!"
+        return "Hello World!"
 
-    func_uuid = fxc.register_function(hello_world)
-
-    tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df'
-    result = fxc.run(endpoint_id=tutorial_endpoint, function_id=func_uuid)
-
-    print(fxc.get_result(result))
+    tutorial_endpoint_id = '4b116d3c-1703-4f8f-9f6f-39921e5864df'
+    with FuncXExecutor(endpoint_id=tutorial_endpoint_id) as fxe:
+        future = fxe.submit(hello_world)
+        print(future.result())
 
 
 Deploying an endpoint

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,11 +22,11 @@ To check if you have the right Python version, run the following commands::
 
 This should return the Python version, for example: ``Python 3.8.10``.
 
-To check if your endpoint/client have network access and can connect to the funcX service, run ::
+To check if your endpoint/client has network access and can connect to the funcX service, run::
 
   >>> curl https://api2.funcx.org/v2/version
 
-This should return a version string, for example: ``"1.0.2"``
+This should return a version string, for example: ``"1.0.5"``
 
 .. note:: The funcx client is supported on MacOS, Linux, and Windows. The funcx-endpoint
    is only supported on Linux.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -45,7 +45,7 @@ for reliable installation to avoid python package dependency conflicts.
 
   To update a previously installed funcX to a newer version in the virtual environment, use::
 
-    (funcx_venv) $ python3 -m pip install -U funcx``
+    (funcx_venv) $ python3 -m pip install -U funcx
 
 2. (Optional) The funcX endpoint can be installed using `Pipx <https://pypa.github.io/pipx/installation/>`_ or using pip in the venv::
 
@@ -63,64 +63,64 @@ for reliable installation to avoid python package dependency conflicts.
 .. note:: For more detailed info on setting up Jupyter with Python3.5 go `here <https://jupyter.readthedocs.io/en/latest/install.html>`_
 
 
+First Run
+---------
+
+The funcX SDK makes use of the funcX web services, most of which restrict use
+to Globus authenticated users.  Consequently, if you have not previously used
+funcX from your workstation, or have otherwise not authenticated with Globus,
+then the FuncXClient will present a one-time URL.  The one-time URL workflow
+will culminate in a token code to be pasted back into the terminal.  The
+easiest approach is typically from the command line:
+
+.. code-block:: python
+
+    >>> from funcx import FuncXClient
+    >>> FuncXClient()
+    Please authenticate with Globus here:
+    ------------------------------------
+    https://auth.globus.org/v2/oauth2/authorize?[...very...long...url]&prompt=login
+    ------------------------------------
+
+    Enter the resulting Authorization Code here:
+
+funcX will then cache the credentials for future invocations, so this workflow
+will only be initiated once.
+
 Running a function
 ------------------
 
-After installing the funcX SDK, you can register functions and execute
-them on available endpoints.  To use the SDK, you should first instantiate
-a funcX client and authenticate with the funcX service. funcX uses
-Globus to manage authentication and authorization, enabling you to
-authenticate using one of several hundred supported identity providers
-(e.g., institution, ORCID, Google). If you have not authenticated previously,
-funcX will present a one-time URL that you can use to authenticate
-with your chosen identity. You will then need to copy and paste the resulting
-access code into the prompt.
+After installing the funcX SDK, you can define a function and submit it for
+execution to available endpoints.  For most use-cases that will use the
+``FuncXExecutor``:
 
 .. code-block:: python
 
-    from funcx.sdk.client import FuncXClient
+    from funcx.sdk.client import FuncXExecutor
 
-    fxc = FuncXClient()
+    # First, define the function ...
+    def add_func(a, b):
+        return a + b
 
+    tutorial_endpoint_id = '4b116d3c-1703-4f8f-9f6f-39921e5864df' # Public tutorial endpoint
+    # ... then create the executor, ...
+    with FuncXExecutor(endpoint_id=tutorial_endpoint_id) as fxe:
+        # ... then submit for execution, ...
+        future = fxe.submit(add_func, 5, 10)
 
-Like most FaaS platforms, you must first register a function before you can
-execute or share it. To do so, you can simply write a Python function
-and register it using the SDK.
+        # ... and finally, wait for the result
+        print(future.result())
 
-.. code-block:: python
+.. note::
+    Like most FaaS platforms, the function must be registered with the upstream
+    web services before it can be executed on a remote endopint.  While one can
+    manually register a function (see the FuncXClient or FuncXExecutor API
+    documentation), the above workflow will automatically handle registration.
 
-  def add_func(a, b):
-    return a + b
-
-  func_uuid = fxc.register_function(add_func)
-
-
-When executing the function, you must specify the function ID and the
-endpoint ID on which you wish to execute the function. You can pass
-arbitrary input arguments like standard Python functions. The following
-code shows how to run the add function on the tutorial endpoint.
-
-Note: the tutorial endpoint is open for anyone to use; please limit
-the number of functions you send to this endpoint.
-
-.. code-block:: python
-
-    tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df' # Public tutorial endpoint
-    res = fxc.run(5, 10, function_id=func_uuid, endpoint_id=tutorial_endpoint)
-
-Finally, you can retrieve the result (or check on the status of the execution)
-via the SDK. The SDK will raise an exception if the result is not yet ready
-or it will return the Python result from your function.
-
-Note: the tutorial endpoint is hosted on a small Kubernetes cluster and
-occasionally it becomes overwhelmed. If you are unable to retrieve the
-result, please try again later (funcX will cache results until you return)
-or deploy an endpoint on local resources.
-
-.. code-block:: python
-
- print(fxc.get_result(res))
-
+A word on the above example: while the tutorial endpoint is open for anyone to
+use, it is hosted on a small Kubernetes cluster -- somewhat intentionally
+underpowered.  As it is a shared (and tiny) resource, please be conscientious
+with the size and number of functions you send to this endpoint.
 
 Deploying an endpoint
 ----------------------

--- a/funcx_sdk/funcx/sdk/asynchronous/funcx_future.py
+++ b/funcx_sdk/funcx/sdk/asynchronous/funcx_future.py
@@ -3,7 +3,11 @@ from concurrent.futures import Future
 
 
 class FuncXFuture(Future):
-    """Extends concurrent.futures.Future to include an optional task UUID."""
+    """
+    Extend `concurrent.futures.Future`_ to include an optional task UUID.
+
+    .. _concurrent.futures.Future: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future
+    """  # noqa
 
     task_id: t.Optional[str]
     """The UUID for the task behind this Future. In batch mode, this will

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -146,11 +146,11 @@ class FuncXClient:
             (warn_about_url_mismatch, "warn_about_url_mismatch"),
         ]:
             if arg is not None:
-                warnings.warn(
+                msg = (
                     f"The '{name}' argument is deprecated. "
-                    "It will be removed in a future release.",
-                    DeprecationWarning,
+                    "It will be removed in a future release."
                 )
+                warnings.warn(msg)
 
         if results_ws_uri is None:
             results_ws_uri = get_web_socket_url(environment)

--- a/funcx_sdk/funcx/sdk/utils/__init__.py
+++ b/funcx_sdk/funcx/sdk/utils/__init__.py
@@ -1,0 +1,7 @@
+import typing as t
+from itertools import islice
+
+
+def chunk_by(iterable: t.Iterable, size) -> t.Iterable[tuple]:
+    to_chunk_iter = iter(iterable)
+    return iter(lambda: tuple(islice(to_chunk_iter, size)), ())

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -187,6 +187,9 @@ class FuncxWebClient(globus_sdk.BaseClient):
             data.update(additional_fields)
         return self.post("/endpoints", data=data)
 
+    def get_result_amqp_url(self) -> globus_sdk.GlobusHTTPResponse:
+        return self.get("get_amqp_result_connection_url")
+
     def get_endpoint_status(
         self, endpoint_id: ID_PARAM_T
     ) -> globus_sdk.GlobusHTTPResponse:

--- a/funcx_sdk/funcx/version.py
+++ b/funcx_sdk/funcx/version.py
@@ -4,7 +4,7 @@ from funcx.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 
 def compare_versions(

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -18,6 +18,7 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
+    "pika>=1.2",
     "funcx-common==0.0.18",
     "tblib==1.7.0",
 ]

--- a/funcx_sdk/tests/conftest.py
+++ b/funcx_sdk/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 from funcx import FuncXClient
-from funcx.sdk.executor import FuncXExecutor
 
 config = {
     "funcx_service_address": "https://api2.funcx.org/v2",
@@ -65,27 +64,3 @@ def fxc_args(pytestconfig):
 def fxc(fxc_args):
     fxc = FuncXClient(**fxc_args)
     return fxc
-
-
-@pytest.fixture
-def async_fxc(fxc_args):
-    fxc = FuncXClient(**fxc_args, asynchronous=True)
-    return fxc
-
-
-@pytest.fixture
-def fx(fxc):
-    fx = FuncXExecutor(fxc)
-    return fx
-
-
-@pytest.fixture
-def batch_fx(fxc):
-    fx = FuncXExecutor(fxc, batch_enabled=True)
-    return fx
-
-
-@pytest.fixture
-def endpoint(pytestconfig):
-    endpoint = pytestconfig.getoption("--endpoint")[0]
-    return endpoint

--- a/funcx_sdk/tests/integration/test_executor_int.py
+++ b/funcx_sdk/tests/integration/test_executor_int.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+
+import pytest
+from tests.utils import try_assert
+
+from funcx import FuncXClient
+from funcx.sdk.executor import FuncXExecutor, _ResultWatcher
+
+
+@pytest.mark.skipif(
+    not os.getenv("FUNCX_INTEGRATION_TEST_WEB_URL"), reason="no integration web url"
+)
+def test_resultwatcher_graceful_shutdown():
+    service_url = os.environ["FUNCX_INTEGRATION_TEST_WEB_URL"]
+    fxc = FuncXClient(funcx_service_address=service_url)
+    fxe = FuncXExecutor(funcx_client=fxc)
+    rw = _ResultWatcher(fxe)
+    rw._start_consuming = mock.Mock()
+    rw.start()
+
+    try_assert(lambda: rw._start_consuming.called)
+    rw.shutdown()
+
+    try_assert(lambda: rw._channel is None)
+    try_assert(lambda: not rw._connection or rw._connection.is_closed)
+    try_assert(lambda: not rw.is_alive())
+    fxe.shutdown()

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -158,24 +158,12 @@ def test_executor_context_manager(fxexecutor):
     assert _is_stopped(fxe._result_watcher)
 
 
-def test_property_task_group_id_passthru(fxexecutor):
+def test_property_task_group_id_is_isolated(fxexecutor):
     fxc, fxe = fxexecutor
-    fxc.session_task_group_id = uuid.uuid4()
-    assert fxe.task_group_id is fxc.session_task_group_id
-
-    fxc.session_task_group_id = uuid.uuid4()
-    assert fxe.task_group_id is fxc.session_task_group_id
-
-
-def test_property_task_group_id_override(fxexecutor):
-    fxc, fxe = fxexecutor
-    assert fxe.task_group_id is fxc.session_task_group_id
+    assert fxe.task_group_id != fxc.session_task_group_id
 
     fxe.task_group_id = uuid.uuid4()
-    assert fxe.task_group_id is not fxc.session_task_group_id
-
-    fxe.task_group_id = None
-    assert fxe.task_group_id is fxc.session_task_group_id
+    assert fxe.task_group_id != fxc.session_task_group_id
 
 
 def test_multiple_register_function_fails(fxexecutor, mocker):

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -1,32 +1,101 @@
+from __future__ import annotations
+
 import random
+import threading
+import typing as t
 import uuid
+from unittest import mock
 
+import pika
 import pytest
+from funcx_common import messagepack
+from funcx_common.messagepack.message_types import Result, ResultErrorDetails
+from tests.utils import try_assert, try_for_timeout
 
-from funcx import FuncXExecutor
-from funcx.sdk.executor import TaskSubmissionInfo
+from funcx import FuncXClient, FuncXExecutor
+from funcx.errors import FuncxTaskExecutionFailed
+from funcx.sdk.asynchronous.funcx_future import FuncXFuture
+from funcx.sdk.executor import TaskSubmissionInfo, _ResultWatcher
+from funcx.serialize.facade import FuncXSerializer
 
 
-def test_executor_shutdown(mocker):
-    """ensure that executor shutdown does not crash"""
-    mocker.patch("funcx.sdk.executor.atexit")
-    mocker.patch("funcx.sdk.executor.ExecutorPollerThread.event_loop_thread")
-    fcli = mocker.MagicMock()
-    fexe = FuncXExecutor(funcx_client=fcli)
-    # increment starts the websocket handler, decrement is a no-op
-    fexe.poller_thread.atomic_controller.increment()
-    fexe.poller_thread.atomic_controller.decrement()
+def _is_stopped(thread: threading.Thread | None) -> bool:
+    def _wrapped():
+        return not (thread and thread.is_alive())
 
-    # there is a handler for the websocket service
-    ws_handler = fexe.poller_thread.ws_handler
-    assert ws_handler is not None
-    # but its underlying connection is not valid because the
-    # executor's main thread is mocked
-    # the connection should not be gettable: ValueError on property access
-    with pytest.raises(ValueError):
-        ws_handler.ws
+    return _wrapped
 
-    fexe.shutdown()
+
+def noop():
+    return 1
+
+
+class MockedFuncXExecutor(FuncXExecutor):
+    def __init__(self, *args, **kwargs):
+        kwargs.update({"funcx_client": mock.Mock(spec=FuncXClient)})
+        super().__init__(*args, **kwargs)
+        self._time_to_stop_mock = threading.Event()
+        self._task_submitter_exception: t.Type[Exception] | None = None
+
+    def _task_submitter_impl(self):
+        try:
+            super()._task_submitter_impl()
+        except Exception as exc:
+            self._task_submitter_exception = exc
+
+
+class MockedResultWatcher(_ResultWatcher):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._time_to_stop_mock = threading.Event()
+
+    def start(self) -> None:
+        super().start()
+        try_assert(lambda: self._connection is not None)
+
+    def run(self):
+        self._connection = mock.MagicMock()
+        self._channel = mock.MagicMock()
+        self._time_to_stop_mock.wait()
+
+    def shutdown(self, *args, **kwargs):
+        super().shutdown(*args, **kwargs)
+        self._time_to_stop_mock.set()
+
+    def join(self, timeout: float | None = None) -> None:
+        if self._time_to_stop:  # important to identify bugs
+            self._time_to_stop_mock.set()
+        super().join(timeout=timeout)
+
+
+@pytest.fixture
+def fxexecutor(mocker):
+    fxc = mock.MagicMock()
+    fxc.session_task_group_id = str(uuid.uuid4())
+    fxe = FuncXExecutor(funcx_client=fxc)
+    watcher = mocker.patch("funcx.sdk.executor._ResultWatcher", autospec=True)
+
+    def create_mock_watcher(*args, **kwargs):
+        return MockedResultWatcher(fxe)
+
+    watcher.side_effect = create_mock_watcher
+
+    yield fxc, fxe
+
+    fxe.shutdown(wait=False, cancel_futures=True)
+    try_for_timeout(_is_stopped(fxe._task_submitter))
+    try_for_timeout(_is_stopped(fxe._result_watcher))
+
+    if not _is_stopped(fxe._task_submitter)():
+        trepr = repr(fxe._task_submitter)
+        raise RuntimeError(
+            "FuncXExecutor still running: _task_submitter thread alive: %s" % trepr
+        )
+    if not _is_stopped(fxe._result_watcher)():
+        trepr = repr(fxe._result_watcher)
+        raise RuntimeError(
+            "FuncXExecutor still running: _result_watcher thread alive: %r" % trepr
+        )
 
 
 def test_task_submission_info_stringification():
@@ -45,108 +114,717 @@ def test_task_submission_info_stringification():
     assert "endpoint_id='bar_ep'" in as_str
 
 
-def test_property_results_ws_uri_passthru(mocker, randomstring):
-    fcli = mocker.MagicMock(results_ws_uri=randomstring())
-    fexe = FuncXExecutor(funcx_client=fcli)
-    assert fexe.results_ws_uri is fcli.results_ws_uri
+@pytest.mark.parametrize("argname", ("batch_interval", "batch_enabled"))
+def test_deprecated_args_warned(argname, mocker):
+    mock_warn = mocker.patch("funcx.sdk.executor.warnings")
+    fxc = mock.Mock(spec=FuncXClient)
+    FuncXExecutor(funcx_client=fxc).shutdown()
+    mock_warn.warn.assert_not_called()
 
-    fcli.results_ws_uri = randomstring()
-    assert fexe.results_ws_uri is fcli.results_ws_uri
+    FuncXExecutor(funcx_client=fxc, **{argname: 1}).shutdown()
+    mock_warn.warn.assert_called()
 
 
-def test_property_task_group_id_passthru(mocker, randomstring):
-    fcli = mocker.MagicMock(session_task_group_id=randomstring())
-    fexe = FuncXExecutor(funcx_client=fcli)
-    assert fexe.task_group_id is fcli.session_task_group_id
+def test_invalid_args_raise(randomstring):
+    invalid_arg = f"abc_{randomstring()}"
+    with pytest.raises(TypeError) as wrapped_err:
+        FuncXExecutor(**{invalid_arg: 1}).shutdown()
 
-    fcli.session_task_group_id = randomstring()
-    assert fexe.task_group_id is fcli.session_task_group_id
+    err = wrapped_err.value
+    assert "invalid argument" in str(err)
+    assert f"'{invalid_arg}'" in str(err)
+
+
+def test_creates_default_client_if_none_provided(mocker):
+    mock_fxc_klass = mocker.patch("funcx.sdk.executor.FuncXClient")
+    FuncXExecutor().shutdown()
+
+    mock_fxc_klass.assert_called()
+
+
+def test_executor_shutdown(fxexecutor):
+    fxc, fxe = fxexecutor
+    fxe.shutdown()
+
+    try_assert(_is_stopped(fxe._task_submitter))
+    try_assert(_is_stopped(fxe._result_watcher))
+
+
+def test_executor_context_manager(fxexecutor):
+    fxc, fxe = fxexecutor
+    with fxe:
+        pass
+    assert _is_stopped(fxe._task_submitter)
+    assert _is_stopped(fxe._result_watcher)
+
+
+def test_property_task_group_id_passthru(fxexecutor):
+    fxc, fxe = fxexecutor
+    fxc.session_task_group_id = uuid.uuid4()
+    assert fxe.task_group_id is fxc.session_task_group_id
+
+    fxc.session_task_group_id = uuid.uuid4()
+    assert fxe.task_group_id is fxc.session_task_group_id
+
+
+def test_property_task_group_id_override(fxexecutor):
+    fxc, fxe = fxexecutor
+    assert fxe.task_group_id is fxc.session_task_group_id
+
+    fxe.task_group_id = uuid.uuid4()
+    assert fxe.task_group_id is not fxc.session_task_group_id
+
+    fxe.task_group_id = None
+    assert fxe.task_group_id is fxc.session_task_group_id
+
+
+def test_multiple_register_function_fails(fxexecutor, mocker):
+    fxc, fxe = fxexecutor
+
+    fxc.register_function.return_value = "abc"
+
+    fxe.register_function(noop)
+
+    with pytest.raises(ValueError):
+        fxe.register_function(noop)
+
+    try_assert(lambda: fxe._stopped)
+
+    with pytest.raises(RuntimeError):
+        fxe.register_function(noop)
+
+
+def test_shortcut_register_function(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    fn_id = str(uuid.uuid4())
+    fxe.register_function(noop, function_id=fn_id)
+
+    with pytest.raises(ValueError):
+        fxe.register_function(noop, function_id=fn_id)
+
+    fxc.register_function.assert_not_called()
+
+
+def test_failed_registration_shuts_down_executor(fxexecutor, randomstring):
+    fxc, fxe = fxexecutor
+
+    exc_text = randomstring()
+    fxc.register_function.side_effect = Exception(exc_text)
+
+    with pytest.raises(Exception) as wrapped_exc:
+        fxe.register_function(noop)
+
+    exc = wrapped_exc.value
+    assert exc_text in str(exc)
+    try_assert(lambda: fxe._stopped)
+
+
+def test_submit_raises_if_thread_stopped(fxexecutor):
+    fxc, fxe = fxexecutor
+    fxe.shutdown()
+
+    try_assert(_is_stopped(fxe._task_submitter), "Test prerequisite")
+
+    with pytest.raises(RuntimeError) as wrapped_exc:
+        fxe.submit(noop)
+
+    err = wrapped_exc.value
+    assert " is shutdown;" in str(err)
+
+
+def test_submit_auto_registers_function(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    fxc.register_function.return_value = "abc"
+    fxe.endpoint_id = "some_ep_id"
+    fxe.submit(noop)
+
+    fxc.register_function.assert_called()
+
+
+def test_submit_value_error_if_no_endpoint(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    with pytest.raises(ValueError) as pytest_exc:
+        fxe.submit(noop)
+
+    err = pytest_exc.value
+    assert "No endpoint_id set" in str(err)
+    assert "    fxe = FuncXExecutor(endpoint_id=" in str(err), "Expected hint"
+    try_assert(_is_stopped(fxe._task_submitter), "Expected graceful shutdown on error")
+
+
+def test_map_raises(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    with pytest.raises(NotImplementedError):
+        fxe.map(noop)
 
 
 @pytest.mark.parametrize("num_tasks", [0, 1, 2, 10])
-def test_reload_tasks_happy_path(mocker, num_tasks, randomstring):
-    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+def test_reload_tasks_none_completed(fxexecutor, mocker, num_tasks):
+    fxc, fxe = fxexecutor
+
     mock_log = mocker.patch("funcx.sdk.executor.log")
 
-    tg_uuid = str(uuid.uuid4())
     mock_data = {
-        "taskgroup_id": tg_uuid,
-        "tasks": [
-            {"id": randomstring(), "created_at": 1234567890} for _ in range(num_tasks)
-        ],
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [{"id": uuid.uuid4()} for _ in range(num_tasks)],
     }
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
 
-    fcli = mocker.MagicMock()
-    fcli.session_task_group_id = tg_uuid
-    fcli.web_client.get_taskgroup_tasks.return_value = mock_data
-    fexe = FuncXExecutor(funcx_client=fcli)
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
 
-    client_futures = list(fexe.reload_tasks())
+    client_futures = list(fxe.reload_tasks())
     if num_tasks == 0:
         log_args, log_kwargs = mock_log.warning.call_args
         assert "Received no tasks" in log_args[0]
-        assert tg_uuid in log_args[0]
+        assert fxe.task_group_id in log_args[0]
     else:
         assert not mock_log.warning.called
 
     assert len(client_futures) == num_tasks
-    assert fexe.poller_thread.atomic_controller.increment.called
-    assert 1 == fexe.poller_thread.atomic_controller.increment.call_count
     assert not any(fut.done() for fut in client_futures)
 
-    for fut in fexe._function_future_map.values():
-        fut.set_result(1)
 
-    assert all(fut.done() for fut in client_futures)
+@pytest.mark.parametrize("num_tasks", [1, 2, 10])
+def test_reload_tasks_some_completed(fxexecutor, mocker, num_tasks):
+    fxc, fxe = fxexecutor
+
+    mock_log = mocker.patch("funcx.sdk.executor.log")
+
+    mock_data = {
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [{"id": uuid.uuid4()} for _ in range(num_tasks)],
+    }
+    num_completed = random.randint(1, num_tasks)
+    num_i = 0
+
+    serialize = FuncXSerializer().serialize
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    for t_id in mock_batch_result:
+        if num_i >= num_completed:
+            break
+        num_i += 1
+        mock_batch_result[t_id]["completion_t"] = "0"
+        mock_batch_result[t_id]["status"] = "success"
+        mock_batch_result[t_id]["result"] = serialize("abc")
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
+
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
+
+    client_futures = list(fxe.reload_tasks())
+    if num_tasks == 0:
+        log_args, log_kwargs = mock_log.warning.call_args
+        assert "Received no tasks" in log_args[0]
+        assert fxe.task_group_id in log_args[0]
+    else:
+        assert not mock_log.warning.called
+
+    assert len(client_futures) == num_tasks
+    assert sum(1 for fut in client_futures if fut.done()) == num_completed
 
 
-def test_reload_tasks_cancels_existing_futures(mocker, randomstring):
-    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+def test_reload_tasks_all_completed(fxexecutor):
+    fxc, fxe = fxexecutor
 
-    tg_uuid = str(uuid.uuid4())
+    serialize = FuncXSerializer().serialize
+    num_tasks = 5
+
+    mock_data = {
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [
+            {
+                "id": uuid.uuid4(),
+                "completion_t": 25,
+                "status": "success",
+                "result": serialize("abc"),
+            }
+            for _ in range(num_tasks)
+        ],
+    }
+
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
+
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
+
+    client_futures = list(fxe.reload_tasks())
+
+    assert len(client_futures) == num_tasks
+    assert sum(1 for fut in client_futures if fut.done()) == num_tasks
+    assert fxe._result_watcher is None, "Should NOT start watcher: all tasks done!"
+
+
+def test_reload_starts_new_watcher(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    num_tasks = 3
+
+    mock_data = {
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [{"id": uuid.uuid4()} for _ in range(num_tasks)],
+    }
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
+
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
+
+    client_futures = list(fxe.reload_tasks())
+
+    assert len(client_futures) == num_tasks
+    try_assert(lambda: fxe._result_watcher.is_alive())
+    watcher_1 = fxe._result_watcher
+
+    client_futures = list(fxe.reload_tasks())
+    try_assert(lambda: fxe._result_watcher.is_alive())
+    watcher_2 = fxe._result_watcher
+
+    assert watcher_1 is not watcher_2
+
+
+def test_reload_tasks_cancels_existing_futures(fxexecutor, randomstring):
+    fxc, fxe = fxexecutor
 
     def mock_data():
         return {
-            "taskgroup_id": tg_uuid,
-            "tasks": [
-                {"id": randomstring(), "created_at": 1234567890}
-                for i in range(random.randint(0, 20))
-            ],
+            "taskgroup_id": fxe.task_group_id,
+            "tasks": [{"id": uuid.uuid4()} for i in range(random.randint(0, 20))],
         }
 
-    fcli = mocker.MagicMock()
-    fcli.session_task_group_id = tg_uuid
-    fcli.web_client.get_taskgroup_tasks.return_value = mock_data()
-    fexe = FuncXExecutor(funcx_client=fcli)
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data()
 
-    client_futures_1 = list(fexe.reload_tasks())
-    fcli.get_taskgroup_tasks.return_value = mock_data()
-    client_futures_2 = list(fexe.reload_tasks())
+    client_futures_1 = list(fxe.reload_tasks())
+    fxc.get_taskgroup_tasks.return_value = mock_data()
+    client_futures_2 = list(fxe.reload_tasks())
 
     assert all(fut.done() for fut in client_futures_1)
     assert all(fut.cancelled() for fut in client_futures_1)
     assert not any(fut.done() for fut in client_futures_2)
 
 
-def test_client_taskgroup_tasks_fails_gracefully(mocker):
-    mocker.patch("funcx.sdk.executor.ExecutorPollerThread")
+def test_reload_client_taskgroup_tasks_fails_gracefully(fxexecutor):
+    fxc, fxe = fxexecutor
 
-    tg_uuid = str(uuid.uuid4())
     mock_datum = (
-        (KeyError, {"mispeleed": tg_uuid}),
+        (KeyError, {"mispeleed": fxe.task_group_id}),
         (ValueError, {"taskgroup_id": "abcd"}),
-        (None, {"taskgroup_id": tg_uuid}),
+        (None, {"taskgroup_id": fxe.task_group_id}),
     )
 
-    fcli = mocker.MagicMock()
-    fcli.session_task_group_id = tg_uuid
-    fexe = FuncXExecutor(funcx_client=fcli)
-
     for expected_exc_class, md in mock_datum:
-        fcli.web_client.get_taskgroup_tasks.return_value = md
+        fxc.web_client.get_taskgroup_tasks.return_value = md
         if expected_exc_class:
             with pytest.raises(expected_exc_class):
-                fexe.reload_tasks()
+                fxe.reload_tasks()
         else:
-            fexe.reload_tasks()
-            fexe.shutdown()
+            fxe.reload_tasks()
+
+
+def test_reload_sets_failed_tasks(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    mock_data = {
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [
+            {"id": uuid.uuid4(), "completion_t": 1, "exception": "doh!"}
+            for i in range(random.randint(0, 10))
+        ],
+    }
+
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
+
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
+
+    futs = list(fxe.reload_tasks())
+
+    assert all(fut.done() for fut in futs)
+    assert all("doh!" in str(fut.exception()) for fut in futs)
+
+
+def test_reload_handles_deseralization_error_gracefully(fxexecutor):
+    fxc, fxe = fxexecutor
+    fxc.fx_serializer = FuncXSerializer()
+
+    mock_data = {
+        "taskgroup_id": fxe.task_group_id,
+        "tasks": [
+            {"id": uuid.uuid4(), "completion_t": 1, "result": "a", "status": "success"}
+            for i in range(random.randint(0, 10))
+        ],
+    }
+
+    mock_batch_result = {t["id"]: t for t in mock_data["tasks"]}
+    mock_batch_result = mock.MagicMock(data={"results": mock_batch_result})
+
+    fxc.web_client.get_taskgroup_tasks.return_value = mock_data
+    fxc.web_client.get_batch_status.return_value = mock_batch_result
+
+    futs = list(fxe.reload_tasks())
+
+    assert all(fut.done() for fut in futs)
+    assert all("Failed to set " in str(fut.exception()) for fut in futs)
+
+
+@pytest.mark.parametrize("batch_size", tuple(range(1, 11)))
+def test_task_submitter_respects_batch_size(fxexecutor, batch_size):
+    fxc, fxe = fxexecutor
+
+    fxc.create_batch.side_effect = mock.MagicMock
+    fxc.register_function.return_value = "abc"
+    num_batches = 50
+
+    fxe.endpoint_id = "some_ep_id"
+    fxe.batch_size = batch_size
+    for _ in range(num_batches * batch_size):
+        fxe.submit(noop)
+    fxe.shutdown(cancel_futures=True)
+
+    for args, _kwargs in fxc.batch_run.call_args_list:
+        batch, *_ = args
+        assert batch.add.call_count <= batch_size
+
+
+def test_task_submitter_stops_executor_on_exception():
+    fxe = MockedFuncXExecutor()
+    fxe._tasks_to_send.put(("too", "much", "destructuring", "!!"))
+
+    try_assert(lambda: fxe._stopped)
+    try_assert(lambda: isinstance(fxe._task_submitter_exception, ValueError))
+
+
+def test_task_submitter_stops_executor_on_upstream_error_response(randomstring):
+    fxe = MockedFuncXExecutor()
+
+    upstream_error = Exception(f"Upstream error {randomstring}!!")
+    fxe.funcx_client.batch_run.side_effect = upstream_error
+    fxe.task_group_id = "abc"
+    tsi = TaskSubmissionInfo(
+        task_num=12345, function_id="abc", endpoint_id="abc", args=(), kwargs={}
+    )
+    fxe._tasks_to_send.put((FuncXFuture(), tsi))
+
+    try_assert(lambda: fxe._stopped)
+    try_assert(lambda: str(upstream_error) == str(fxe._task_submitter_exception))
+
+
+def test_task_submitter_handles_stale_result_watcher_gracefully(fxexecutor, mocker):
+    fxc, fxe = fxexecutor
+    fxe.endpoint_id = "blah"
+
+    task_id = str(uuid.uuid4())
+    fxc.batch_run.return_value = [task_id]
+    fxe.submit(noop)
+    try_assert(lambda: bool(fxe._result_watcher), "Test prerequisite")
+    try_assert(lambda: bool(fxe._result_watcher._open_futures), "Test prerequisite")
+    watcher_1 = fxe._result_watcher
+    watcher_1._closed = True  # simulate shutting down, but not yet stopped
+    watcher_1._time_to_stop = True
+
+    fxe.submit(noop)
+    try_assert(lambda: fxe._result_watcher is not watcher_1, "Test prerequisite")
+
+
+def test_task_submitter_sets_future_task_ids(fxexecutor):
+    fxc, fxe = fxexecutor
+
+    num_tasks = random.randint(2, 20)
+    futs = [FuncXFuture() for _ in range(num_tasks)]
+    batch_ids = [uuid.uuid4() for _ in range(num_tasks)]
+
+    fxc.batch_run.return_value = batch_ids
+    fxe._submit_tasks(futs, [])
+
+    assert all(f.task_id == task_id for f, task_id in zip(futs, batch_ids))
+
+
+def test_resultwatcher_stops_if_unable_to_connect(mocker):
+    mock_time = mocker.patch("funcx.sdk.executor.time")
+    fxe = mock.Mock(spec=FuncXExecutor)
+    rw = _ResultWatcher(fxe)
+    rw._connect = mock.Mock(return_value=mock.Mock(spec=pika.SelectConnection))
+
+    rw.run()
+    assert rw._connection_tries >= rw.connect_attempt_limit
+    assert mock_time.sleep.call_count == rw._connection_tries - 1, "Should wait between"
+
+
+def test_resultwatcher_ignores_invalid_tasks(mocker):
+    fxe = mock.Mock(spec=FuncXExecutor)
+    rw = _ResultWatcher(fxe)
+    rw._connect = mock.Mock(return_value=mock.Mock(spec=pika.SelectConnection))
+
+    futs = [FuncXFuture() for i in range(random.randint(1, 10))]
+    futs[0].task_id = uuid.uuid4()
+    num_added = rw.watch_for_task_results(futs)
+    assert 1 == num_added
+
+
+def test_resultwatcher_cancels_futures_on_unexpected_stop(mocker):
+    mocker.patch("funcx.sdk.executor.time")
+    fxe = mock.Mock(spec=FuncXExecutor)
+    rw = _ResultWatcher(fxe)
+    rw._connect = mock.Mock(return_value=mock.Mock(spec=pika.SelectConnection))
+
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    rw.watch_for_task_results([fut])
+    rw.run()
+
+    assert "thread quit" in str(fut.exception())
+
+
+def test_resultwatcher_gracefully_handles_unexpected_exception(mocker):
+    mocker.patch("funcx.sdk.executor.time")
+    mock_log = mocker.patch("funcx.sdk.executor.log")
+    fxe = mock.Mock(spec=FuncXExecutor)
+    rw = _ResultWatcher(fxe)
+    rw._connect = mock.Mock(return_value=mock.Mock(spec=pika.SelectConnection))
+    rw._event_watcher = mock.Mock(side_effect=Exception)
+
+    rw.run()
+
+    assert mock_log.exception.call_count > 2
+    args, _kwargs = mock_log.exception.call_args
+    assert "shutting down" in args[0]
+
+
+def test_resultwatcher_blocks_until_tasks_done():
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+
+    res = Result(task_id=fut.task_id, data="abc123")
+    mrw._received_results[fut.task_id] = (None, res)
+
+    mrw.shutdown(wait=False)
+    try_assert(lambda: not mrw._time_to_stop, timeout_ms=1000)
+    mrw._match_results_to_futures()
+    try_assert(lambda: mrw._time_to_stop)
+
+
+def test_resultwatcher_does_not_check_if_no_results():
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw._match_results_to_futures = mock.Mock()
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+
+    mrw._match_results_to_futures.assert_not_called()
+    mrw.shutdown(cancel_futures=True)
+
+
+def test_resultwatcher_checks_match_if_results():
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    res = Result(task_id=fut.task_id, data="abc123")
+
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw._received_results[fut.task_id] = (None, res)
+
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+
+    assert fut.done() and not fut.cancelled()
+    assert fut.result() is not None
+    mrw.shutdown(cancel_futures=True)
+
+
+def test_resultwatcher_opportunistically_stops():
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    res = Result(task_id=fut.task_id, data="abc123")
+
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw._received_results[fut.task_id] = (None, res)
+
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+    mrw._event_watcher()
+
+    try_assert(lambda: not mrw.is_alive())
+
+
+def test_resultwatcher_repr():
+    mrw = MockedResultWatcher(mock.Mock())
+    assert "<✗;" in repr(mrw)
+    mrw._consumer_tag = "asdf"
+    assert "<✓;" in repr(mrw)
+    mrw._consumer_tag = None
+    assert "<✗;" in repr(mrw)
+
+    for i in range(10):
+        assert f"fut={i};" in repr(mrw)
+        mrw._open_futures[f"a{i}"] = 1
+    mrw._open_futures.update({f"b{i}": 1 for i in range(1000)})
+    assert "fut=1,010; " in repr(mrw), "includes separator"
+
+    for i in range(10):
+        assert f"res={i};" in repr(mrw)
+        mrw._received_results[f"a{i}"] = 1
+    mrw._received_results.update({f"b{i}": 1 for i in range(1000)})
+    assert "res=1,010; " in repr(mrw), "includes separator"
+
+    assert "; qp=-" in repr(mrw), "blank queue prefix shown with dash (-)"
+    mrw._queue_prefix = "abc"
+    assert f"; qp={mrw._queue_prefix}" in repr(mrw)
+
+
+def test_resultwatcher_match_sets_exception(randomstring):
+    payload = randomstring()
+    fxs = FuncXSerializer()
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    err_details = ResultErrorDetails(code="1234", user_message="some_user_message")
+    res = Result(task_id=fut.task_id, error_details=err_details, data=payload)
+
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.funcx_executor.funcx_client.fx_serializer.deserialize = fxs.deserialize
+    mrw._received_results[fut.task_id] = (mock.Mock(timestamp=5), res)
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+    mrw._event_watcher()
+
+    assert payload in str(fut.exception())
+    assert isinstance(fut.exception(), FuncxTaskExecutionFailed)
+
+
+def test_resultwatcher_match_sets_result(randomstring):
+    payload = randomstring()
+    fxs = FuncXSerializer()
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    res = Result(task_id=fut.task_id, data=fxs.serialize(payload))
+
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.funcx_executor.funcx_client.fx_serializer.deserialize = fxs.deserialize
+    mrw._received_results[fut.task_id] = (None, res)
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+    mrw._event_watcher()
+
+    assert fut.result() == payload
+
+
+def test_resultwatcher_match_handles_deserialization_error():
+    invalid_payload = "invalidly serialized"
+    fxs = FuncXSerializer()
+    fut = FuncXFuture(task_id=uuid.uuid4())
+    res = Result(task_id=fut.task_id, data=invalid_payload)
+
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.funcx_executor.funcx_client.fx_serializer.deserialize = fxs.deserialize
+    mrw._received_results[fut.task_id] = (None, res)
+    mrw.watch_for_task_results([fut])
+    mrw.start()
+    mrw._event_watcher()
+    mrw._event_watcher()
+
+    exc = fut.exception()
+    assert "Malformed or unexpected data structure" in str(exc)
+    assert invalid_payload in str(exc)
+
+
+@pytest.mark.parametrize("unpacked", ("not_a_Result", Exception))
+def test_resultwatcher_onmessage_verifies_result_type(mocker, unpacked):
+    mock_unpack = mocker.patch("funcx.sdk.executor.messagepack.unpack")
+
+    mock_unpack.side_effect = unpacked
+    mock_channel = mock.Mock()
+    mock_deliver = mock.Mock()
+    mock_props = mock.Mock()
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw._on_message(mock_channel, mock_deliver, mock_props, b"some_bytes")
+    mock_channel.basic_nack.assert_called()
+    assert not mrw._received_results
+
+
+def test_resultwatcher_onmessage_sets_check_results_flag():
+    res = Result(task_id=uuid.uuid4(), data="abc")
+
+    mock_channel = mock.Mock()
+    mock_deliver = mock.Mock()
+    mock_props = mock.Mock()
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw._on_message(mock_channel, mock_deliver, mock_props, messagepack.pack(res))
+    mock_channel.basic_nack.assert_not_called()
+    assert mrw._received_results
+    assert mrw._time_to_check_results.is_set()
+
+
+@pytest.mark.parametrize("exc", (MemoryError("some description"), "some description"))
+def test_resultwatcher_stops_loop_on_open_failure(exc):
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    mrw._connection.ioloop.stop.assert_not_called()
+    assert not mrw._cancellation_reason
+    mrw._on_open_failed(mock.Mock(), exc)
+    mrw._connection.ioloop.stop.assert_called()
+    assert "some description" in str(mrw._cancellation_reason)
+    mrw.shutdown()
+
+
+def test_resultwatcher_connection_closed_stops_loop():
+    exc = MemoryError("some description")
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    mrw._connection.ioloop.stop.assert_not_called()
+    mrw._on_connection_closed(mock.Mock(), exc)
+    mrw._connection.ioloop.stop.assert_called()
+    mrw.shutdown()
+
+
+def test_resultwatcher_channel_closed_retries_then_shuts_down():
+    exc = Exception("some pika reason")
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    for i in range(1, mrw.channel_close_window_limit):
+        mrw._connection.ioloop.call_later.reset_mock()
+        mrw._on_channel_closed(mock.Mock(), exc)
+        assert len(mrw._channel_closes) == i
+    assert not mrw._closed
+    mrw._on_channel_closed(mock.Mock(), exc)
+    assert mrw._closed
+
+    # and finally, no error if we call "too many" times
+    mrw._on_channel_closed(mock.Mock(), exc)
+
+
+def test_resultwatcher_connection_opened_resets_fail_counter():
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    mrw._connection_tries = 57
+    mrw._on_connection_open(None)
+    assert mrw._connection_tries == 0
+    mrw.shutdown()
+
+
+def test_resultwatcher_channel_opened_starts_consuming():
+    mock_channel = mock.Mock()
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    assert mrw._consumer_tag is None
+    mrw._on_channel_open(mock_channel)
+    assert mock_channel is mrw._channel
+    assert mrw._consumer_tag is not None
+    mrw.shutdown()
+
+
+def test_resultwatcher_amqp_acks_in_bulk():
+    mrw = MockedResultWatcher(mock.Mock())
+    mrw.start()
+    mrw._to_ack.extend(range(200))
+    assert mrw._channel.basic_ack.call_count == 0
+    mrw._event_watcher()
+    assert not mrw._to_ack
+    assert mrw._channel.basic_ack.call_count == 1
+    mrw.shutdown()

--- a/funcx_sdk/tests/unit/test_web_client.py
+++ b/funcx_sdk/tests/unit/test_web_client.py
@@ -87,3 +87,15 @@ def test_user_app_name_property(client, user_app_name):
 def test_app_name_not_settable(client):
     with pytest.raises(NotImplementedError):
         client.app_name = "qux"
+
+
+def test_get_amqp_url(client, randomstring):
+    expected_response = randomstring()
+    responses.add(
+        responses.GET,
+        "https://api.funcx/get_amqp_result_connection_url",
+        json={"some_key": expected_response},
+    )
+
+    res = client.get_result_amqp_url()
+    assert res["some_key"] == expected_response

--- a/funcx_sdk/tests/utils.py
+++ b/funcx_sdk/tests/utils.py
@@ -1,0 +1,76 @@
+import itertools
+import sys
+import time
+import types
+import typing as t
+
+
+def create_traceback(start: int = 0) -> types.TracebackType:
+    """
+    Dynamically create a traceback.
+
+    Builds a traceback from the top of the stack (the currently executing frame) on
+    down to the root frame.  Optionally, use start to build from an earlier stack
+    frame.
+    """
+    tb = None
+    for depth in itertools.count(start + 1, 1):
+        try:
+            frame = sys._getframe(depth)
+            tb = types.TracebackType(tb, frame, frame.f_lasti, frame.f_lineno)
+        except ValueError:
+            break
+    return tb
+
+
+def try_assert(
+    test_func: t.Callable[[], bool],
+    fail_msg: str = "",
+    timeout_ms: float = 5000,
+    attempts: int = 0,
+    check_period_ms: int = 20,
+):
+    tb = create_traceback(start=1)
+    timeout_s = abs(timeout_ms) / 1000.0
+    check_period_s = abs(check_period_ms) / 1000.0
+    if attempts > 0:
+        for _attempt_no in range(attempts):
+            if test_func():
+                return
+            time.sleep(check_period_s)
+        else:
+            att_fail = (
+                f"\n  (Still failing after attempt limit [{attempts}], testing every"
+                f" {check_period_ms}ms)"
+            )
+            raise AssertionError(f"{str(fail_msg)}{att_fail}".strip()).with_traceback(
+                tb
+            )
+
+    elif timeout_s > 0:
+        end = time.monotonic() + timeout_s
+        while time.monotonic() < end:
+            if test_func():
+                return
+            time.sleep(check_period_s)
+        att_fail = (
+            f"\n  (Still failing after timeout [{timeout_ms}ms], with attempts "
+            f"every {check_period_ms}ms)"
+        )
+        raise AssertionError(f"{str(fail_msg)}{att_fail}".strip()).with_traceback(tb)
+
+    else:
+        raise AssertionError("Bad test configuration: no attempts or timeout period")
+
+
+def try_for_timeout(
+    test_func: t.Callable, timeout_ms: int = 5000, check_period_ms: int = 20
+) -> bool:
+    timeout_s = abs(timeout_ms) / 1000.0
+    check_period_s = abs(check_period_ms) / 1000.0
+    end = time.monotonic() + timeout_s
+    while time.monotonic() < end:
+        if test_func():
+            return True
+        time.sleep(check_period_s)
+    return False

--- a/funcx_sdk/tox.ini
+++ b/funcx_sdk/tox.ini
@@ -3,6 +3,8 @@ envlist = py{310,39,38,37}
 skip_missing_interpreters = true
 
 [testenv]
+passenv =
+    FUNCX_INTEGRATION_TEST_WEB_URL
 usedevelop = true
 extras = test
 commands =


### PR DESCRIPTION
# Description

There are two main goals of this work:
    
1. More closely align with the super-class' signature and descibed behaviors
    
    Previously, to submit a function to the executor, the interface was:
    
    ```python
    def submit(self, function, *args, endpoint_id=None, container_uuid=None, **kwargs):
        assert endpoint_id is not None
     ```
    
    In other words, endpoint_id is required, and is intermingled with the function's arguments at the submit() call.  With this commit, the endpoint is part of the executor object itself and executing a function matches the super-class' signature:
    
    ```python
    fxe = FuncXExecutor(endpoint_id=ep_id)
    fxe.submit(fn, *fn_args, **fn_kwargs)
    ```
    
    To further match the super-class' intent, this commit also introduces `__enter__()` and `__exit__()`, and follows the `.shutdown()` semantics (e.g., waiting by default, but optionally)
    
2. Directly interface with the funcX services AMQP queue
    
    At the same time, funcX services have moved to using an AMQP service, which makes the need for the WebSocketPoller class largely unnecessary.  This commit replaces that usage in the Executor with a `pika`-using class.  I've made a strong attempt to handle the non-happy path cases gracefully and noisily -- if it fails, I don't want the library to just hang.  I want the user to get feedback, where possible.
    
    I've also updated the class block-comment documentation -- if any of the examples don't work, that's a bug to address.

[sc-13884] [sc-14173] [sc-14174] [sc-17985] [sc-18282]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintenance/cleanup
