### PR TITLE
Check if `result` is defined before logging.

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -395,7 +395,8 @@ class EndpointInterchange:
                         continue
 
                     except Exception as exc:
-                        log.debug(f"Invalid message received: {result}")
+                        if "result" in vars():
+                            log.debug(f"Invalid message received: {result}")
                         log.warning(
                             f"Invalid message received: no task_id.  Ignoring. {exc}"
                         )

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -395,8 +395,6 @@ class EndpointInterchange:
                         continue
 
                     except Exception as exc:
-                        if "result" in vars():
-                            log.debug(f"Invalid message received: {result}")
                         log.warning(
                             f"Invalid message received: no task_id.  Ignoring. {exc}"
                         )


### PR DESCRIPTION
# Description

Checks if `result` is defined before referencing it in the exception handling. It looks like `multiprocessing.queue.get()` is failing (in my case on macOS 13.0 with py3.9) from an OSError which is pretty suspect. 

Fixes #964

## Type of change

- Bug fix (non-breaking change that fixes an issue)
