### PR TITLE
Auto-shutdown FuncXExecutor objects at script end

### DIFF
--- a/changelog.d/20230124_175331_kevin_readd_atexit_handler_to_fxexecutor.rst
+++ b/changelog.d/20230124_175331_kevin_readd_atexit_handler_to_fxexecutor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- Initiate shutdown of any currently running FuncXExecutor objects when the main
+  thread ends (a.k.a., "end of script").  This follows the same behavior as
+  both ``ThreadPoolExecutor`` and ``ProcessPoolExecutor``.

--- a/funcx_sdk/tests/integration/test_executor_int.py
+++ b/funcx_sdk/tests/integration/test_executor_int.py
@@ -1,4 +1,7 @@
 import os
+import subprocess
+import sys
+import textwrap
 from unittest import mock
 
 import pytest
@@ -26,3 +29,30 @@ def test_resultwatcher_graceful_shutdown():
     try_assert(lambda: not rw._connection or rw._connection.is_closed)
     try_assert(lambda: not rw.is_alive())
     fxe.shutdown()
+
+
+def test_executor_atexit_handler_catches_all_instances(tmp_path):
+    test_script = tmp_path / "test.py"
+    script_content = textwrap.dedent(
+        """
+        import random
+        from funcx import FuncXExecutor
+        from funcx.sdk.executor import _REGISTERED_FXEXECUTORS
+
+        fxc = " a fake funcx_client"
+        num_executors = random.randrange(1, 10)
+        for i in range(num_executors):
+            FuncXExecutor(funcx_client=fxc)  # start N threads, none shutdown
+        fxe = FuncXExecutor(funcx_client=fxc)  # intentionally overwritten
+        fxe = FuncXExecutor(funcx_client=fxc)
+
+        num_executors += 2
+        assert len(_REGISTERED_FXEXECUTORS) == num_executors, (
+            f"Verify test setup: {len(_REGISTERED_FXEXECUTORS)} != {num_executors}"
+        )
+        fxe.shutdown()  # only shutting down _last_ instance.  Should still exit cleanly
+        """
+    )
+    test_script.write_text(script_content)
+    res = subprocess.run([sys.executable, str(test_script)], timeout=5)
+    assert res.returncode == 0

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -463,7 +463,7 @@ def test_reload_handles_deseralization_error_gracefully(fxexecutor):
 
 
 @pytest.mark.parametrize("batch_size", tuple(range(1, 11)))
-def test_task_submitter_respects_batch_size(fxexecutor, batch_size):
+def test_task_submitter_respects_batch_size(fxexecutor, batch_size: int):
     fxc, fxe = fxexecutor
 
     fxc.create_batch.side_effect = mock.MagicMock


### PR DESCRIPTION
The normal `atexit` handler will not work because there are non-daemon threads still about at script end.  Consequently, use a background thread "watcher" to watch the *main* thread and signal all known executors to shutdown.

[sc-21525]

## Type of change

- New feature (non-breaking change that adds functionality)
