### PR TITLE
Handle invalid refresh tokens

### DIFF
--- a/changelog.d/20221216_103757_30907815+rjmello_invalid_grant.rst
+++ b/changelog.d/20221216_103757_30907815+rjmello_invalid_grant.rst
@@ -1,0 +1,9 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- When a `FuncXClient` is instantiated, the validity of the user's refresh
+  tokens will be verified. If a token is found to be invalid, a new auth flow
+  will be initiated.
+
+- When an API auth error is raised by a `FuncXClient` method, a new auth flow
+  will be initiated.

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -28,7 +28,7 @@ from funcx.serialize import FuncXSerializer
 from funcx.version import __version__, compare_versions
 
 from .batch import Batch
-from .login_manager import LoginManager, LoginManagerProtocol
+from .login_manager import LoginManager, LoginManagerProtocol, requires_login
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +272,7 @@ class FuncXClient:
         self._task_status_table[task_id] = status
         return status
 
+    @requires_login
     def get_task(self, task_id):
         """Get a funcX task.
 
@@ -294,6 +295,7 @@ class FuncXClient:
         rets = self._update_task_table(r.text, task_id)
         return rets
 
+    @requires_login
     def get_result(self, task_id):
         """Get the result of a funcX task
 
@@ -320,6 +322,7 @@ class FuncXClient:
                 logger.warning("We have an exception : {}".format(task["exception"]))
                 task["exception"].reraise()
 
