### PR TITLE
Sc 19617 feature flag endpoints with multi tenant

### DIFF
--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -124,16 +124,28 @@ def version_command():
 
 @app.command(name="configure", help="Configure an endpoint")
 @click.option("--endpoint-config", default=None, help="a template config to use")
+@click.option(
+    "--multi-tenant",
+    is_flag=True,
+    default=False,
+    hidden=True,
+    help="Configure endpoint as multi-tenant capable",
+)
 @name_arg
 @common_options
-def configure_endpoint(*, name: str, endpoint_config: str | None):
+def configure_endpoint(
+    *,
+    name: str,
+    endpoint_config: str | None,
+    multi_tenant: bool,
+):
     """Configure an endpoint
 
     Drops a config.py template into the funcx configs directory.
     The template usually goes to ~/.funcx/<ENDPOINT_NAME>/config.py
     """
     endpoint = get_cli_endpoint()
-    endpoint.configure_endpoint(name, endpoint_config)
+    endpoint.configure_endpoint(name, endpoint_config, multi_tenant)
 
 
 @app.command(name="start", help="Start an endpoint by name")

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -179,7 +179,11 @@ class EndpointInterchange:
 
     def register_endpoint(self):
         reg_info = register_endpoint(
-            self.funcx_client, self.endpoint_id, self.endpoint_dir, self.endpoint_name
+            self.funcx_client,
+            self.endpoint_id,
+            self.endpoint_dir,
+            self.endpoint_name,
+            self.config.multi_tenant is True,
         )
         self.task_q_info, self.result_q_info = reg_info
         log.info(f"Endpoint registered with UUID: {self.endpoint_id}")

