### PR TITLE
Remove unnecessary use of EP name

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -317,7 +317,6 @@ class Endpoint:
             )
 
             Endpoint.daemon_launch(
-                self.name,
                 endpoint_uuid,
                 endpoint_dir,
                 endpoint_config,
@@ -328,7 +327,6 @@ class Endpoint:
 
     @staticmethod
     def daemon_launch(
-        ep_name,
         endpoint_uuid,
         endpoint_dir,
         endpoint_config: Config,
@@ -341,7 +339,6 @@ class Endpoint:
             reg_info=reg_info,
             endpoint_id=endpoint_uuid,
             endpoint_dir=endpoint_dir,
-            endpoint_name=ep_name,
             funcx_client=funcx_client,
             result_store=result_store,
             logdir=endpoint_dir,

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -55,7 +55,6 @@ class EndpointInterchange:
         logdir=".",
         endpoint_id=None,
         endpoint_dir=".",
-        endpoint_name="default",
         funcx_client: FuncXClient | None = None,
         result_store: ResultStore | None = None,
     ):
@@ -77,11 +76,8 @@ class EndpointInterchange:
         endpoint_id : str
              Identity string that identifies the endpoint to the broker
 
-        endpoint_dir : str
+        endpoint_dir : pathlib.Path
              Endpoint directory path to store registration info in
-
-        endpoint_name : str
-             Name of endpoint
 
         funcx_client_options : Dict
              FuncXClient initialization options
@@ -95,7 +91,6 @@ class EndpointInterchange:
         self.config = config
 
         self.endpoint_dir = endpoint_dir
-        self.endpoint_name = endpoint_name
 
         if funcx_client is None:
             funcx_client = FuncXClient()

--- a/funcx_endpoint/funcx_endpoint/endpoint/result_store.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/result_store.py
@@ -43,8 +43,7 @@ class ResultStore:
     """
 
     def __init__(self, endpoint_dir: str | pathlib.Path):
-        self.endpoint_dir = pathlib.Path(endpoint_dir)
-        self.data_path = self.endpoint_dir / "unacked_results"
+        self.data_path = pathlib.Path(endpoint_dir) / "unacked_results"
         self.data_path.mkdir(exist_ok=True)
 
         self.data_path.chmod(mode=0o0700)

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -28,8 +28,6 @@ def _fake_http_response(*, status: int = 200, method: str = "GET") -> requests.R
 class TestStart:
     @pytest.fixture(autouse=True)
     def test_setup_teardown(self, fs):
-        # Code that will run before your test, for example:
-
         funcx_dir = f"{os.getcwd()}"
         config_dir = pathlib.Path(funcx_dir) / "mock_endpoint"
         assert not config_dir.exists()
@@ -37,10 +35,7 @@ class TestStart:
         # pyfakefs will take care of newly created files, not existing config
         fs.add_real_file(default_config.__file__)
 
-        # A test function will be run at this point
         yield
-        # Code that will run after your test, for example:
-        # shutil.rmtree(config_dir)
 
     def test_configure(self):
         manager = Endpoint(funcx_dir=os.getcwd())


### PR DESCRIPTION
Following the thread that the name _is the same as_ the EP configuration directory, there's no need to pass it around.  Since we're already passing the configuration directory around, just calculate the name when/if needed.

While here, move to some more use of `pathlib`, which engenders a nice simplification in `register_endpoint` as well.

## Type of change

- Code maintenance/cleanup
