### PR TITLE
Pass the HTEX interchange an existing FuncXClient

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -173,7 +173,10 @@ class EndpointInterchange:
         log.info("Starting Executors")
         for executor in self.config.executors:
             if hasattr(executor, "passthrough") and executor.passthrough is True:
-                executor.start(results_passthrough=self.results_passthrough)
+                executor.start(
+                    results_passthrough=self.results_passthrough,
+                    funcx_client=self.funcx_client,
+                )
 
     def register_endpoint(self):
         reg_info = register_endpoint(

--- a/funcx_endpoint/tests/integration/funcx_endpoint/executors/mock_executors.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/executors/mock_executors.py
@@ -6,6 +6,7 @@ import unittest.mock
 import dill
 from funcx_common.messagepack.message_types import Result, Task
 
+from funcx import FuncXClient
 from funcx_endpoint.executors.high_throughput.messages import Message
 
 
@@ -15,8 +16,13 @@ class MockExecutor(unittest.mock.Mock):
         self.results_passthrough: multiprocessing.Queue | None = None
         self.passthrough = True
 
-    def start(self, results_passthrough: multiprocessing.Queue = None):
+    def start(
+        self,
+        results_passthrough: multiprocessing.Queue = None,
+        funcx_client: FuncXClient = None,
+    ):
         self.results_passthrough = results_passthrough
+        self.funcx_client = funcx_client
 
     def submit_raw(self, packed_task: bytes):
         task: Task = Message.unpack(packed_task)

--- a/funcx_endpoint/tests/unit/test_highthroughputinterchange.py
+++ b/funcx_endpoint/tests/unit/test_highthroughputinterchange.py
@@ -13,12 +13,9 @@ mod_dot_path = "funcx_endpoint.executors.high_throughput.interchange"
 
 
 @mock.patch(f"{mod_dot_path}.zmq")
-@mock.patch(f"{mod_dot_path}.FuncXClient")
 @mock.patch(f"{mod_dot_path}.Interchange.load_config")
 class TestHighThroughputInterchange:
-    def test_migrate_internal_task_status(
-        self, _mzmq, _mfxc, _mfn_conf, tmp_path, mocker
-    ):
+    def test_migrate_internal_task_status(self, _mzmq, _mfn_conf, tmp_path, mocker):
         mock_evt = mock.Mock()
         mock_evt.is_set.side_effect = [False, True]  # run once, please
         task_id = str(uuid.uuid4())
@@ -34,7 +31,7 @@ class TestHighThroughputInterchange:
         assert 0 <= time.monotonic() - ts < 20, "Expecting a timestamp"
         assert state == TaskState.WAITING_FOR_NODES
 
-    def test_start_task_status(self, _mzmq, _mfxc, _mfn_conf, tmp_path, mocker):
+    def test_start_task_status(self, _mzmq, _mfn_conf, tmp_path, mocker):
         mock_evt = mock.Mock()
         mock_evt.is_set.side_effect = [False, False, True]  # run once, please
         task_id = str(uuid.uuid4())


### PR DESCRIPTION
# Description

The HTEX's internal interchange currently creates an endpoint for the sole purpose of querying for container information, but this was hanging on my machine. After unsuccessful investigation into why it was hanging, the decision was made to simply pass the client to the interchange whole. This also solves the issue where the interchange's client always pointed to prod.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
