### PR TITLE
refactor funcx client creation for endpoint stop

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -154,6 +154,18 @@ class Endpoint:
             endpoint_uuid = str(uuid.uuid4())
         return endpoint_uuid
 
+    @staticmethod
+    def get_funcx_client(config: Config | None) -> FuncXClient:
+        if config:
+            funcx_client_options = {
+                "funcx_service_address": config.funcx_service_address,
+                "environment": config.environment,
+            }
+
+            return FuncXClient(**funcx_client_options)
+        else:
+            return FuncXClient()
+
     def start_endpoint(
         self,
         name,
@@ -174,12 +186,7 @@ class Endpoint:
                 "executor definitions"
             )
 
-        funcx_client_options = {
-            "funcx_service_address": endpoint_config.funcx_service_address,
-            "environment": endpoint_config.environment,
-        }
-
-        self.fx_client = FuncXClient(**funcx_client_options)
+        fx_client = Endpoint.get_funcx_client(endpoint_config)
 
         endpoint_uuid = Endpoint.check_endpoint_json(endpoint_json, endpoint_uuid)
 
@@ -238,7 +245,7 @@ class Endpoint:
         reg_info = None
         try:
             reg_info = register_endpoint(
-                self.fx_client,
+                fx_client,
                 endpoint_uuid,
                 endpoint_dir,
                 self.name,
@@ -323,7 +330,7 @@ class Endpoint:
                 endpoint_dir,
                 endpoint_config,
                 reg_info,
-                self.fx_client,
+                fx_client,
                 result_store,
             )
 
@@ -360,7 +367,11 @@ class Endpoint:
         return None
 
     @staticmethod
-    def stop_endpoint(endpoint_dir: pathlib.Path, lock_uuid: bool = False):
+    def stop_endpoint(
+        endpoint_dir: pathlib.Path,
+        endpoint_config: Config | None,
+        lock_uuid: bool = False,
+    ):
         pid_path = endpoint_dir / "daemon.pid"
         ep_name = endpoint_dir.name
 
@@ -368,7 +379,9 @@ class Endpoint:
             endpoint_id = Endpoint.get_endpoint_id(endpoint_dir)
             if not endpoint_id:
                 raise ValueError(f"Endpoint <{ep_name}> could not be located")
-            FuncXClient(do_version_check=False).lock_endpoint(endpoint_id)
+
+            fx_client = Endpoint.get_funcx_client(endpoint_config)
+            fx_client.lock_endpoint(endpoint_id)
 
         ep_status = Endpoint.check_pidfile(pid_path)
         if ep_status["exists"] and not ep_status["active"]:
@@ -417,7 +430,7 @@ class Endpoint:
 
         # stopping the endpoint should handle all of the process cleanup before
         # deletion of the directory
-        Endpoint.stop_endpoint(endpoint_dir)
+        Endpoint.stop_endpoint(endpoint_dir, None)
 
         shutil.rmtree(endpoint_dir)
         log.info(f"Endpoint <{ep_name}> has been deleted.")

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -83,8 +83,9 @@ def test_endpoint_logout(monkeypatch):
     return_value="abc-uuid",
 )
 @patch("funcx_endpoint.cli.get_config_dir", return_value=pathlib.Path("some_ep_dir"))
+@patch("funcx_endpoint.cli.read_config")
 @patch("funcx_endpoint.endpoint.endpoint.FuncXClient.lock_endpoint")
-def test_endpoint_lock(mock_get_id, mock_get_conf, mock_lock_endpoint):
+def test_endpoint_lock(mock_get_id, mock_get_conf, mock_get_fxc, mock_lock_endpoint):
     _do_stop_endpoint(name="abc-endpoint", remote=False)
     assert not mock_lock_endpoint.called
     _do_stop_endpoint(name="abc-endpoint", remote=True)

--- a/funcx_endpoint/tests/unit/test_cli_behavior.py
+++ b/funcx_endpoint/tests/unit/test_cli_behavior.py
@@ -83,7 +83,8 @@ def test_start_endpoint_existing_ep(run_line, mock_cli_state, make_endpoint_dir)
     mock_ep.start_endpoint.assert_called_once()
 
 
-def test_stop_endpoint(run_line, mock_cli_state, make_endpoint_dir):
+@mock.patch("funcx_endpoint.cli.read_config")
+def test_stop_endpoint(read_config, run_line, mock_cli_state, make_endpoint_dir):
     run_line("stop foo")
     mock_ep, _ = mock_cli_state
     mock_ep.stop_endpoint.assert_called_once()


### PR DESCRIPTION
stop_endpoint needs to read config.py now when the --remote option is specified, and will use it to create a FuncXClient for the env/service, as start_endpoint does.

This refactors that creation a bit to make it easier to use, and this fixes an issue where the incorrect environment might be used as the config specifies.

Note that this is a fairly simple change - moving some pre-existing code into a method and adding a call to it in stop_endpoint, plus some changes to mocking in tests to make sure everything passes.  There isn't any 'new' logic.

