### PR TITLE
Repurpose lock endpoint method to stop endpoint

### DIFF
--- a/changelog.d/20221212_155851_30907815+rjmello_stop_ep.rst
+++ b/changelog.d/20221212_155851_30907815+rjmello_stop_ep.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Renamed the ``FuncXClient`` method ``lock_endpoint`` to ``stop_endpoint``.
+- Renamed the ``Endpoint.stop_endpoint()`` parameter ``lock_uuid`` to ``remote``.

--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -335,7 +335,7 @@ def stop_endpoint(*, name: str, remote: bool):
 
 def _do_stop_endpoint(*, name: str, remote: bool = False) -> None:
     ep_dir = get_config_dir() / name
-    Endpoint.stop_endpoint(ep_dir, read_config(name), lock_uuid=remote)
+    Endpoint.stop_endpoint(ep_dir, read_config(name), remote=remote)
 
 
 @app.command("restart")

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -381,7 +381,7 @@ class Endpoint:
                 raise ValueError(f"Endpoint <{ep_name}> could not be located")
 
             fx_client = Endpoint.get_funcx_client(endpoint_config)
-            fx_client.lock_endpoint(endpoint_id)
+            fx_client.stop_endpoint(endpoint_id)
 
         ep_status = Endpoint.check_pidfile(pid_path)
         if ep_status["exists"] and not ep_status["active"]:

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -370,12 +370,12 @@ class Endpoint:
     def stop_endpoint(
         endpoint_dir: pathlib.Path,
         endpoint_config: Config | None,
-        lock_uuid: bool = False,
+        remote: bool = False,
     ):
         pid_path = endpoint_dir / "daemon.pid"
         ep_name = endpoint_dir.name
 
-        if lock_uuid is True:
+        if remote is True:
             endpoint_id = Endpoint.get_endpoint_id(endpoint_dir)
             if not endpoint_id:
                 raise ValueError(f"Endpoint <{ep_name}> could not be located")

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -119,9 +119,11 @@ def test_endpoint_logout(monkeypatch):
 )
 @patch("funcx_endpoint.cli.get_config_dir", return_value=pathlib.Path("some_ep_dir"))
 @patch("funcx_endpoint.cli.read_config")
-@patch("funcx_endpoint.endpoint.endpoint.FuncXClient.lock_endpoint")
-def test_endpoint_lock(mock_get_id, mock_get_conf, mock_get_fxc, mock_lock_endpoint):
+@patch("funcx_endpoint.endpoint.endpoint.FuncXClient.stop_endpoint")
+def test_stop_remote_endpoint(
+    mock_get_id, mock_get_conf, mock_get_fxc, mock_stop_endpoint
+):
     _do_stop_endpoint(name="abc-endpoint", remote=False)
-    assert not mock_lock_endpoint.called
+    assert not mock_stop_endpoint.called
     _do_stop_endpoint(name="abc-endpoint", remote=True)
-    assert mock_lock_endpoint.called
+    assert mock_stop_endpoint.called

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -744,9 +744,17 @@ class FuncXClient:
             res.append(self.web_client.whitelist_remove(endpoint_id, fid))
         return res
 
-    def lock_endpoint(self, endpoint_id):
-        """Set a lock for the specified endpoint UUID such that any clients
-        that attempts to connect will be rejected for a brief period
+    def stop_endpoint(self, endpoint_id):
+        """Stop an endpoint by temporarily blocking connection attempts.
 
+        Parameters
+        ----------
+        endpoint_id : str
+            The uuid of the endpoint
+
+        Returns
+        -------
+        json
+            The response of the request
         """
-        return self.web_client.add_endpoint_uuid_lock(endpoint_id)
+        return self.web_client.stop_endpoint(endpoint_id)

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -744,8 +744,8 @@ class FuncXClient:
             res.append(self.web_client.whitelist_remove(endpoint_id, fid))
         return res
 
-    def stop_endpoint(self, endpoint_id):
-        """Stop an endpoint by temporarily blocking connection attempts.
+    def stop_endpoint(self, endpoint_id: str):
+        """Stop an endpoint by dropping it's active connections.
 
         Parameters
         ----------

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -234,7 +234,5 @@ class FuncxWebClient(globus_sdk.BaseClient):
     ) -> globus_sdk.GlobusHTTPResponse:
         return self.delete(f"/endpoints/{endpoint_id}/whitelist/{function_id}")
 
-    def add_endpoint_uuid_lock(
-        self, endpoint_id: ID_PARAM_T
-    ) -> globus_sdk.GlobusHTTPResponse:
+    def stop_endpoint(self, endpoint_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
         return self.post(f"/endpoints/{endpoint_id}/lock", data={})


### PR DESCRIPTION
# Description

A method is needed in `FuncXClient` to remotely stop an endpoint. The preferred way to accomplish this is to temporarily block connection attempts from the remote endpoint, ultimately causing it to stop.  Since the `lock_endpoint()` method already exists and does exactly this, it is being renamed to `stop_endpoint()` to more clearly describe what the method is accomplishing.

[sc-9584]

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
