### PR TITLE
Refactor some Endpoint management code

### DIFF
--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest.mock import Mock, patch
 
 import pytest
@@ -6,7 +7,6 @@ from click.testing import CliRunner
 import funcx.sdk.client
 import funcx.sdk.login_manager
 from funcx_endpoint.cli import _do_logout_endpoints, _do_stop_endpoint, app
-from funcx_endpoint.endpoint.endpoint import Endpoint
 
 runner = CliRunner()
 
@@ -82,9 +82,9 @@ def test_endpoint_logout(monkeypatch):
     "funcx_endpoint.endpoint.endpoint.Endpoint.get_endpoint_id",
     return_value="abc-uuid",
 )
-@patch("funcx_endpoint.cli.get_cli_endpoint", return_value=Endpoint())
+@patch("funcx_endpoint.cli.get_config_dir", return_value=pathlib.Path("some_ep_dir"))
 @patch("funcx_endpoint.endpoint.endpoint.FuncXClient.lock_endpoint")
-def test_endpoint_lock(mock_get_id, mock_get_cli, mock_lock_endpoint):
+def test_endpoint_lock(mock_get_id, mock_get_conf, mock_lock_endpoint):
     _do_stop_endpoint(name="abc-endpoint", remote=False)
     assert not mock_lock_endpoint.called
     _do_stop_endpoint(name="abc-endpoint", remote=True)

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from importlib.machinery import SourceFileLoader
 
 import pika
@@ -22,8 +23,9 @@ def test_endpoint_id(mocker, funcx_dir):
     mock_client.return_value = None
 
     manager = Endpoint(funcx_dir=str(funcx_dir))
+    config_dir = funcx_dir / "mock_endpoint"
 
-    manager.configure_endpoint("mock_endpoint", None)
+    manager.configure_endpoint(config_dir, None)
     endpoint_config = SourceFileLoader(
         "config", str(funcx_dir / "mock_endpoint" / "config.py")
     ).load_module()
@@ -66,8 +68,9 @@ def test_start_no_reg_info(mocker, funcx_dir):
     )
 
     manager = Endpoint(funcx_dir=funcx_dir)
+    config_dir = pathlib.Path(funcx_dir) / "mock_endpoint"
 
-    manager.configure_endpoint("mock_endpoint", None)
+    manager.configure_endpoint(config_dir, None)
     endpoint_config = SourceFileLoader(
         "config", str(funcx_dir / "mock_endpoint" / "config.py")
     ).load_module()

--- a/funcx_endpoint/tests/unit/test_cli_behavior.py
+++ b/funcx_endpoint/tests/unit/test_cli_behavior.py
@@ -16,9 +16,8 @@ def funcx_dir_path(tmp_path):
 
 @pytest.fixture(autouse=True)
 def mock_cli_state(funcx_dir_path):
-    with mock.patch("funcx_endpoint.cli.get_cli_endpoint") as mock_cli:
-        mock_ep = mock.Mock()
-        mock_cli.return_value = mock_ep
+    with mock.patch("funcx_endpoint.cli.Endpoint") as mock_ep:
+        mock_ep.return_value = mock_ep
         with mock.patch("funcx_endpoint.cli.CommandState.ensure") as m_state:
             mock_state = mock.Mock()
             mock_state.endpoint_config_dir = funcx_dir_path
@@ -35,7 +34,10 @@ def make_endpoint_dir(mock_cli_state):
         ep_dir = mock_state.endpoint_config_dir / name
         ep_dir.mkdir(parents=True, exist_ok=True)
         ep_config = ep_dir / "config.py"
-        ep_config.write_text("config = 1")  # minimal setup to make loading work
+        ep_config.write_text(  # minimal setup to make loading work
+            "from funcx_endpoint.endpoint.utils.config import Config\n"
+            "config = Config(multi_tenant=False)"
+        )
 
     return func
 

