### PR TITLE
Robustify task processing

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -4,9 +4,8 @@ import logging
 import pickle
 import uuid
 
-from funcx_common.messagepack import InvalidMessageError
 from funcx_common.messagepack import Message as OutgoingMessage
-from funcx_common.messagepack import pack, unpack
+from funcx_common.messagepack import pack
 from funcx_common.messagepack.message_types import (
     EPStatusReport as OutgoingEPStatusReport,
 )
@@ -20,7 +19,6 @@ from funcx_common.messagepack.message_types import TaskTransition
 from funcx_endpoint.executors.high_throughput.messages import (
     EPStatusReport as InternalEPStatusReport,
 )
-from funcx_endpoint.executors.high_throughput.messages import Message as InternalMessage
 from funcx_endpoint.executors.high_throughput.messages import Task as InternalTask
 
 logger = logging.getLogger(__name__)
@@ -66,25 +64,10 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
     return message
 
 
-def try_convert_from_messagepack(message: bytes) -> bytes:
-    try:
-        unpacked = unpack(message)
-    except InvalidMessageError:
-        # message isn't in messagepack form,
-        # assume it's already in internal message form
-        return message
-
-    internal_message: InternalMessage | None = None
-
-    if isinstance(unpacked, OutgoingTask):
-        container_id = "RAW" if unpacked.container_id is None else unpacked.container_id
-        internal_message = InternalTask(
-            task_id=str(unpacked.task_id),
-            container_id=str(container_id),
-            task_buffer=unpacked.task_buffer,
-        )
-
-    if internal_message:
-        message = internal_message.pack()
-
-    return message
+def convert_to_internaltask(message: OutgoingTask) -> bytes:
+    container_id = "RAW" if message.container_id is None else message.container_id
+    return InternalTask(
+        task_id=str(message.task_id),
+        container_id=str(container_id),
+        task_buffer=message.task_buffer,
+    ).pack()

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_messages_compat.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_messages_compat.py
@@ -1,7 +1,7 @@
 import pickle
 import uuid
 
-from funcx_common.messagepack import pack, unpack
+from funcx_common.messagepack import unpack
 from funcx_common.messagepack.message_types import (
     EPStatusReport as OutgoingEPStatusReport,
 )
@@ -10,7 +10,7 @@ from funcx_common.messagepack.message_types import TaskTransition
 from funcx_common.tasks.constants import ActorName, TaskState
 
 from funcx_endpoint.endpoint.messages_compat import (
-    try_convert_from_messagepack,
+    convert_to_internaltask,
     try_convert_to_messagepack,
 )
 from funcx_endpoint.executors.high_throughput.messages import (
@@ -60,9 +60,8 @@ def test_external_task_to_internal_task():
     external = OutgoingTask(
         task_id=task_id, container_id=container_id, task_buffer=task_buffer
     )
-    message = pack(external)
 
-    incoming = try_convert_from_messagepack(message)
+    incoming = convert_to_internaltask(external)
     internal = InternalMessage.unpack(incoming)
 
     assert isinstance(internal, InternalTask)
@@ -76,9 +75,8 @@ def test_external_task_without_container_id_converts_to_RAW():
     task_buffer = b"task_buffer"
 
     external = OutgoingTask(task_id=task_id, container_id=None, task_buffer=task_buffer)
-    message = pack(external)
 
-    incoming = try_convert_from_messagepack(message)
+    incoming = convert_to_internaltask(external)
     internal = InternalMessage.unpack(incoming)
 
     assert isinstance(internal, InternalTask)


### PR DESCRIPTION
Try to *first* collect the task_id so as to be able to be more robust in error handling: if we're not going to be able to process the task, let the end-user's waiting future  know about it, rather than silently dropping it.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup