### PR TITLE
Fix safety check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
       - name: install requirements
         run: |
           python -m pip install -U pip setuptools wheel
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: build docs
@@ -44,9 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: install requirements
         run: |
+          python -m pip install --upgrade setuptools
           python -m pip install './funcx_sdk'
           python -m pip install './funcx_endpoint'
           python -m pip install safety
@@ -62,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -U pip setuptools
@@ -87,7 +90,7 @@ jobs:
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -U pip setuptools


### PR DESCRIPTION
Fixes [failing safety check](https://github.com/funcx-faas/funcX/actions/runs/3969447847/jobs/6803954222) ([CVE-2022-40897](https://pyup.io/v/52495/f17/)), and updates our overall usage of the `setup-python` action