### PR TITLE
Enable smoke tests against a LOCAL setup

### DIFF
--- a/smoke_tests/Makefile
+++ b/smoke_tests/Makefile
@@ -1,5 +1,17 @@
-.PHONY: prod dev
+
+# Friendly reminder before running 'local'* smoke tests:
+# $ export FUNCX_LOCAL_ENDPOINT_ID=<id_of_your_local_endpoint>
+# and optionally:
+# $ export FUNCX_LOCAL_KNOWN_FUNCTION_ID=<id_of_function_in_your_local_setup>
+
+.PHONY: prod dev local
 prod:
 	tox
 dev:
 	tox -e localdeps -- --funcx-config dev
+local_with_dev_sdk:
+	@if [ -z "${FUNCX_LOCAL_ENDPOINT_ID}" ]; then echo "Missing exported FUNCX_LOCAL_ENDPOINT_ID"; exit 1; fi
+	tox -e localdeps -- --funcx-config local
+local_with_published_sdk:
+	@if [ -z "${FUNCX_LOCAL_ENDPOINT_ID}" ]; then echo "Missing exported FUNCX_LOCAL_ENDPOINT_ID"; exit 1; fi
+	tox -- --funcx-config local

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -26,3 +26,15 @@ repo):
 You can also run `localdeps` against dev with
 
     tox -e localdeps -- --funcx-config dev
+
+One can also run tests against a local webservice setup.  Use the make targets
+`local_with_published_sdk` and `local_with_dev_sdk` to run tests with published
+(to PyPi) SDK code, or with the local (possibly not even committed) dev code:
+
+    make local_with_published_sdk
+    make local_with_dev_sdk
+
+As with the above make targets, these are just wrappers around tox; can do the above by invoking tox direcly:
+
+    tox -- --funcx-config local
+    tox -e localdeps -- --funcx-config local

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -27,6 +27,7 @@ from funcx.sdk.web_client import FuncxWebClient
 #
 #  this var starts with the ID env var load
 _LOCAL_ENDPOINT_ID = os.getenv("FUNCX_LOCAL_ENDPOINT_ID")
+_LOCAL_FUNCTION_ID = os.getenv("FUNCX_LOCAL_KNOWN_FUNCTION_ID")
 
 _CONFIGS = {
     "dev": {
@@ -52,10 +53,8 @@ _CONFIGS = {
     },
     "local": {
         # localhost; typical defaults for a helm deploy
-        "client_args": {
-            "funcx_service_address": "http://localhost:5000/v2",
-            "results_ws_uri": "ws://localhost:6000/ws/v2/",
-        },
+        "client_args": {"environment": "local"},
+        "public_hello_fn_uuid": _LOCAL_FUNCTION_ID,
         "endpoint_uuid": _LOCAL_ENDPOINT_ID,
     },
 }

--- a/smoke_tests/tox.ini
+++ b/smoke_tests/tox.ini
@@ -6,6 +6,7 @@ envlist = py
 passenv =
     FUNCX_LOCAL_ENDPOINT_ID
     FUNCX_LOCAL_ENDPOINT_NAME
+    FUNCX_LOCAL_KNOWN_FUNCTION_ID
     FUNCX_SMOKE_CLIENT_ID
     FUNCX_SMOKE_CLIENT_SECRET
 # don't try to install a package
@@ -21,6 +22,7 @@ commands = pytest -v {posargs}
 passenv =
     FUNCX_LOCAL_ENDPOINT_ID
     FUNCX_LOCAL_ENDPOINT_NAME
+    FUNCX_LOCAL_KNOWN_FUNCTION_ID
     FUNCX_SMOKE_CLIENT_ID
     FUNCX_SMOKE_CLIENT_SECRET
 # don't try to install a package


### PR DESCRIPTION
# Description

Add two new `make` targets:

- `local_with_published_sdk` -- test with the published-to-pypi SDK code against the 'local' environment (that is `FuncXClient(environment="local")`)
- `local_with_dev_sdk` -- test the 'local' environment with the local SDK and endpoint changes -- note that this installs the local directory and so these changes might not have even been committed yet.

Makes use of two environment variables so as to ascertain the local setup:

- `FUNCX_LOCAL_ENDPOINT_ID` -- required; the id of a local _running_ endpoint.
- `FUNCX_LOCAL_KNOWN_FUNCTION_ID` -- a "known" function that returns hello world.  (See tests for more information.)  This is optional, but if not set, then those tests will be skipped.

[sc-20002]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup
