### PR TITLE
Remove monkeypatching of sqlite adapter

### DIFF
--- a/changelog.d/20221106_000523_kevin_remove_monkeypatch.rst
+++ b/changelog.d/20221106_000523_kevin_remove_monkeypatch.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Updated minimum Globus SDK requirement to v3.14.0

--- a/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
+++ b/funcx_sdk/funcx/sdk/login_manager/tokenstore.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import pathlib
-import sqlite3
 
 from globus_sdk.tokenstorage import SQLiteAdapter
 
@@ -78,6 +77,8 @@ def get_token_storage_adapter(*, environment: str | None = None) -> SQLiteAdapte
     if not os.path.exists(fname):
         invalidate_old_config()
     # namespace is equal to the current environment
-    adapter = SQLiteAdapter(fname, namespace=_resolve_namespace(environment))
-    adapter._connection = sqlite3.connect(adapter.dbname, check_same_thread=False)
-    return adapter
+    return SQLiteAdapter(
+        fname,
+        namespace=_resolve_namespace(environment),
+        connect_params={"check_same_thread": False},
+    )

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.20.0",
-    "globus-sdk>=3.6.0,<4",
+    "globus-sdk>=3.14.0,<4",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types


### PR DESCRIPTION
In PR #934 (2bae1dba02), we chose to monkeypatch an internal Globus SDK object. As of Globus SDK v3.13, that monkeypatch is no longer necessary.  Increase minimum Globus SDK version, and remove monkeypatch.

[sc-19020]

## Type of change

- Code maintenance/cleanup
