### PR TITLE
fix endpoint start error handling and pid exist check

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -412,6 +412,8 @@ class Endpoint:
 
             if pid_path.exists():
                 log.warning(f"Endpoint <{ep_name}> did not gracefully shutdown")
+                # Do cleanup anyway, TODO figure out where it should have done that
+                pid_path.unlink(missing_ok=True)
             else:
                 log.info(f"Endpoint <{ep_name}> is now stopped")
         except OSError:
@@ -453,10 +455,15 @@ class Endpoint:
         if not pid_path.exists():
             return status
 
-        pid = int(pid_path.read_text().strip())
+        status["exists"] = True
+
         try:
+            pid = int(pid_path.read_text().strip())
             psutil.Process(pid)
             status["active"] = True
+        except ValueError:
+            # Invalid literal for int() parsing
+            pass
         except psutil.NoSuchProcess:
             pass
 

--- a/funcx_endpoint/tests/unit/test_endpoint_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpoint_unit.py
@@ -101,3 +101,24 @@ def test_list_endpoints_long_names_wrapped(
         assert ep["status"] in buf.getvalue(), "expected no wrapping of status"
         assert str(ep["id"]) in buf.getvalue(), "expected no wrapping of id"
         assert ep_name not in buf.getvalue(), "expected only name column is wrapped"
+
+
+@pytest.mark.parametrize(
+    "pid_info",
+    [
+        [False, None, False, False],
+        [True, "", True, False],
+        [True, "123", True, False],
+    ],
+)
+def test_pid_file_check(pid_info, fs):
+    has_file, pid_content, should_exist, should_active = pid_info
+
+    pid_path = "sample_daemon.pid"
+    if has_file:
+        with open(pid_path, "w") as f:
+            f.write(pid_content)
+
+    pid_status = Endpoint.check_pidfile(pid_path)
+    assert should_exist == pid_status["exists"]
+    assert should_active == pid_status["active"]


### PR DESCRIPTION
(Note that this builds on a previous PR that included some refactoring, will be rebased to main once the other PR is merged)

Fixes an issue where checking the daemon.pid file never returns exists=True, and also handles Locked and InUse api return codes in the appropriate exception type (GlobusApiError not FuncXResponseError)