--- a/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/register_endpoint.py
@@ -11,27 +11,26 @@ log = logging.getLogger(__name__)
 
 
 def register_endpoint(
-    funcx_client: FuncXClient, endpoint_uuid: str, endpoint_dir: str, endpoint_name: str
+    funcx_client: FuncXClient,
+    endpoint_uuid: str,
+    endpoint_dir: str,
+    endpoint_name: str,
+    multi_tenant: bool = False,
 ) -> t.Tuple[t.Dict, t.Dict]:
     """Register the endpoint and return the registration info. This function needs
     to be isolated so that the function can both be called from the endpoint start
-    process as well as the daemon process that it spawns.
+    process and the daemon process that it spawns.
 
-    Parameters
-    ----------
-    funcx_client : FuncXClient
-        The auth'd client to communicate with the funcX service
+    :param funcx_client: FuncXClient The auth'd client to communicate with
+     the funcX service
+    :param endpoint_uuid: str The uuid to register the endpoint with
+    :param endpoint_dir: str The endpoint directory path to store data in
+    :param endpoint_name: str The name of the endpoint
+    :param multi_tenant: bool Whether the endpoint should be multi-tenant
 
-    endpoint_uuid : str
-        The uuid to register the endpoint with
+    :return: Registration params
+    :rtype: tuple[dict, dict]
 
-    endpoint_dir : str
-        The endpoint directory path to store data in
-
-    endpoint_name : str
-        The name of the endpoint
-
-    Returns: tuple[dict, dict]
         Eg return value:
         ({'pika_conn_params': <PIKA_URLParameters>,
           'exchange_name': 'tasks',
@@ -50,6 +49,7 @@ def register_endpoint(
         endpoint_name,
         endpoint_uuid,
         endpoint_version=funcx_endpoint.__version__,
+        multi_tenant=multi_tenant,
     )
     if reg_info.get("endpoint_id") != endpoint_uuid:
         raise ValueError("Unexpected response from server: mismatched endpoint id.")

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/config.py
@@ -66,6 +66,10 @@ class Config(RepresentationMixin):
     log_dir : str
         Optional path string to the top-level directory where logs should be written to.
         Default: None
+
+    multi_tenant : bool | None
+        Designates the endpoint as a multi-tenant endpoint
+        Default: None
     """
 
     def __init__(
@@ -75,6 +79,7 @@ class Config(RepresentationMixin):
         # Connection info
         environment: str | None = None,
         funcx_service_address=None,
+        multi_tenant: bool | None = None,
         # Tuning info
         heartbeat_period=30,
         heartbeat_threshold=120,
@@ -112,6 +117,8 @@ class Config(RepresentationMixin):
         # Connection info
         self.environment = environment
         self.funcx_service_address = funcx_service_address
+
+        self.multi_tenant = multi_tenant is True
 
         # Tuning info
         self.heartbeat_period = heartbeat_period

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -461,20 +461,23 @@ class FuncXClient:
         return task_uuids
 
     def register_endpoint(
-        self, name, endpoint_id, metadata=None, endpoint_version=None
+        self,
+        name,
+        endpoint_id,
+        metadata=None,
+        endpoint_version=None,
+        multi_tenant=False,
     ):
         """Register an endpoint with the funcX service.
 
         Parameters
         ----------
-        name : str
-            Name of the endpoint
-        endpoint_id : str
-                The uuid of the endpoint
-        metadata : dict
-            endpoint metadata, see default_config example
-        endpoint_version: str
-            Version string to be passed to the webService as a compatibility check
+        :param name str Name of the endpoint
+        :param endpoint_id str The uuid of the endpoint
+        :param metadata dict endpoint metadata, see default_config example
+        :param endpoint_version str Version string to be passed to the
+               webService as a compatibility check
+        :param multi_tenant bool Whether the endpoint supports multiple users
 
         Returns
         -------
@@ -490,6 +493,7 @@ class FuncXClient:
             endpoint_id=endpoint_id,
             metadata=metadata,
             endpoint_version=endpoint_version,
+            multi_tenant=multi_tenant,
         )
         return r.data
 

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -174,6 +174,7 @@ class FuncxWebClient(globus_sdk.BaseClient):
         *,
         metadata: t.Optional[t.Dict[str, t.Any]] = None,
         endpoint_version: t.Optional[str] = None,
+        multi_tenant: t.Optional[bool] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data: t.Dict[str, t.Any] = {
@@ -181,6 +182,12 @@ class FuncxWebClient(globus_sdk.BaseClient):
             "endpoint_uuid": str(endpoint_id),
             "version": endpoint_version,
         }
+
+        # Only send this param if True.  Will have to change to
+        # `if multi_tenant is not None` if we want to always pass it
+        if multi_tenant:
+            data["multi_tenant"] = multi_tenant
+
         if metadata:
             data["meta"] = metadata
         if additional_fields is not None:

--- a/funcx_sdk/tests/unit/test_web_client.py
+++ b/funcx_sdk/tests/unit/test_web_client.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import responses
 
@@ -99,3 +101,14 @@ def test_get_amqp_url(client, randomstring):
 
     res = client.get_result_amqp_url()
     assert res["some_key"] == expected_response
+
+
+@pytest.mark.parametrize("multi_tenant", [None, True, False])
+def test_multi_tenant_post(client, multi_tenant):
+    responses.post(url="https://api.funcx/endpoints")
+    resp = client.register_endpoint("ep_name", "ep_id", multi_tenant=multi_tenant)
+    req_body = json.loads(resp._response.request.body)
+    if multi_tenant:
+        assert req_body["multi_tenant"] == multi_tenant
+    else:
+        assert "multi_tenant" not in req_body


### PR DESCRIPTION
Add multi-tenant flag to local config.py and as an (currently hidden CLI) configure --multi-tenant option when creating the same.  The flag will be sent to web-service when creating/registering an endpoint.

It is expected that if an endpoint is re-registered with a different flag suibsequently, the web service will return a conflict error.

Note that one of the considerations is where to add the flag as a required parameter and where to have a False default.  This is to maximize backwards compatibility (in methods, sdk, tests) when it's appropriate.