### PR TITLE
Add a small amount of typing

### DIFF
--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/container_sched.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/container_sched.py
@@ -2,7 +2,9 @@ import logging
 import math
 import random
 
-log = logging.getLogger(__name__)
+from funcx_endpoint.logging_config import FXLogger
+
+log: FXLogger = logging.getLogger(__name__)  # type: ignore
 
 
 def naive_scheduler(
@@ -17,7 +19,7 @@ def naive_scheduler(
     """
 
     log.trace("Entering scheduler...")
-    log.trace(f"old_worker_map: {old_worker_map}")
+    log.trace("old_worker_map: %s", old_worker_map)
     q_sizes = {}
     q_types = []
     new_worker_map = {}

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -32,12 +32,12 @@ from funcx_endpoint.executors.high_throughput.messages import (
     Message,
     MessageType,
 )
-from funcx_endpoint.logging_config import setup_logging
+from funcx_endpoint.logging_config import FXLogger
 
 if t.TYPE_CHECKING:
     import multiprocessing as mp
 
-log = logging.getLogger(__name__)
+log: FXLogger = logging.getLogger(__name__)  # type: ignore
 
 LOOP_SLOWDOWN = 0.0  # in seconds
 HEARTBEAT_CODE = (2**32) - 1
@@ -96,7 +96,7 @@ class Interchange:
         strategy=None,
         poll_period=None,
         heartbeat_period=None,
-        heartbeat_threshold=None,
+        heartbeat_threshold=1,
         working_dir=None,
         provider=None,
         max_workers_per_node=None,
@@ -295,7 +295,7 @@ class Interchange:
             )
         )
 
-        self._ready_manager_queue: dict[str, t.Any] = {}
+        self._ready_manager_queue: dict[bytes, t.Any] = {}
 
         self.blocks: dict[str, str] = {}
         self.block_id_map: dict[str, str] = {}
@@ -340,7 +340,7 @@ class Interchange:
         self.task_cancel_running_queue: queue.Queue = queue.Queue()
         self.task_cancel_pending_trap: dict[str, str] = {}
         self.task_status_deltas: dict[str, list[TaskTransition]] = {}
-        self.container_switch_count: dict[str, int] = {}
+        self.container_switch_count: dict[bytes, int] = {}
 
     def load_config(self):
         """Load the config"""
@@ -419,9 +419,8 @@ class Interchange:
                 self.last_heartbeat = time.time()
             except zmq.Again:
                 log.trace(
-                    "No new incoming task - {} tasks in internal queue".format(
-                        self.total_pending_task_count
-                    )
+                    "No new incoming task - %s tasks in internal queue",
+                    self.total_pending_task_count,
                 )
                 continue
 
@@ -578,9 +577,7 @@ class Interchange:
         log.info(f"Endpoint id: {self.endpoint_id}")
 
         while True:
-            log.trace(  # type: ignore[attr-defined]
-                f"Endpoint id : {self.endpoint_id}, {type(self.endpoint_id)}"
-            )
+            log.trace("Endpoint id : %s, %s", self.endpoint_id, type(self.endpoint_id))
             msg = EPStatusReport(
                 self.endpoint_id, self.get_status_report(), self.task_status_deltas
             )
@@ -677,7 +674,7 @@ class Interchange:
         self._status_report_thread.join()
         log.info("HighThroughput Interchange stopped")
 
-    def start(self, poll_period=None):
+    def start(self, poll_period: int | None = None) -> None:
         """Start the Interchange
 
         Parameters:
@@ -711,7 +708,7 @@ class Interchange:
         )
         self._command_thread.start()
 
-        status_report_queue = queue.Queue()
+        status_report_queue: queue.Queue[bytes] = queue.Queue()
         self._status_report_thread = threading.Thread(
             target=self._status_report_loop,
             args=(self._kill_event, status_report_queue),
@@ -735,7 +732,7 @@ class Interchange:
         # for scheduling a job (or maybe any other attention?).
         # Anything altering the state of the manager should add it
         # onto this list.
-        interesting_managers = set()
+        interesting_managers: set[bytes] = set()
 
         # This value records when the last cold routing in soft mode happens
         # When the cold routing in soft mode happens, it may cause worker containers to
@@ -758,7 +755,8 @@ class Interchange:
                 message = self.task_outgoing.recv_multipart()
                 manager = message[0]
 
-                if manager not in self._ready_manager_queue:
+                mdata = self._ready_manager_queue.get(manager)
+                if not mdata:
                     reg_flag = False
 
                     try:
@@ -766,15 +764,16 @@ class Interchange:
                         reg_flag = True
                     except Exception:
                         log.warning(
-                            "Got a non-json registration message from " "manager:%s",
+                            "Got a non-json registration message from manager:%s",
                             manager,
                         )
-                        log.debug(f"Message :\n{message}\n")
+                        log.debug("Message :\n%s\n", message)
 
                     # By default we set up to ignore bad nodes/registration messages.
-                    self._ready_manager_queue[manager] = {
-                        "last": time.time(),
-                        "reg_time": time.time(),
+                    now = time.time()
+                    mdata = {
+                        "last": now,
+                        "reg_time": now,
                         "free_capacity": {"total_workers": 0},
                         "max_worker_count": 0,
                         "active": True,
@@ -783,9 +782,10 @@ class Interchange:
                     }
                     if reg_flag is True:
                         interesting_managers.add(manager)
-                        log.info(f"Adding manager: {manager} to ready queue")
-                        self._ready_manager_queue[manager].update(msg)
-                        log.info(f"Registration info for manager {manager}: {msg}")
+                        log.info(f"Adding manager: {manager!r} to ready queue")
+                        mdata.update(msg)
+                        log.info(f"Registration info for manager {manager!r}: {msg}")
+                        self._ready_manager_queue[manager] = mdata
 
                         if (
                             msg["python_v"].rsplit(".", 1)[0]
@@ -793,7 +793,7 @@ class Interchange:
                             or msg["parsl_v"] != self.current_platform["parsl_v"]
                         ):
                             log.info(
-                                f"Manager:{manager} version:{msg['python_v']} "
+                                f"Manager:{manager!r} version:{msg['python_v']} "
                                 "does not match the interchange"
                             )
                     else:
@@ -815,22 +815,19 @@ class Interchange:
                             )
 
                 else:
-                    self._ready_manager_queue[manager]["last"] = time.time()
+                    mdata["last"] = time.time()
                     if message[1] == b"HEARTBEAT":
-                        log.debug(f"Manager {manager} sends heartbeat")
+                        log.debug("Manager %s sends heartbeat", manager)
                         self.task_outgoing.send_multipart(
                             [manager, b"", PKL_HEARTBEAT_CODE]
                         )
                     else:
                         manager_adv = dill.loads(message[1])
-                        log.debug(f"Manager {manager} requested {manager_adv}")
-                        self._ready_manager_queue[manager]["free_capacity"].update(
-                            manager_adv
-                        )
-                        self._ready_manager_queue[manager]["free_capacity"][
-                            "total_workers"
-                        ] = sum(manager_adv["free"].values())
+                        log.debug("Manager %s requested %s", manager, manager_adv)
+                        manager_adv["total_workers"] = sum(manager_adv["free"].values())
+                        mdata["free_capacity"].update(manager_adv)
                         interesting_managers.add(manager)
+                        del manager_adv
 
             # If we had received any requests, check if there are tasks that could be
             # passed
@@ -863,24 +860,22 @@ class Interchange:
 
             # Task cancel is high priority, so we'll process all requests
             # in one go
-            while True:
-                try:
+            try:
+                while True:
                     manager, task_id = self.task_cancel_running_queue.get(block=False)
                     log.debug(
-                        f"Task:{task_id} on manager:{manager} is "
-                        "now CANCELLED while running"
+                        "CANCELLED running task (id: %s, manager: %s)", task_id, manager
                     )
                     cancel_message = dill.dumps(("TASK_CANCEL", task_id))
                     self.task_outgoing.send_multipart([manager, b"", cancel_message])
-
-                except queue.Empty:
-                    break
+            except queue.Empty:
+                pass
 
             for manager in task_dispatch:
                 tasks = task_dispatch[manager]
                 if tasks:
                     log.info(
-                        'Sending task message "{}..." to manager {}'.format(
+                        'Sending task message "{}..." to manager {!r}'.format(
                             str(tasks)[:50], manager
                         )
                     )
@@ -891,7 +886,7 @@ class Interchange:
 
                     for task in tasks:
                         task_id = task["task_id"]
-                        log.info(f"Sent task {task_id} to manager {manager}")
+                        log.info(f"Sent task {task_id} to manager {manager!r}")
                         if (
                             self.task_cancel_pending_trap
                             and task_id in self.task_cancel_pending_trap
@@ -903,15 +898,13 @@ class Interchange:
                             )
                             self.task_cancel_pending_trap.pop(task_id)
                         else:
-                            log.debug(f"Task:{task_id} is now WAITING_FOR_LAUNCH")
+                            log.debug("Task:%s is now WAITING_FOR_LAUNCH", task_id)
                             tt = TaskTransition(
                                 timestamp=time.time_ns(),
                                 state=TaskState.WAITING_FOR_LAUNCH,
                                 actor=ActorName.INTERCHANGE,
                             )
-                            self.task_status_deltas[
-                                task_id
-                            ] = self.task_status_deltas.get(task_id, [])
+                            self.task_status_deltas.setdefault(task_id, [])
                             self.task_status_deltas[task_id].append(tt)
 
             # Receive any results and forward to client
@@ -921,7 +914,8 @@ class Interchange:
             ):
                 log.debug("entering results_incoming section")
                 manager, *b_messages = self.results_incoming.recv_multipart()
-                if manager not in self._ready_manager_queue:
+                mdata = self._ready_manager_queue.get(manager)
+                if not mdata:
                     log.warning(
                         "Received a result from a un-registered manager: %s",
                         manager,
@@ -930,7 +924,7 @@ class Interchange:
                     # We expect the batch of messages to be (optionally) a task status
                     # update message followed by 0 or more task results
                     try:
-                        log.debug("Trying to unpack ")
+                        log.debug("Trying to unpack")
                         manager_report = Message.unpack(b_messages[0])
                         if manager_report.task_statuses:
                             log.info(
@@ -949,7 +943,7 @@ class Interchange:
                             [manager, b"", PKL_HEARTBEAT_CODE]
                         )
                         b_messages = b_messages[1:]
-                        self._ready_manager_queue[manager]["last"] = time.time()
+                        mdata["last"] = time.time()
                         self.container_switch_count[
                             manager
                         ] = manager_report.container_switch_count
@@ -965,9 +959,7 @@ class Interchange:
                         r = dill.loads(b_message)
 
                         log.debug(
-                            "Received result for task {} from {}".format(
-                                r["task_id"], manager
-                            )
+                            "Received task result %s (from %s)", r["task_id"], manager
                         )
                         task_type = self.containers[r["container_id"]]
                         log.debug(
@@ -976,22 +968,20 @@ class Interchange:
                             self._ready_manager_queue,
                         )
 
-                        self._ready_manager_queue[manager]["tasks"][task_type].remove(
-                            r["task_id"]
-                        )
+                        mdata["tasks"][task_type].remove(r["task_id"])
 
                         # Transfer any outstanding task statuses to the result message
                         if r["task_id"] in self.task_status_deltas:
                             r["task_statuses"] += self.task_status_deltas[r["task_id"]]
                             b_messages[idx] = dill.dumps(r)
                             log.debug(
-                                "Transferring statuses for {}: {}".format(
-                                    r["task_id"], r["task_statuses"]
-                                )
+                                "Transferring statuses for %s: %s",
+                                r["task_id"],
+                                r["task_statuses"],
                             )
                             del self.task_status_deltas[r["task_id"]]
 
-                    self._ready_manager_queue[manager]["total_tasks"] -= len(b_messages)
+                    mdata["total_tasks"] -= len(b_messages)
 
                     # TODO: handle this with a Task message or something?
                     # previously used this; switched to mono-message,
@@ -999,38 +989,34 @@ class Interchange:
                     self.results_outgoing.send(dill.dumps(b_messages))
                     interesting_managers.add(manager)
 
-                    log.debug(
-                        "Current tasks: {}".format(
-                            self._ready_manager_queue[manager]["tasks"]
-                        )
-                    )
+                    log.debug(f"Current tasks: {mdata['tasks']}")
                 log.debug("leaving results_incoming section")
 
             # Send status reports from this main thread to avoid thread-safety on zmq
             # sockets
             try:
                 packed_status_report = status_report_queue.get(block=False)
-                log.trace(f"forwarding status report: {packed_status_report}")
+                log.trace("forwarding status report: %s", packed_status_report)
                 self.results_outgoing.send(packed_status_report)
             except queue.Empty:
                 pass
 
             log.trace("entering bad_managers section")
+            now = time.time()
+            hbt_window_start = now - self.heartbeat_threshold
             bad_managers = [
                 manager
                 for manager in self._ready_manager_queue
-                if time.time() - self._ready_manager_queue[manager]["last"]
-                > self.heartbeat_threshold
+                if hbt_window_start > self._ready_manager_queue[manager]["last"]
             ]
             bad_manager_msgs = []
             for manager in bad_managers:
                 log.debug(
-                    "Last: {} Current: {}".format(
-                        self._ready_manager_queue[manager]["last"], time.time()
-                    )
+                    "Last: %s Current: %s",
+                    self._ready_manager_queue[manager]["last"],
+                    now,
                 )
-                log.warning(f"Too many heartbeats missed for manager {manager}")
-                e = ManagerLost(manager)
+                log.warning(f"Too many heartbeats missed for manager {manager!r}")
                 for task_type in self._ready_manager_queue[manager]["tasks"]:
                     for tid in self._ready_manager_queue[manager]["tasks"][task_type]:
                         try:
@@ -1043,8 +1029,8 @@ class Interchange:
                             }
                             pkl_package = dill.dumps(result_package)
                             bad_manager_msgs.append(pkl_package)
-                log.warning(f"Sent failure reports, unregistering manager {manager}")
-                self._ready_manager_queue.pop(manager, "None")
+                log.warning(f"Sent failure reports, unregistering manager {manager!r}")
+                self._ready_manager_queue.pop(manager, None)
                 if manager in interesting_managers:
                     interesting_managers.remove(manager)
             if bad_manager_msgs:
@@ -1213,9 +1199,9 @@ class Interchange:
         """
         status = []
         if self.provider:
-            log.trace(f"Getting the status of {list(self.blocks.values())} blocks.")
+            log.trace("Getting the status of %s blocks.", list(self.blocks.values()))
             status = self.provider.status(list(self.blocks.values()))
-            log.trace(f"The status is {status}")
+            log.trace("The status is %s", status)
 
         return status
 
@@ -1244,6 +1230,7 @@ def starter(comm_q: mp.Queue, *args, **kwargs) -> None:
 
 
 def cli_run():
+    from funcx_endpoint.logging_config import setup_logging
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--client_address", required=True, help="Client address")

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange_task_dispatch.py
@@ -1,26 +1,33 @@
+from __future__ import annotations
+
 import collections
 import logging
 import queue
 import random
 
-log = logging.getLogger(__name__)
+from funcx_endpoint.logging_config import FXLogger
+
+log: FXLogger = logging.getLogger(__name__)  # type: ignore
 log.info("Interchange task dispatch started")
 
 
 def naive_interchange_task_dispatch(
-    interesting_managers,
-    pending_task_queue,
-    ready_manager_queue,
-    scheduler_mode="hard",
-    cold_routing=False,
-):
+    interesting_managers: set[bytes],
+    pending_task_queue: dict[str, queue.Queue[dict]],
+    ready_manager_queue: dict[bytes, dict],
+    scheduler_mode: str = "hard",
+    cold_routing: bool = False,
+) -> tuple[dict[bytes, list], int]:
     """
     This is an initial task dispatching algorithm for interchange.
     It returns a dictionary, whose key is manager, and the value is the list of tasks
     to be sent to manager, and the total number of dispatched tasks.
     """
+    task_dispatch: dict[bytes, list] = {}
+    dispatched_tasks = 0
     if scheduler_mode == "hard":
-        return dispatch(
+        dispatched_tasks += dispatch(
+            task_dispatch,
             interesting_managers,
             pending_task_queue,
             ready_manager_queue,
@@ -28,198 +35,199 @@ def naive_interchange_task_dispatch(
         )
 
     elif scheduler_mode == "soft":
-        task_dispatch, dispatched_tasks = {}, 0
         loops = ["warm"] if not cold_routing else ["warm", "cold"]
         for loop in loops:
-            task_dispatch, dispatched_tasks = dispatch(
+            dispatched_tasks += dispatch(
+                task_dispatch,
                 interesting_managers,
                 pending_task_queue,
                 ready_manager_queue,
                 scheduler_mode="soft",
                 loop=loop,
-                task_dispatch=task_dispatch,
-                dispatched_tasks=dispatched_tasks,
             )
-        return task_dispatch, dispatched_tasks
+    return task_dispatch, dispatched_tasks
 
 
 def dispatch(
-    interesting_managers,
-    pending_task_queue,
-    ready_manager_queue,
-    scheduler_mode="hard",
-    loop="warm",
-    task_dispatch=None,
-    dispatched_tasks=0,
-):
+    task_dispatch: dict[bytes, list],
+    interesting_managers: set[bytes],
+    pending_task_queue: dict[str, queue.Queue[dict]],
+    ready_manager_queue: dict[bytes, dict],
+    scheduler_mode: str = "hard",
+    loop: str = "warm",
+) -> int:
     """
     This is the core task dispatching algorithm for interchange.
     The algorithm depends on the scheduler mode and which loop.
     """
-    if not task_dispatch:
-        task_dispatch = {}
+    dispatched_tasks = 0
     if interesting_managers:
         shuffled_managers = list(interesting_managers)
         random.shuffle(shuffled_managers)
         for manager in shuffled_managers:
-            tasks_inflight = ready_manager_queue[manager]["total_tasks"]
-            real_capacity = min(
-                ready_manager_queue[manager]["free_capacity"]["total_workers"],
-                ready_manager_queue[manager]["max_worker_count"] - tasks_inflight,
+            mdata = ready_manager_queue[manager]
+            tasks_inflight = mdata["total_tasks"]
+            real_capacity: int = min(
+                mdata["free_capacity"]["total_workers"],
+                mdata["max_worker_count"] - tasks_inflight,
             )
-            if real_capacity and ready_manager_queue[manager]["active"]:
-                if scheduler_mode == "hard":
-                    tasks, tids = get_tasks_hard(
-                        pending_task_queue, ready_manager_queue[manager], real_capacity
-                    )
-                else:
-                    tasks, tids = get_tasks_soft(
-                        pending_task_queue,
-                        ready_manager_queue[manager],
-                        real_capacity,
-                        loop=loop,
-                    )
-                if tasks:
-                    log.debug(f"Got {len(tasks)} tasks from queue")
-                    for task_type in tids:
-                        # This line is a set update, not dict update
-                        ready_manager_queue[manager]["tasks"][task_type].update(
-                            tids[task_type]
-                        )
-                    log.debug(
-                        "The tasks on manager {} is {}".format(
-                            manager, ready_manager_queue[manager]["tasks"]
-                        )
-                    )
-                    ready_manager_queue[manager]["total_tasks"] += len(tasks)
-                    if manager not in task_dispatch:
-                        task_dispatch[manager] = []
-                    task_dispatch[manager] += tasks
-                    dispatched_tasks += len(tasks)
-                    log.debug(f"Assigned tasks {tids} to manager {manager}")
-                if ready_manager_queue[manager]["free_capacity"]["total_workers"] > 0:
-                    log.trace(
-                        "Manager {} still has free_capacity {}".format(
-                            manager,
-                            ready_manager_queue[manager]["free_capacity"][
-                                "total_workers"
-                            ],
-                        )
-                    )
-                else:
-                    log.debug(f"Manager {manager} is now saturated")
-                    interesting_managers.remove(manager)
+            if not (real_capacity > 0 and mdata["active"]):
+                interesting_managers.remove(manager)
+                continue
+
+            if scheduler_mode == "hard":
+                tasks, tids = get_tasks_hard(pending_task_queue, mdata, real_capacity)
             else:
+                tasks, tids = get_tasks_soft(
+                    pending_task_queue,
+                    mdata,
+                    real_capacity,
+                    loop=loop,
+                )
+            if tasks:
+                log.debug("Got %s tasks from queue", len(tasks))
+                for task_type in tids:
+                    # This line is a set update, not dict update
+                    mdata["tasks"][task_type].update(tids[task_type])
+                log.debug(f"The tasks on manager %s is {mdata['tasks']}", manager)
+                mdata["total_tasks"] += len(tasks)
+                if manager not in task_dispatch:
+                    task_dispatch[manager] = []
+                task_dispatch[manager] += tasks
+                dispatched_tasks += len(tasks)
+                log.debug("Assigned tasks %s to manager %s", tids, manager)
+            if mdata["free_capacity"]["total_workers"] > 0:
+                log.trace(
+                    "Manager %s still has free_capacity %s",
+                    manager,
+                    mdata["free_capacity"]["total_workers"],
+                )
+            else:
+                log.debug("Manager %s is now saturated", manager)
                 interesting_managers.remove(manager)
 
     log.trace(
-        "The task dispatch of {} loop is {}, in total {} tasks".format(
-            loop, task_dispatch, dispatched_tasks
-        )
+        "The task dispatch of %s loop is %s, in total %s tasks",
+        loop,
+        task_dispatch,
+        dispatched_tasks,
     )
-    return task_dispatch, dispatched_tasks
+    return dispatched_tasks
 
 
-def get_tasks_hard(pending_task_queue, manager_ads, real_capacity):
-    tasks = []
-    tids = collections.defaultdict(set)
-    task_type = manager_ads["worker_type"]
+def get_tasks_hard(
+    pending_task_queue: dict[str, queue.Queue[dict]],
+    manager_ads: dict,
+    real_capacity: int,
+) -> tuple[list[dict], dict[str, set[str]]]:
+    tasks: list[dict] = []
+    tids: dict[str, set[str]] = collections.defaultdict(set)
+    task_type: str = manager_ads["worker_type"]
     if not task_type:
         log.warning(
             "Using hard scheduler mode but with manager worker type unset. "
             "Use soft scheduler mode. Set this in the config."
         )
         return tasks, tids
-    if task_type not in pending_task_queue:
-        log.trace(f"No task of type {task_type}. Exiting task fetching.")
+    task_q = pending_task_queue.get(task_type)
+    if not task_q:
+        log.trace("No task of type %s. Exiting task fetching.", task_type)
         return tasks, tids
 
     # dispatch tasks of available types on manager
-    if task_type in manager_ads["free_capacity"]["free"]:
-        while manager_ads["free_capacity"]["free"][task_type] > 0 and real_capacity > 0:
-            try:
-                x = pending_task_queue[task_type].get(block=False)
-            except queue.Empty:
-                break
-            else:
+    free_cap = manager_ads["free_capacity"]
+    if task_type in free_cap["free"]:
+        try:
+            while real_capacity > 0 and free_cap["free"][task_type] > 0:
+                x = task_q.get(block=False)
                 log.debug(f"Get task {x}")
                 tasks.append(x)
                 tids[task_type].add(x["task_id"])
-                manager_ads["free_capacity"]["free"][task_type] -= 1
-                manager_ads["free_capacity"]["total_workers"] -= 1
+                free_cap["free"][task_type] -= 1
+                free_cap["total_workers"] -= 1
                 real_capacity -= 1
+        except queue.Empty:
+            pass
 
     # dispatch tasks to unused slots based on the manager type
     log.trace("Second round of task fetching in hard mode")
-    while manager_ads["free_capacity"]["free"]["unused"] > 0 and real_capacity > 0:
-        try:
-            x = pending_task_queue[task_type].get(block=False)
-        except queue.Empty:
-            break
-        else:
+    try:
+        while real_capacity > 0 and free_cap["free"]["unused"] > 0:
+            x = task_q.get(block=False)
             log.debug(f"Get task {x}")
             tasks.append(x)
             tids[task_type].add(x["task_id"])
-            manager_ads["free_capacity"]["free"]["unused"] -= 1
-            manager_ads["free_capacity"]["total_workers"] -= 1
+            free_cap["free"]["unused"] -= 1
+            free_cap["total_workers"] -= 1
             real_capacity -= 1
+    except queue.Empty:
+        pass
     return tasks, tids
 
 
-def get_tasks_soft(pending_task_queue, manager_ads, real_capacity, loop="warm"):
+def get_tasks_soft(
+    pending_task_queue: dict[str, queue.Queue[dict]],
+    manager_ads: dict,
+    real_capacity: int,
+    loop: str = "warm",
+) -> tuple[list[dict], dict[str, set[str]]]:
     tasks = []
     tids = collections.defaultdict(set)
 
     # Warm routing to dispatch tasks
+    free_cap = manager_ads["free_capacity"]
     if loop == "warm":
-        for task_type in manager_ads["free_capacity"]["free"]:
+        for task_type in free_cap["free"]:
             # Dispatch tasks that are of the available container types on the manager
             if task_type != "unused":
+                task_q = pending_task_queue.get(task_type)
+                if not task_q:
+                    continue
                 type_inflight = len(manager_ads["tasks"].get(task_type, set()))
                 type_capacity = min(
-                    manager_ads["free_capacity"]["free"][task_type],
-                    manager_ads["free_capacity"]["total"][task_type] - type_inflight,
+                    free_cap["free"][task_type],
+                    free_cap["total"][task_type] - type_inflight,
                 )
-                while (
-                    manager_ads["free_capacity"]["free"][task_type] > 0
-                    and real_capacity > 0
-                    and type_capacity > 0
-                ):
-                    try:
-                        if task_type not in pending_task_queue:
-                            break
-                        x = pending_task_queue[task_type].get(block=False)
-                    except queue.Empty:
-                        break
-                    else:
+                try:
+                    while (
+                        real_capacity > 0
+                        and type_capacity > 0
+                        and free_cap["free"][task_type] > 0
+                    ):
+                        x = task_q.get(block=False)
                         log.debug(f"Get task {x}")
                         tasks.append(x)
                         tids[task_type].add(x["task_id"])
-                        manager_ads["free_capacity"]["free"][task_type] -= 1
-                        manager_ads["free_capacity"]["total_workers"] -= 1
+                        free_cap["free"][task_type] -= 1
+                        free_cap["total_workers"] -= 1
                         real_capacity -= 1
                         type_capacity -= 1
+                except queue.Empty:
+                    pass
             # Dispatch tasks to unused container slots on the manager
             else:
+                task_q = pending_task_queue.get(task_type)  # "unused" queue
+                if not task_q:
+                    log.debug("Unexpectedly non-existent 'unused' queue")
+                    continue
                 task_types = list(pending_task_queue.keys())
                 random.shuffle(task_types)
                 for task_type in task_types:
-                    while (
-                        manager_ads["free_capacity"]["free"]["unused"] > 0
-                        and manager_ads["free_capacity"]["total_workers"] > 0
-                        and real_capacity > 0
-                    ):
-                        try:
-                            x = pending_task_queue[task_type].get(block=False)
-                        except queue.Empty:
-                            break
-                        else:
+                    try:
+                        while (
+                            real_capacity > 0
+                            and free_cap["free"]["unused"] > 0
+                            and free_cap["total_workers"] > 0
+                        ):
+                            x = task_q.get(block=False)
                             log.debug(f"Get task {x}")
                             tasks.append(x)
                             tids[task_type].add(x["task_id"])
-                            manager_ads["free_capacity"]["free"]["unused"] -= 1
-                            manager_ads["free_capacity"]["total_workers"] -= 1
+                            free_cap["free"]["unused"] -= 1
+                            free_cap["total_workers"] -= 1
                             real_capacity -= 1
+                    except queue.Empty:
+                        pass
         return tasks, tids
 
     # Cold routing round: allocate tasks of random types
@@ -232,15 +240,17 @@ def get_tasks_soft(pending_task_queue, manager_ads, real_capacity, loop="warm"):
     task_types = list(pending_task_queue.keys())
     random.shuffle(task_types)
     for task_type in task_types:
-        while manager_ads["free_capacity"]["total_workers"] > 0 and real_capacity > 0:
-            try:
-                x = pending_task_queue[task_type].get(block=False)
-            except queue.Empty:
-                break
-            else:
-                log.debug(f"Get task {x}")
+        task_q = pending_task_queue.get(task_type)
+        if not task_q:
+            continue
+        try:
+            while real_capacity > 0 and free_cap["total_workers"] > 0:
+                x = task_q.get(block=False)
                 tasks.append(x)
                 tids[task_type].add(x["task_id"])
-                manager_ads["free_capacity"]["total_workers"] -= 1
+                free_cap["total_workers"] -= 1
                 real_capacity -= 1
+                log.debug(f"Get task {x}")
+        except queue.Empty:
+            pass
     return tasks, tids

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/worker_map.py
@@ -8,7 +8,9 @@ import time
 from queue import Empty, Queue
 from typing import Any
 
-log = logging.getLogger(__name__)
+from funcx_endpoint.logging_config import FXLogger
+
+log: FXLogger = logging.getLogger(__name__)  # type: ignore
 
 
 class WorkerMap:
@@ -142,10 +144,10 @@ class WorkerMap:
         """
         spin_ups = {}
 
-        log.trace(f"Next Worker Qsize: {len(next_worker_q)}")
-        log.trace(f"Active Workers: {self.active_workers}")
-        log.trace(f"Pending Workers: {self.pending_workers}")
-        log.trace(f"Max Worker Count: {self.max_worker_count}")
+        log.trace("Next Worker Qsize: %s", len(next_worker_q))
+        log.trace("Active Workers: %s", self.active_workers)
+        log.trace("Pending Workers: %s", self.pending_workers)
+        log.trace("Max Worker Count: %s", self.max_worker_count)
 
         if (
             len(next_worker_q) > 0
@@ -245,19 +247,19 @@ class WorkerMap:
         """
         spin_downs = []
         container_switch_count = 0
+        now = time.time()
         for worker_type in self.total_worker_type_counts:
             if worker_type == "unused":
                 continue
             if (
                 check_idle
-                and time.time() - self.worker_idle_since[worker_type]
-                < worker_max_idletime
+                and now - self.worker_idle_since[worker_type] < worker_max_idletime
             ):
-                log.trace(f"Current time: {time.time()}")
-                log.trace(f"Idle since: {self.worker_idle_since[worker_type]}")
                 log.trace(
-                    "Worker type %s has not exceeded maximum idle "
-                    "time %s, continuing",
+                    "Current time: %s (idle since: %s).  Worker type %s has not "
+                    "exceeded maximum idle time %s; continuing",
+                    now,
+                    self.worker_idle_since[worker_type],
                     worker_type,
                     worker_max_idletime,
                 )

--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -218,25 +218,15 @@ def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:
     }
 
 
-def add_trace_level() -> None:
-    """This adds a trace level to the logging system.
+class FXLogger(logging.Logger):
+    TRACE = logging.DEBUG - 5
 
-    See https://stackoverflow.com/questions/2183233
-    """
+    def trace(self, msg, *args, **kwargs):
+        self.log(FXLogger.TRACE, msg, args, **kwargs)
 
-    TRACE = 5
-    logging.TRACE = TRACE  # type: ignore[attr-defined]
 
-    def logForLevel(self, message, *args, **kwargs):
-        if self.isEnabledFor(TRACE):
-            self._log(TRACE, message, args, **kwargs)
-
-    def logToRoot(message, *args, **kwargs):
-        logging.log(TRACE, message, *args, **kwargs)
-
-    logging.addLevelName(TRACE, "TRACE")
-    logging.getLoggerClass().trace = logForLevel  # type: ignore[attr-defined]
-    logging.trace = logToRoot  # type: ignore[attr-defined]
+logging.setLoggerClass(FXLogger)
+logger = logging.getLogger(__name__)
 
 
 def setup_logging(
@@ -246,8 +236,6 @@ def setup_logging(
     debug: bool = False,
     no_color: bool = False,
 ) -> None:
-    add_trace_level()
-
     if logfile is not None:
         config = _get_file_dict_config(logfile, console_enabled, debug, no_color)
     else:

--- a/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/kube_simple.py
@@ -2,9 +2,10 @@ import logging
 import math
 import time
 
+from funcx_endpoint.logging_config import FXLogger
 from funcx_endpoint.strategies.base import BaseStrategy
 
-log = logging.getLogger(__name__)
+log: FXLogger = logging.getLogger(__name__)  # type: ignore
 
 
 class KubeSimpleStrategy(BaseStrategy):
@@ -54,10 +55,10 @@ class KubeSimpleStrategy(BaseStrategy):
         parallelism = self.interchange.provider.parallelism
 
         active_tasks = self.interchange.get_total_tasks_outstanding()
-        log.trace(f"Pending tasks : {active_tasks}")
+        log.trace("Pending tasks : %s", active_tasks)
 
         status = self.interchange.provider_status()
-        log.trace(f"Provider status : {status}")
+        log.trace("Provider status : %s", status)
 
         for task_type in active_tasks.keys():
             active_pods = status.get(task_type, 0)

--- a/funcx_endpoint/tests/integration/funcx_endpoint/conftest.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/conftest.py
@@ -6,8 +6,6 @@ import pytest
 import responses
 from pika.exchange_type import ExchangeType
 
-from funcx_endpoint.logging_config import add_trace_level
-
 
 @pytest.fixture(autouse=True)
 def _autouse_responses():
@@ -17,11 +15,6 @@ def _autouse_responses():
 
     responses.stop()
     responses.reset()
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _set_logging_trace_level():
-    add_trace_level()
 
 
 # mock logging config to do nothing


### PR DESCRIPTION
The initial change is to the `Interchange.start()` method signature, which then opens a number of minor items to mypy.  One of those changes is the `log.trace` method; address by subclassing the logger.  Mypy has learned a little bit since ~a year ago, so the only trickery here is in the `import`:

    from funcx_endpoint.logging_config import FXLogger

    log: FXLogger = logging.getLogger(__name__)  # type: ignore

`logging_config.py` tells the logging system to return FXLogger, but `mypy` doesn't infer that deeply.  So, promise it that "we know what we're doing," and then `.trace()` can exist.

The other changes are of the "while here" variety:

 - don't waste time interpolating strings for messages that won't be emitted!

 - cache lookups for easier reading and to simplify some mypy-isms

 - use if-guard style in a couple of places to reduce indent

## Type of change

- Code maintenance/cleanup