### PR TITLE
Turn endpoint status test back on

### DIFF
--- a/smoke_tests/tests/test_s3_indirect.py
+++ b/smoke_tests/tests/test_s3_indirect.py
@@ -1,5 +1,4 @@
 import pytest
-from funcx_common.task_storage.default_storage import DEFAULT_REDIS_STORAGE_THRESHOLD
 
 try:
     from funcx.errors import FuncxTaskExecutionFailed
@@ -20,11 +19,6 @@ def large_arg_consumer(data: str) -> int:
 @pytest.mark.parametrize("size", [200, 2000, 20000, 200000])
 def test_allowed_result_sizes(submit_function_and_get_result, endpoint, size):
     """funcX should allow all listed result sizes which are under 512KB limit"""
-    if size >= DEFAULT_REDIS_STORAGE_THRESHOLD:
-        pytest.skip(
-            "prod currently has a race condition with S3, which has been fixed in dev"
-        )
-
     r = submit_function_and_get_result(
         endpoint, func=large_result_producer, func_args=(size,)
     )
@@ -51,11 +45,6 @@ def test_result_size_too_large(submit_function_and_get_result, endpoint):
 @pytest.mark.parametrize("size", [200, 2000, 20000, 200000])
 def test_allowed_arg_sizes(submit_function_and_get_result, endpoint, size):
     """funcX should allow all listed result sizes which are under 512KB limit"""
-    if size >= DEFAULT_REDIS_STORAGE_THRESHOLD:
-        pytest.skip(
-            "prod currently has a race condition with S3, which has been fixed in dev"
-        )
-
     r = submit_function_and_get_result(
         endpoint, func=large_arg_consumer, func_args=(bytearray(size),)
     )

--- a/smoke_tests/tests/test_version.py
+++ b/smoke_tests/tests/test_version.py
@@ -1,4 +1,3 @@
-import pytest
 import requests
 from packaging.version import Version
 
@@ -34,7 +33,6 @@ def test_simple_function(fxc):
     assert func_uuid is not None, "Invalid function uuid returned"
 
 
-@pytest.mark.skip(reason="Endpoint status reports are broken in prod")
 def test_ep_status(fxc, endpoint):
     """Test whether the tutorial EP is online and reporting status"""
     response = fxc.get_endpoint_status(endpoint)


### PR DESCRIPTION
# Description

Turns on the status check for an endpoint given it has been fixed.

## Type of change

- Code maintenance/cleanup