### PR TITLE
Enforce endpoint id not wrapped

### DIFF
--- a/changelog.d/20221107_105710_kevin_no_wrap_list_endpoint_id.rst
+++ b/changelog.d/20221107_105710_kevin_no_wrap_list_endpoint_id.rst
@@ -1,0 +1,10 @@
+Bug Fixes
+^^^^^^^^^
+
+- Prevent Endpoint ID from wrapping in ``funcx-endpoint list`` output.
+
+Changed
+^^^^^^^
+
+- Reorder ``funcx-endpoint list`` output: ``Endpoint ID`` column is now first
+  and ``Endpoint Name`` is now last.

--- a/funcx_endpoint/tests/unit/test_endpoint_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpoint_unit.py
@@ -1,0 +1,66 @@
+import functools
+import io
+import random
+import uuid
+from collections import namedtuple
+from unittest import mock
+
+import pytest
+
+from funcx_endpoint.endpoint.endpoint import Endpoint
+
+
+@pytest.fixture
+def mock_ep():
+    buf = io.StringIO()
+    ep = Endpoint()
+    ep.get_endpoints = mock.Mock()
+    ep.get_endpoints.return_value = {}
+    ep.print_endpoint_table = functools.partial(ep.print_endpoint_table, ofile=buf)
+    yield ep, buf
+
+
+def test_list_endpoints_none_configured(mock_ep):
+    ep, buf = mock_ep
+    ep.print_endpoint_table()
+    assert "No endpoints configured" in buf.getvalue()
+    assert "Hint:" in buf.getvalue()
+    assert "funcx-endpoint configure" in buf.getvalue()
+
+
+def test_list_endpoints_no_id_yet(mock_ep, randomstring):
+    ep, buf = mock_ep
+    expected_col_length = random.randint(2, 30)
+    ep.get_endpoints.return_value = {
+        "default": {"status": randomstring(length=expected_col_length), "id": None}
+    }
+    ep.print_endpoint_table()
+    assert ep.get_endpoints.return_value["default"]["status"] in buf.getvalue()
+    assert "| Endpoint ID |" in buf.getvalue(), "Expecting column shrinks to size"
+
+
+@pytest.mark.parametrize("term_size", ((30, 5), (50, 5), (67, 5), (72, 5), (120, 5)))
+def test_list_endpoints_long_names_wrapped(mock_ep, mocker, term_size, randomstring):
+    ep, buf = mock_ep
+    tsize = namedtuple("terminal_size", ["columns", "lines"])(*term_size)
+    mock_shutil = mocker.patch("funcx_endpoint.endpoint.endpoint.shutil")
+    mock_shutil.get_terminal_size.return_value = tsize
+
+    def rand_length_str(min_=2, max_=30):
+        return randomstring(length=random.randint(min_, max_))
+
+    expected_data = {
+        rand_length_str(100, 110): {"status": rand_length_str(), "id": uuid.uuid4()},
+        rand_length_str(100, 110): {"status": rand_length_str(), "id": uuid.uuid4()},
+        rand_length_str(100, 110): {"status": rand_length_str(), "id": uuid.uuid4()},
+        rand_length_str(100, 110): {"status": rand_length_str(), "id": None},
+        rand_length_str(100, 110): {"status": rand_length_str(), "id": uuid.uuid4()},
+    }
+    ep.get_endpoints.return_value = expected_data
+
+    ep.print_endpoint_table()
+
+    for ep_name, ep in expected_data.items():
+        assert ep["status"] in buf.getvalue(), "expected no wrapping of status"
+        assert str(ep["id"]) in buf.getvalue(), "expected no wrapping of id"
+        assert ep_name not in buf.getvalue(), "expected only name column is wrapped"


### PR DESCRIPTION
# Description

While here, re-order columns so stable columns are on the left, and the dynamically sized column (name) is on the right.  This is in keeping with other tools, like `ls -l`.

The table width is no longer hard-capped at 80 columns, but enforces a 68-character minimum width and will expand to the terminal width.  The name column, if it exceeds the available space, will wrap.

Example new output:
```
$ funcx-endpoint list
No endpoints configured!

  (Hint: funcx-endpoint configure)
```

```
$ funcx-endpoint list
+-------------+-------------+-----------------------------+
| Endpoint ID |   Status    |        Endpoint Name        |
+=============+=============+=============================+
| None        | Initialized | new_endpoint_with_long_name |
+-------------+-------------+-----------------------------+
```

```
$ funcx-endpoint list
+--------------------------------------+-------------+-----------------------------+
|             Endpoint ID              |   Status    |        Endpoint Name        |
+======================================+=============+=============================+
| None                                 | Initialized | new_endpoint_with_long_name |
+--------------------------------------+-------------+-----------------------------+
| 87bdafae-e625-4ddb-868a-f779b3f15129 | Stopped     | other_endpoint_name         |
+--------------------------------------+-------------+-----------------------------+
| None                                 | Initialized | akdjshflkdjs flkadjsh       |
|                                      |             | asdfjkh asdflkjh asdflkjh   |
|                                      |             | asdljkfh asdfljkh asdfljkh  |
+--------------------------------------+-------------+-----------------------------+
```

[sc-20001]
Fixes: #954

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)