+    @requires_login
     def get_batch_result(self, task_id_list):
         """Request status for a batch of task_ids"""
         assert isinstance(
@@ -357,6 +360,7 @@ class FuncXClient:
 
         return results
 
+    @requires_login
     def run(self, *args, endpoint_id=None, function_id=None, **kwargs) -> str:
         """Initiate an invocation
 
@@ -418,6 +422,7 @@ class FuncXClient:
             task_group_id=task_group_id, create_websocket_queue=create_websocket_queue
         )
 
+    @requires_login
     def batch_run(self, batch) -> t.List[str]:
         """Initiate a batch of tasks to funcX
 
@@ -461,6 +466,7 @@ class FuncXClient:
 
         return task_uuids
 
+    @requires_login
     def register_endpoint(
         self,
         name,
@@ -498,10 +504,12 @@ class FuncXClient:
         )
         return r.data
 
+    @requires_login
     def get_result_amqp_url(self) -> dict[str, str]:
         r = self.web_client.get_result_amqp_url()
         return r.data
 
+    @requires_login
     def get_containers(self, name, description=None):
         """
         Register a DLHub endpoint with the funcX service and get the containers to
@@ -524,6 +532,7 @@ class FuncXClient:
         r = self.web_client.post("get_containers", data=data)
         return r.data["endpoint_uuid"], r.data["endpoint_containers"]
 
+    @requires_login
     def get_container(self, container_uuid, container_type):
         """Get the details of a container for staging it locally.
 
@@ -544,6 +553,7 @@ class FuncXClient:
         r = self.web_client.get(f"containers/{container_uuid}/{container_type}")
         return r.data["container"]
 
+    @requires_login
     def get_endpoint_status(self, endpoint_uuid):
         """Get the status reports for an endpoint.
 
@@ -560,6 +570,7 @@ class FuncXClient:
         r = self.web_client.get_endpoint_status(endpoint_uuid)
         return r.data
 
+    @requires_login
     def get_endpoints(self):
         """Get a list of all endpoints owned by the current user across all systems.
 
@@ -571,6 +582,7 @@ class FuncXClient:
         r = self.web_client.get_endpoints()
         return r.data
 
+    @requires_login
     def register_function(
         self,
         function,
@@ -621,6 +633,7 @@ class FuncXClient:
         r = self.web_client.register_function(data)
         return r.data["function_uuid"]
 
+    @requires_login
     def search_function(self, q, offset=0, limit=10, advanced=False):
         """Search for function via the funcX service
 
@@ -643,6 +656,7 @@ class FuncXClient:
             q, offset=offset, limit=limit, advanced=advanced
         )
 
+    @requires_login
     def search_endpoint(self, q, scope="all", owner_id=None):
         """
 
@@ -660,6 +674,7 @@ class FuncXClient:
         """
         return self.searcher.search_endpoint(q, scope=scope, owner_id=owner_id)
 
+    @requires_login
     def register_container(self, location, container_type, name="", description=""):
         """Register a container with the funcX service.
 
@@ -691,6 +706,7 @@ class FuncXClient:
         r = self.web_client.post("containers", data=payload)
         return r.data["container_id"]
 
+    @requires_login
     def build_container(self, container_spec):
         """
         Submit a request to build a docker image based on a container spec. This
@@ -733,6 +749,7 @@ class FuncXClient:
             logger.error(message)
             raise SystemError(message)
 
+    @requires_login
     def add_to_whitelist(self, endpoint_id, function_ids):
         """Adds the function to the endpoint's whitelist
 
@@ -750,6 +767,7 @@ class FuncXClient:
         """
         return self.web_client.whitelist_add(endpoint_id, function_ids)
 
+    @requires_login
     def get_whitelist(self, endpoint_id):
         """List the endpoint's whitelist
 
@@ -765,6 +783,7 @@ class FuncXClient:
         """
         return self.web_client.get_whitelist(endpoint_id)
 
+    @requires_login
     def delete_from_whitelist(self, endpoint_id, function_ids):
         """List the endpoint's whitelist
 
@@ -787,6 +806,7 @@ class FuncXClient:
             res.append(self.web_client.whitelist_remove(endpoint_id, fid))
         return res
 
+    @requires_login
     def stop_endpoint(self, endpoint_id: str):
         """Stop an endpoint by dropping it's active connections.
 

--- a/funcx_sdk/funcx/sdk/login_manager/__init__.py
+++ b/funcx_sdk/funcx/sdk/login_manager/__init__.py
@@ -1,3 +1,4 @@
+from .decorators import requires_login
 from .manager import FuncxScopes, LoginManager
 from .protocol import LoginManagerProtocol
 
@@ -5,4 +6,5 @@ __all__ = (
     "LoginManager",
     "FuncxScopes",
     "LoginManagerProtocol",
+    "requires_login",
 )

--- a/funcx_sdk/funcx/sdk/login_manager/decorators.py
+++ b/funcx_sdk/funcx/sdk/login_manager/decorators.py
@@ -1,0 +1,31 @@
+import functools
+import logging
+
+import globus_sdk
+
+log = logging.getLogger(__name__)
+
+
+def requires_login(func):
+    """Decorator that initiates a new auth flow when
+    an API auth error is raised.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except globus_sdk.AuthAPIError as e:
+            log.debug(
+                "Unauthorized API call (callable: %s).  Exception text: %s",
+                func.__name__,
+                e,
+            )
+            self.login_manager.run_login_flow()
+            # Initiate a new web client with updated authorizer
+            self.web_client = self.login_manager.get_funcx_web_client(
+                base_url=self.funcx_service_address
+            )
+            return func(self, *args, **kwargs)
+
+    return wrapper

--- a/funcx_sdk/funcx/sdk/login_manager/manager.py
+++ b/funcx_sdk/funcx/sdk/login_manager/manager.py
@@ -122,16 +122,37 @@ class LoginManager:
         return tokens_revoked
 
     def ensure_logged_in(self) -> None:
-        with self._access_lock:
-            data = self._token_storage.get_by_resource_server()
-        needs_login = False
-        for rs_name, _rs_scopes in self.login_requirements:
-            if rs_name not in data:
-                needs_login = True
+        """Ensures that the user has valid refresh tokens. If a token
+        is found to be invalid, a new login flow is initiated.
+        """
+        for server, _scopes in self.login_requirements:
+            if not self.has_login(server):
+                self.run_login_flow()
                 break
 
-        if needs_login:
-            self.run_login_flow()
+    def _validate_token(self, token: str) -> bool:
+        auth_client = internal_auth_client()
+        try:
+            res = auth_client.oauth2_validate_token(token)
+        except globus_sdk.AuthAPIError:
+            return False
+        return res["active"] is True
+
+    def has_login(self, resource_server: str) -> bool:
+        """
+        Determines if the user has a valid refresh token for the given
+        resource server
+        """
+        # Client identities are always logged in
+        if is_client_login():
+            return True
+
+        with self._access_lock:
+            tokens = self._token_storage.get_token_data(resource_server)
+        if tokens is None or "refresh_token" not in tokens:
+            return False
+        rt = tokens["refresh_token"]
+        return self._validate_token(rt)
 
     def _get_authorizer(
         self, resource_server: str

--- a/funcx_sdk/tests/unit/test_login_manager.py
+++ b/funcx_sdk/tests/unit/test_login_manager.py
@@ -4,19 +4,29 @@ from unittest import mock
 
 import globus_sdk
 import pytest
+import requests
 
 from funcx.sdk._environments import _get_envname
+from funcx.sdk.login_manager import LoginManager, requires_login
 from funcx.sdk.login_manager.client_login import (
     _get_client_creds_from_env,
     get_client_login,
     is_client_login,
 )
-from funcx.sdk.login_manager.manager import LoginManager
 from funcx.sdk.login_manager.tokenstore import _resolve_namespace
 
 CID_KEY = "FUNCX_SDK_CLIENT_ID"
 CSC_KEY = "FUNCX_SDK_CLIENT_SECRET"
 MOCK_BASE = "funcx.sdk.login_manager"
+
+
+def _fake_http_response(*, status: int = 200, method: str = "GET") -> requests.Response:
+    req = requests.Request(method, "https://funcx.example.org/")
+    p_req = req.prepare()
+    res = requests.Response()
+    res.request = p_req
+    res.status_code = status
+    return res
 
 
 @pytest.fixture
@@ -159,3 +169,61 @@ def test_get_authorizer(mocker, logman):
 
     with pytest.raises(LookupError):
         logman._get_authorizer("some_resource_server")
+
+
+@pytest.mark.parametrize("has_login", (True, False))
+def test_ensure_logged_in(mocker, logman, has_login):
+    logman.has_login = mock.Mock(return_value=has_login)
+    mock_run_login_flow = mocker.patch(
+        f"{MOCK_BASE}.manager.LoginManager.run_login_flow"
+    )
+
+    logman.ensure_logged_in()
+
+    assert has_login is not mock_run_login_flow.called
+
+
+@pytest.mark.parametrize("tokens", ({"refresh_token": "123"}, {}))
+def test_has_login(mocker, logman, tokens):
+    logman._token_storage.get_token_data = mock.Mock(return_value=tokens)
+    logman._validate_token = mock.Mock(return_value=True)
+    env = {CID_KEY: "some_id", CSC_KEY: "some_secret"}
+
+    assert logman.has_login("funcx") is bool(tokens)
+    with mock.patch.dict(os.environ, env):
+        assert logman.has_login("funcx") is True
+
+
+def test_requires_login_decorator(mocker, logman):
+    mocked_run_login_flow = mocker.patch(
+        f"{MOCK_BASE}.manager.LoginManager.run_login_flow"
+    )
+    mocked_get_funcx_web_client = mocker.patch(
+        f"{MOCK_BASE}.manager.LoginManager.get_funcx_web_client"
+    )
+
+    expected = "expected result"
+    mock_method = mock.Mock()
+    mock_method.side_effect = [
+        expected,
+        globus_sdk.AuthAPIError(_fake_http_response(status=400, method="POST")),
+        expected,
+    ]
+    mock_method.__name__ = "mock_method"
+
+    class MockClient:
+        login_manager = logman
+        funcx_service_address = "127.0.0.1"
+        upstream_call = requires_login(mock_method)
+
+    mock_client = MockClient()
+
+    res = mock_client.upstream_call(None)  # case: no need to reauth
+    assert res == expected
+    assert not mocked_run_login_flow.called
+    assert not mocked_get_funcx_web_client.called
+
+    res = mock_client.upstream_call(None)  # case: now must reauth
+    assert res == expected
+    assert mocked_run_login_flow.called
+    assert mocked_get_funcx_web_client.called


### PR DESCRIPTION
# Description

Invalid refresh tokens will be handled when a `FuncXClient` object is instantiated and when an API auth error is raised by a `FuncXClient` method. The former is accomplished by directly validating the tokens against Globus Auth, and the latter by catching `AuthAPIError` exceptions. If a token is found to be invalid, a new auth flow will be initiated.

[sc-20480]

## Type of change

- New feature (non-breaking change that adds functionality)
