### PR TITLE
Doc update to clarify that the binder link is a hosted jupyter notebook.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 **funcX** client and endpoint software releases are available on `PyPI <https://pypi.org/project/funcx/>`_.
 
-You can try funcX on `Binder <https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb>`_
+You can try funcX on a hosted Jupyter notebook with `Binder <https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb>`_
 
 
 Installation


### PR DESCRIPTION
# Description

This PR updates the quickstart to clarify that the binder link is to a jupyter notebook.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
