### PR TITLE
Timeout tests after 10 mins

### DIFF
--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1


### PR DESCRIPTION
# Description

A simple solution to the tests not timing out. Add a 10 min timeout to the workflow calling the tests.

## Type of change

- Bug fix (non-breaking change that fixes an issue)