### PR TITLE
Fix hourly smoketest

### DIFF
--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -1,9 +1,17 @@
 import time
 
+import pytest
+from packaging.version import Version
+
+import funcx
+
 try:
     from funcx.errors import TaskPending
 except ImportError:
     from funcx.utils.errors import TaskPending
+
+
+sdk_version = Version(funcx.version.__version__)
 
 
 def test_run_pre_registered_function(
@@ -25,6 +33,7 @@ def ohai():
     return "ohai"
 
 
+@pytest.mark.skipif(sdk_version.release < (1, 0, 5), reason="batch.add iface updated")
 def test_batch(fxc, endpoint):
     """Test batch submission and get_batch_result"""
 


### PR DESCRIPTION
The `Batch.add()` interface has recently changed, but the production test won't recognize that until we release the SDK to pypi.  Dev misses this because it pulls from the local filesystem.  Hmm.

Implemented solution: skip test until SDK v1.0.5 released, which should be right around the corner.

## Type of change

- Bug fix (non-breaking change that fixes an issue)