### PR TITLE
Add methods for retrieving endpoint metadata

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -570,6 +570,25 @@ class FuncXClient:
         return r.data
 
     @requires_login
+    def get_endpoint_metadata(self, endpoint_uuid):
+        """Get the metadata for an endpoint.
+
+        Parameters
+        ----------
+        endpoint_uuid : str
+            UUID of the endpoint in question
+
+        Returns
+        -------
+        dict
+            Informational fields about the metadata, such as IP, hostname, and
+            configuration values. If there were any issues deserializing this data, may
+            also include an "errors" key.
+        """
+        r = self.web_client.get_endpoint_metadata(endpoint_uuid)
+        return r.data
+
+    @requires_login
     def get_endpoints(self):
         """Get a list of all endpoints owned by the current user across all systems.
 

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -202,6 +202,11 @@ class FuncxWebClient(globus_sdk.BaseClient):
     ) -> globus_sdk.GlobusHTTPResponse:
         return self.get(f"endpoints/{endpoint_id}/status")
 
+    def get_endpoint_metadata(
+        self, endpoint_id: ID_PARAM_T
+    ) -> globus_sdk.GlobusHTTPResponse:
+        return self.get(f"endpoints/{endpoint_id}")
+
     def get_endpoints(self) -> globus_sdk.GlobusHTTPResponse:
         return self.get("/endpoints")
 


### PR DESCRIPTION
# Description

Adds a method to the `web-client` and to the `client` for accessing the new `GET /endpoints/{uuid}` API endpoint introduced in https://github.com/globusonline/funcx-services/pull/211.

[sc-20196]

## Type of change

- New feature (non-breaking change that adds functionality)
