### PR TITLE
Limit interface binding

### DIFF
--- a/changelog.d/20230106_132001_yadudoc1729_limit_interface_binding.rst
+++ b/changelog.d/20230106_132001_yadudoc1729_limit_interface_binding.rst
@@ -1,0 +1,41 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- `HighThroughputExecutor.address` now accepts only IPv4 and IPv6. Example configs
+  have been updated to use `parsl.address_by_interface` instead of `parsl.address_by_hostname`.
+  Please note that following this change, endpoints that were previously configured
+  with `HighThroughputExecutor(address=address_by_hostname())` will now raise a `ValueError`
+  and will need updating.
+
+- For better security, `HighThroughputExecutor` now listens only on a specific interface
+  rather than all interfaces.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/docs/configs/bebop.py
+++ b/docs/configs/bebop.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
 
@@ -19,7 +19,7 @@ user_opts = {
 config = Config(
     executors=[
         HighThroughputExecutor(
-            address=address_by_hostname(),
+            address=address_by_interface('ib0'),
             provider=SlurmProvider(
                 partition=user_opts['bebop']['partition'],
                 launcher=SrunLauncher(),

--- a/docs/configs/cooley.py
+++ b/docs/configs/cooley.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import MpiExecLauncher
 from parsl.providers import CobaltProvider
 
@@ -22,7 +22,7 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=2,
             worker_debug=False,
-            address=address_by_hostname(),
+            address=address_by_interface('ib0'),
             provider=CobaltProvider(
                 queue='default',
                 account=user_opts['cooley']['account'],

--- a/docs/configs/frontera.py
+++ b/docs/configs/frontera.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
 
@@ -11,9 +11,9 @@ from funcx_endpoint.executors import HighThroughputExecutor
 user_opts = {
     'frontera': {
         'worker_init': 'source ~/setup_funcx_test_env.sh',
-        'scheduler_options': '#SBATCH -A MCB20024',
+        'account': 'EAR22001',
         'partition': 'development',
-
+        'scheduler_options': '',
     }
 }
 
@@ -22,8 +22,9 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=2,
             worker_debug=False,
-            address=address_by_hostname(),
+            address=address_by_interface('ib0'),
             provider=SlurmProvider(
+                account=user_opts['frontera']['account'],
                 partition=user_opts['frontera']['partition'],
                 launcher=SrunLauncher(),
 

--- a/docs/configs/perlmutter.py
+++ b/docs/configs/perlmutter.py
@@ -19,7 +19,7 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             worker_debug=False,
-            address=address_by_interface('bond0.144'),
+            address=address_by_interface('nmn0'),
             provider=SlurmProvider(
                 partition='GPU',  # Partition / QOS
 

--- a/docs/configs/polaris.py
+++ b/docs/configs/polaris.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import SingleNodeLauncher
 from parsl.providers import PBSProProvider
 
@@ -24,7 +24,7 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=1,
             strategy=SimpleStrategy(max_idletime=300),
-            address=address_by_hostname(),
+            address=address_by_interface('bond0'),
             provider=PBSProProvider(
                 launcher=SingleNodeLauncher(),
                 account=user_opts['polaris']['account'],

--- a/docs/configs/theta.py
+++ b/docs/configs/theta.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import AprunLauncher
 from parsl.providers import CobaltProvider
 
@@ -22,7 +22,7 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=1,
             worker_debug=False,
-            address=address_by_hostname(),
+            address=address_by_interface('vlan2360'),
             provider=CobaltProvider(
                 queue='debug-flat-quad',
                 account=user_opts['theta']['account'],

--- a/docs/configs/theta_singularity.py
+++ b/docs/configs/theta_singularity.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import AprunLauncher
 from parsl.providers import CobaltProvider
 
@@ -22,7 +22,7 @@ config = Config(
         HighThroughputExecutor(
             max_workers_per_node=1,
             worker_debug=False,
-            address=address_by_hostname(),
+            address=address_by_interface('vlan2360'),
             scheduler_mode='soft',
             worker_mode='singularity_reuse',
             container_type='singularity',

--- a/docs/configs/uchicago_ai_cluster.py
+++ b/docs/configs/uchicago_ai_cluster.py
@@ -1,4 +1,4 @@
-from parsl.addresses import address_by_hostname
+from parsl.addresses import address_by_interface
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
 
@@ -23,7 +23,7 @@ config = Config(
         HighThroughputExecutor(
             label="fe.cs.uchicago",
             worker_debug=False,
-            address=address_by_hostname(),
+            address=address_by_interface('ens2f1'),
             provider=SlurmProvider(
                 partition='general',
 

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -366,13 +366,13 @@ class HighThroughputExecutor(RepresentationMixin):
     ):
         """Create the Interchange process and connect to it."""
         self.outgoing_q = zmq_pipes.TasksOutgoing(
-            "0.0.0.0", self.interchange_port_range
+            "127.0.0.1", self.interchange_port_range
         )
         self.incoming_q = zmq_pipes.ResultsIncoming(
-            "0.0.0.0", self.interchange_port_range
+            "127.0.0.1", self.interchange_port_range
         )
         self.command_client = zmq_pipes.CommandClient(
-            "0.0.0.0", self.interchange_port_range
+            "127.0.0.1", self.interchange_port_range
         )
 
         self.is_alive = True

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -7,6 +7,7 @@ to be addressed.
 from __future__ import annotations
 
 import concurrent.futures
+import ipaddress
 import logging
 import multiprocessing
 import os
@@ -295,6 +296,15 @@ class HighThroughputExecutor(RepresentationMixin):
         self.cores_per_worker = cores_per_worker
         self.endpoint_id = endpoint_id
         self._task_counter = 0
+
+        try:
+            ipaddress.ip_address(address=address)
+        except Exception:
+            log.critical(
+                f"Invalid address supplied: {address}. "
+                "Please use a valid IPv4 or IPv6 address"
+            )
+            raise
         self.address = address
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -424,7 +424,7 @@ class HighThroughputExecutor(RepresentationMixin):
             name="Executor-Interchange",
             args=(comm_q,),
             kwargs={
-                "client_address": "127.0.0.1", # executor and ix are on the same node
+                "client_address": "127.0.0.1",  # executor and ix are on the same node
                 "client_ports": (
                     self.outgoing_q.port,
                     self.incoming_q.port,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -424,7 +424,7 @@ class HighThroughputExecutor(RepresentationMixin):
             name="Executor-Interchange",
             args=(comm_q,),
             kwargs={
-                "client_address": self.address,
+                "client_address": "127.0.0.1", # executor and ix are on the same node
                 "client_ports": (
                     self.outgoing_q.port,
                     self.incoming_q.port,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -274,9 +274,7 @@ class Interchange:
             self.worker_task_port = self.worker_ports[0]
             self.worker_result_port = self.worker_ports[1]
 
-            self.task_outgoing.bind(
-                f"{worker_bind_address}:{self.worker_task_port}"
-            )
+            self.task_outgoing.bind(f"{worker_bind_address}:{self.worker_task_port}")
             self.results_incoming.bind(
                 f"{worker_bind_address}:{self.worker_result_port}"
             )

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -268,26 +268,28 @@ class Interchange:
         self.results_incoming.set_hwm(0)
 
         self.endpoint_id = endpoint_id
+        worker_bind_address = f"tcp://{self.interchange_address}"
+        log.info(f"Interchange binding worker ports to {worker_bind_address}")
         if self.worker_ports:
             self.worker_task_port = self.worker_ports[0]
             self.worker_result_port = self.worker_ports[1]
 
             self.task_outgoing.bind(
-                f"tcp://{self.interchange_address}:{self.worker_task_port}"
+                f"{worker_bind_address}:{self.worker_task_port}"
             )
             self.results_incoming.bind(
-                f"tcp://{self.interchange_address}:{self.worker_result_port}"
+                f"{worker_bind_address}:{self.worker_result_port}"
             )
 
         else:
             self.worker_task_port = self.task_outgoing.bind_to_random_port(
-                "tcp://*",
+                worker_bind_address,
                 min_port=worker_port_range[0],
                 max_port=worker_port_range[1],
                 max_tries=100,
             )
             self.worker_result_port = self.results_incoming.bind_to_random_port(
-                "tcp://*",
+                worker_bind_address,
                 min_port=worker_port_range[0],
                 max_port=worker_port_range[1],
                 max_tries=100,

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/interchange.py
@@ -272,8 +272,12 @@ class Interchange:
             self.worker_task_port = self.worker_ports[0]
             self.worker_result_port = self.worker_ports[1]
 
-            self.task_outgoing.bind(f"tcp://*:{self.worker_task_port}")
-            self.results_incoming.bind(f"tcp://*:{self.worker_result_port}")
+            self.task_outgoing.bind(
+                f"tcp://{self.interchange_address}:{self.worker_task_port}"
+            )
+            self.results_incoming.bind(
+                f"tcp://{self.interchange_address}:{self.worker_result_port}"
+            )
 
         else:
             self.worker_task_port = self.task_outgoing.bind_to_random_port(

--- a/funcx_endpoint/tests/unit/test_bad_endpoint_config.py
+++ b/funcx_endpoint/tests/unit/test_bad_endpoint_config.py
@@ -1,0 +1,19 @@
+import pytest
+
+from funcx_endpoint.executors.high_throughput.executor import HighThroughputExecutor
+
+invalid_addresses = ["localhost", "login1.theta.alcf.anl.gov", "*"]
+
+
+@pytest.mark.parametrize("address", invalid_addresses)
+def test_invalid_address(address):
+    with pytest.raises(ValueError):
+        HighThroughputExecutor(address=address)
+
+
+valid_addresses = ["192.168.64.12", "fe80::e643:4bff:fe61:8f72", "129.114.44.12"]
+
+
+@pytest.mark.parametrize("address", valid_addresses)
+def test_valid_address(address):
+    HighThroughputExecutor(address=address)


### PR DESCRIPTION
# Description

Rather than have ZMQ bind to all interfaces with `tcp://*:port` this PR uses the address specified via config to limit binding to a specific interface. The one major downside to this is that the bind requires either an IP address or an interface name, and every config example that uses `address_by_hostname()` is going to be broken following this change.

Ref: http://api.zeromq.org/2-1:zmq-tcp 

@ericmjonas, Could you give this a test run on frontera, please? 

Fixes # [sc-20670]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
