### PR TITLE
Address recent batch.add inteface change

### DIFF
--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -28,13 +28,13 @@ def ohai():
 def test_batch(fxc, endpoint):
     """Test batch submission and get_batch_result"""
 
-    double_fn = fxc.register_function(double)
+    double_fn_id = fxc.register_function(double)
 
     inputs = list(range(10))
     batch = fxc.create_batch()
 
     for x in inputs:
-        batch.add(x, endpoint_id=endpoint, function_id=double_fn)
+        batch.add(double_fn_id, endpoint, args=(x,))
 
     batch_res = fxc.batch_run(batch)
 


### PR DESCRIPTION
# Description

Fix the broken smoke test.  We forgot to make this change in the [`Batch.add()`](https://github.com/funcx-faas/funcX/pull/940) interface change.  Had intended to make it as part of PR #942, but that is on hold for about 2-weeks.  No sense in losing confidence in our tests over the delay, so ... fix it now.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
