### PR TITLE
Shutdown after N failures

### DIFF
--- a/changelog.d/20230113_121808_kevin_fail_count_then_bail.rst
+++ b/changelog.d/20230113_121808_kevin_fail_count_then_bail.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The funcX Endpoint will now shutdown after 5 consecutive failures to
+  initialize.  (The previous behavior was to try indefinitely, even if the
+  error was unrecoverable.)

--- a/funcx_endpoint/tests/unit/test_endpointinterchange.py
+++ b/funcx_endpoint/tests/unit/test_endpointinterchange.py
@@ -1,24 +1,32 @@
+import random
 from unittest.mock import MagicMock
 
+import pytest
+
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
+from funcx_endpoint.endpoint.utils.config import Config
+
+_mock_base = "funcx_endpoint.endpoint.interchange."
 
 
-def test_main_exception_always_quiesces(mocker, tmp_path):
-    false_true_g = iter((False, False, True))
+def test_main_exception_always_quiesces(mocker, fs):
+    num_iterations = random.randint(1, 10)
+
+    # [False, False] * num because _kill_event and _quiesce_event are the same mock;
+    #  .is_set() is called twice per loop
+    is_set_returns = [False, False] * num_iterations + [True]
+    false_true_g = iter(is_set_returns)
 
     def false_true():
         return next(false_true_g)
 
-    mock_conf = MagicMock()
-    mocker.patch("funcx_endpoint.endpoint.interchange.FuncXClient")
-    mocker.patch("funcx_endpoint.endpoint.interchange.multiprocessing")
-    mocker.patch("funcx_endpoint.endpoint.interchange.mpQueue")
+    mocker.patch(f"{_mock_base}multiprocessing")
+    mocker.patch(f"{_mock_base}mpQueue")
     ei = EndpointInterchange(
-        config=mock_conf,
-        funcx_client=mocker.Mock(),
+        config=Config(executors=[]),
+        funcx_client="stub",
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
-        logdir=str(tmp_path),
-        endpoint_dir=str(tmp_path),
+        reconnect_attempt_limit=num_iterations + 10,
     )
     ei._task_puller_proc = MagicMock()
     ei._start_threads_and_main = MagicMock()
@@ -26,4 +34,41 @@ def test_main_exception_always_quiesces(mocker, tmp_path):
     ei._kill_event.is_set = false_true
     ei.start()
 
-    ei._quiesce_event.set.assert_called()
+    assert ei._quiesce_event.set.called
+    assert ei._quiesce_event.set.call_count == num_iterations
+    assert ei._start_threads_and_main.call_count == num_iterations
+
+
+@pytest.mark.parametrize("reconnect_attempt_limit", [-1, 0, 1, 2, 3, 5, 10])
+def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit):
+    num_iterations = reconnect_attempt_limit * 2 + 5  # overkill "just to be sure"
+
+    # [False, False] * num because _kill_event and _quiesce_event are the same mock;
+    #  .is_set() is called twice per loop
+    is_set_returns = [False, False] * num_iterations + [True]
+    false_true_g = iter(is_set_returns)
+
+    def false_true():
+        return next(false_true_g)
+
+    mocker.patch(f"{_mock_base}multiprocessing")
+    mocker.patch(f"{_mock_base}mpQueue")
+    mock_log = mocker.patch(f"{_mock_base}log")
+    ei = EndpointInterchange(
+        config=Config(executors=[]),
+        funcx_client="stub",
+        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        reconnect_attempt_limit=reconnect_attempt_limit,
+    )
+    ei._task_puller_proc = MagicMock()
+    ei._start_threads_and_main = MagicMock()
+    ei._start_threads_and_main.side_effect = Exception("Woot")
+    ei._kill_event.is_set = false_true
+    ei.start()
+
+    reconnect_attempt_limit = max(1, reconnect_attempt_limit)  # checking boundary
+    assert ei._start_threads_and_main.call_count == reconnect_attempt_limit
+
+    expected_msg = f"Failed {reconnect_attempt_limit} consecutive"
+    assert mock_log.critical.called
+    assert expected_msg in mock_log.critical.call_args[0][0]


### PR DESCRIPTION
Rather than continuously retrying, shutdown the endpoint if a heartbeat log message iteration is not achieved after N attempts.

Arbitrarily choose N=5 as default.

## Type of change

- New feature (non-breaking change that adds functionality)