--- a/funcx_endpoint/tests/unit/test_endpoint_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpoint_unit.py
@@ -11,37 +11,43 @@ from funcx_endpoint.endpoint.endpoint import Endpoint
 
 
 @pytest.fixture
-def mock_ep():
+def mock_ep_buf():
     buf = io.StringIO()
-    ep = Endpoint()
-    ep.get_endpoints = mock.Mock()
-    ep.get_endpoints.return_value = {}
-    ep.print_endpoint_table = functools.partial(ep.print_endpoint_table, ofile=buf)
-    yield ep, buf
+    # Endpoint.get_endpoint
+    # ep = mocker.patch("funcx_endpoint.endpoint.endpoint.Endpoint.get_endpoints")
+    Endpoint.get_endpoints = mock.Mock()
+    Endpoint.get_endpoints.return_value = {}
+
+    Endpoint.print_endpoint_table = functools.partial(
+        Endpoint.print_endpoint_table, conf_dir="unused", ofile=buf
+    )
+    yield buf
 
 
-def test_list_endpoints_none_configured(mock_ep):
-    ep, buf = mock_ep
-    ep.print_endpoint_table()
+def test_list_endpoints_none_configured(mock_ep_buf):
+    buf = mock_ep_buf
+    Endpoint.print_endpoint_table()
     assert "No endpoints configured" in buf.getvalue()
     assert "Hint:" in buf.getvalue()
     assert "funcx-endpoint configure" in buf.getvalue()
 
 
-def test_list_endpoints_no_id_yet(mock_ep, randomstring):
-    ep, buf = mock_ep
+def test_list_endpoints_no_id_yet(mock_ep_buf, randomstring):
+    buf = mock_ep_buf
     expected_col_length = random.randint(2, 30)
-    ep.get_endpoints.return_value = {
+    Endpoint.get_endpoints.return_value = {
         "default": {"status": randomstring(length=expected_col_length), "id": None}
     }
-    ep.print_endpoint_table()
-    assert ep.get_endpoints.return_value["default"]["status"] in buf.getvalue()
+    Endpoint.print_endpoint_table()
+    assert Endpoint.get_endpoints.return_value["default"]["status"] in buf.getvalue()
     assert "| Endpoint ID |" in buf.getvalue(), "Expecting column shrinks to size"
 
 
 @pytest.mark.parametrize("term_size", ((30, 5), (50, 5), (67, 5), (72, 5), (120, 5)))
-def test_list_endpoints_long_names_wrapped(mock_ep, mocker, term_size, randomstring):
-    ep, buf = mock_ep
+def test_list_endpoints_long_names_wrapped(
+    mock_ep_buf, mocker, term_size, randomstring
+):
+    buf = mock_ep_buf
     tsize = namedtuple("terminal_size", ["columns", "lines"])(*term_size)
     mock_shutil = mocker.patch("funcx_endpoint.endpoint.endpoint.shutil")
     mock_shutil.get_terminal_size.return_value = tsize
@@ -56,9 +62,9 @@ def test_list_endpoints_long_names_wrapped(mock_ep, mocker, term_size, randomstr
         rand_length_str(100, 110): {"status": rand_length_str(), "id": None},
         rand_length_str(100, 110): {"status": rand_length_str(), "id": uuid.uuid4()},
     }
-    ep.get_endpoints.return_value = expected_data
+    Endpoint.get_endpoints.return_value = expected_data
 
-    ep.print_endpoint_table()
+    Endpoint.print_endpoint_table()
 
     for ep_name, ep in expected_data.items():
         assert ep["status"] in buf.getvalue(), "expected no wrapping of status"


### PR DESCRIPTION
Biggest pieces are:

- Move funcx configuration logic to `cli.py`
- Make many of the Endpoint management methods static
- Agree that the endpoint name *is* the configuration directory name (`ep_dir.name`)
- Remove use of `click` from the Endpoint class -- was a leaky abstraction detail
- Use pathlib.Path to improve clarity

On the way to sc-19623.

## Type of change

- Code maintenance/cleanup
