### PR TITLE
funcx error fix

### DIFF
--- a/funcx_sdk/funcx/errors/error_types.py
+++ b/funcx_sdk/funcx/errors/error_types.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import textwrap
+import time
 
 
 class FuncxError(Exception):
@@ -58,9 +61,10 @@ class FuncxTaskExecutionFailed(Exception):
     Error result from the remote end, wrapped as an exception object
     """
 
-    def __init__(self, remote_data: str, completion_t: str):
+    def __init__(self, remote_data: str, completion_t: str | None = None):
         self.remote_data = remote_data
-        self.completion_t = completion_t
+        # Fill in completion time if missing
+        self.completion_t = completion_t or str(time.time())
 
     def __str__(self) -> str:
         return "\n" + textwrap.indent(self.remote_data, "    ")

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -8,8 +8,6 @@ import typing as t
 import uuid
 import warnings
 
-from globus_sdk.exc.api import GlobusAPIError
-
 from funcx.errors import FuncxTaskExecutionFailed, SerializationError, TaskPending
 from funcx.sdk._environments import (
     get_web_service_url,
@@ -446,10 +444,12 @@ class FuncXClient:
                 # this method of handling errors for a batch response is not
                 # ideal, as it will raise any error in the multi-response,
                 # but it will do until batch_run is deprecated in favor of Executer
+                # Note that some errors may already be caught and raised
+                # by funcx.sdk.client.request as GlobusAPIError
 
                 # Checking for 'Failed' is how FuncxResponseError.unpack
                 # originally checked for errors.
-                raise GlobusAPIError(result)
+                raise FuncxTaskExecutionFailed(result.get("reason"))
 
         if self.asynchronous:
             task_group_id = r["task_group_id"]

--- a/funcx_sdk/funcx/sdk/executor.py
+++ b/funcx_sdk/funcx/sdk/executor.py
@@ -481,12 +481,12 @@ class FuncXExecutor(concurrent.futures.Executor):
                                 fut.set_result(deserialize(task["result"]))
                             else:
                                 exc = FuncxTaskExecutionFailed(
-                                    task["exception"], completed_t or "0"
+                                    task["exception"], completed_t
                                 )
                                 fut.set_exception(exc)
                         except Exception as exc:
                             funcx_err = FuncxTaskExecutionFailed(
-                                "Failed to set result or exception", str(time.time())
+                                "Failed to set result or exception"
                             )
                             funcx_err.__cause__ = exc
                             fut.set_exception(funcx_err)


### PR DESCRIPTION
This fixes an issue where raising GlobusAPIError didn't have the correct argument, so now raising a locally defined FuncX error instead.

Also, refactored current usage a bit to centralize defaulting to 'now' for completion_time of the error in the class itself instead of all its callers.