### PR TITLE
Include the -k doe flag for polaris

### DIFF
--- a/docs/configs/polaris.py
+++ b/docs/configs/polaris.py
@@ -13,7 +13,7 @@ user_opts = {
     'polaris': {
         # Node setup: activate necessary conda environment and such.
         'worker_init': '',
-        'scheduler_options': '#PBS -l filesystems=home:grand:eagle',
+        'scheduler_options': '#PBS -l filesystems=home:grand:eagle\n#PBS -k doe',
         # ALCF allocation to use
         'account': '',
     }


### PR DESCRIPTION
# Description

An ALCF update has made it mandatory for funcX endpoints to include a new PBS command specifying -k doe. This adds it to the docs. Endpoints do not work with polaris queues without it.

## Type of change
- Documentation update
