### PR TITLE
Adding a doc entry and example config for accelerator pinning.

### DIFF
--- a/docs/configs/worker_pinning.py
+++ b/docs/configs/worker_pinning.py
@@ -10,11 +10,13 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=4,
 
-            # Each worker launched will have env vars set to one of (0..3)
+            # `available_accelerators` may be a natural number or a list of strings.
+            # If an integer, then each worker launched will have an automatically
+            # generated environment variable. In this case, one of 0, 1, 2, or 3.
+            # Alternatively, specific strings may be utilized.
             available_accelerators=4,
+            # available_accelerators=['opencl:gpu:1', 'opencl:gpu:2'] # alternative
 
-            # Alternatively a list of strings may be supplied
-            # available_accelerators=['opencl:gpu:1', 'opencl:gpu:2']
             provider=LocalProvider(
                 init_blocks=1,
                 min_blocks=0,
@@ -22,7 +24,6 @@ config = Config(
             ),
         )
     ],
-    funcx_service_address="https://api2.funcx.org/v2",
 )
 
 # fmt: on

--- a/docs/configs/worker_pinning.py
+++ b/docs/configs/worker_pinning.py
@@ -1,0 +1,28 @@
+# fmt: off
+
+from parsl.providers import LocalProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            max_workers_per_node=4,
+
+            # Each worker launched will have env vars set to one of (0..3)
+            available_accelerators=4,
+
+            # Alternatively a list of strings may be supplied
+            # available_accelerators=['opencl:gpu:1', 'opencl:gpu:2']
+            provider=LocalProvider(
+                init_blocks=1,
+                min_blocks=0,
+                max_blocks=1,
+            ),
+        )
+    ],
+    funcx_service_address="https://api2.funcx.org/v2",
+)
+
+# fmt: on

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -152,7 +152,7 @@ Pinning Workers to devices
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Many modern clusters provide multiple accelerators per compute note, yet many applications are best suited to using a
-single accelerator per task. funcX supports pinning each worker to difference accelerators using ``available_accelerators``
+single accelerator per task. funcX supports pinning each worker to different accelerators using the ``available_accelerators``
 option of the ``HighThroughputExecutor``. Provide either the number of accelerators (funcX will assume they are named
 in integers starting from zero) or a list of the names of the accelerators available on the node. Each funcX worker
 will have the following environment variables set to the worker specific identity assigned:

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -146,3 +146,17 @@ The following snippet shows an example configuration for accessing the Bebop sys
 running on a login node, uses the ``SlurmProvider`` to interface with the scheduler, and uses the ``SrunLauncher`` to launch workers.
 
 .. literalinclude:: configs/bebop.py
+
+
+Pinning Workers to devices
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Many modern clusters provide multiple accelerators per compute note, yet many applications are best suited to using a
+single accelerator per task. funcX supports pinning each worker to difference accelerators using ``available_accelerators``
+option of the ``HighThroughputExecutor``. Provide either the number of accelerators (funcX will assume they are named
+in integers starting from zero) or a list of the names of the accelerators available on the node. Each funcX worker
+will have the following environment variables set to the worker specific identity assigned:
+``CUDA_VISIBLE_DEVICES``, ``ROCR_VISIBLE_DEVICES``, ``SYCL_DEVICE_FILTER``.
+
+
+.. literalinclude:: configs/worker_pinning.py


### PR DESCRIPTION
# Description

Adding a bit of documentation with examples for pinning workers to GPUs and similar devices.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update

[sc-18312]