### PR TITLE
No need to auth during *configure* stage

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -137,10 +137,6 @@ class Endpoint:
 
         [1] https://docs.python.org/3/library/fcntl.html
         """
-        # construct client to force login flow
-        # FIXME: `funcx` should provide a cleaner way of doing login
-        FuncXClient(do_version_check=False)
-
         if os.path.exists(self.funcx_dir):
             click.confirm(
                 "Are you sure you want to initialize this directory? "


### PR DESCRIPTION
Auth will happen the first time _any_ endpoint is started.

[sc-20409]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
