### PR TITLE
Remove use of FuncXClient from interchanges

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -325,7 +325,6 @@ class Endpoint:
                 endpoint_dir,
                 endpoint_config,
                 reg_info,
-                fx_client,
                 result_store,
             )
 
@@ -335,7 +334,6 @@ class Endpoint:
         endpoint_dir,
         endpoint_config: Config,
         reg_info,
-        funcx_client: FuncXClient,
         result_store: ResultStore,
     ):
         interchange = EndpointInterchange(
@@ -343,7 +341,6 @@ class Endpoint:
             reg_info=reg_info,
             endpoint_id=endpoint_uuid,
             endpoint_dir=endpoint_dir,
-            funcx_client=funcx_client,
             result_store=result_store,
             logdir=endpoint_dir,
         )

--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -64,10 +64,16 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
     return message
 
 
-def convert_to_internaltask(message: OutgoingTask) -> bytes:
-    container_id = "RAW" if message.container_id is None else message.container_id
+def convert_to_internaltask(message: OutgoingTask, container_type: str | None) -> bytes:
+    container_loc = "RAW"
+    if message.container:
+        for img in message.container.images:
+            if img.image_type == container_type:
+                container_loc = img.location
+                break
+
     return InternalTask(
         task_id=str(message.task_id),
-        container_id=str(container_id),
+        container_id=container_loc,
         task_buffer=message.task_buffer,
     ).pack()

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -23,7 +23,6 @@ from parsl.executors.errors import BadMessage, ScalingFailed
 from parsl.providers import LocalProvider
 from parsl.utils import RepresentationMixin
 
-from funcx import FuncXClient
 from funcx.serialize import FuncXSerializer
 from funcx_endpoint.executors.high_throughput import interchange, zmq_pipes
 from funcx_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
@@ -354,11 +353,7 @@ class HighThroughputExecutor(RepresentationMixin):
                 "--container_image={container_image} "
             )
 
-    def start(
-        self,
-        results_passthrough: multiprocessing.Queue = None,
-        funcx_client: FuncXClient = None,
-    ):
+    def start(self, results_passthrough: multiprocessing.Queue = None):
         """Create the Interchange process and connect to it."""
         self.outgoing_q = zmq_pipes.TasksOutgoing(
             "127.0.0.1", self.interchange_port_range
@@ -384,8 +379,6 @@ class HighThroughputExecutor(RepresentationMixin):
         self._executor_bad_state = threading.Event()
         self._executor_exception = None
         self._start_queue_management_thread()
-
-        self.funcx_client = funcx_client
 
         log.info("Attempting local interchange start")
         self._start_local_interchange_process()
@@ -447,7 +440,6 @@ class HighThroughputExecutor(RepresentationMixin):
                 "logdir": os.path.join(self.run_dir, self.label),
                 "suppress_failure": self.suppress_failure,
                 "endpoint_id": self.endpoint_id,
-                "funcx_client": self.funcx_client,
             },
         )
         self.queue_proc.start()

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -5,8 +5,8 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
-    "funcx>=1.0.8a",
-    "funcx-common==0.0.23",
+    "funcx>=1.0.8",
+    "funcx-common==0.0.24",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
@@ -23,9 +23,6 @@ def funcx_dir(tmp_path):
 
 
 def test_endpoint_id(mocker, funcx_dir):
-    mock_client = mocker.patch(f"{_MOCK_BASE}FuncXClient")
-    mock_client.return_value = None
-
     manager = Endpoint(funcx_dir=str(funcx_dir))
     config_dir = funcx_dir / "mock_endpoint"
 
@@ -47,11 +44,10 @@ def test_endpoint_id(mocker, funcx_dir):
         assert executor.endpoint_id == "mock_endpoint_id"
 
 
-def test_start_requires_pre_registered(mocker, funcx_dir):
+def test_start_requires_pre_registered(funcx_dir):
     with pytest.raises(TypeError):
         EndpointInterchange(
             config=Config(),
-            funcx_client=mocker.Mock(),
             reg_info=None,
             endpoint_id="mock_endpoint_id",
         )
@@ -60,7 +56,6 @@ def test_start_requires_pre_registered(mocker, funcx_dir):
 def test_invalid_message_result_returned(mocker):
     ei = EndpointInterchange(
         config=Config(executors=[mocker.Mock(endpoint_id=None)]),
-        funcx_client=mocker.Mock(),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
     )
 

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange_with_rabbit.py
@@ -4,7 +4,6 @@ import multiprocessing
 import time
 import uuid
 import warnings
-from unittest import mock
 
 import dill
 import pika
@@ -29,9 +28,7 @@ def run_interchange_process(
     a random endpoint id, and the mocked registration info.
     """
 
-    def run_it(reg_info: dict, endpoint_uuid, endpoint_dir, mock_funcx_cli=True):
-        fake_client = mock.Mock() if mock_funcx_cli else None
-
+    def run_it(reg_info: dict, endpoint_uuid, endpoint_dir):
         mock_exe = MockExecutor()
         mock_exe.endpoint_id = endpoint_uuid
 
@@ -41,7 +38,6 @@ def run_interchange_process(
             config=config,
             endpoint_id=endpoint_uuid,
             reg_info=reg_info,
-            funcx_client=fake_client,
             endpoint_dir=endpoint_dir,
         )
 

--- a/funcx_endpoint/tests/unit/test_endpointinterchange.py
+++ b/funcx_endpoint/tests/unit/test_endpointinterchange.py
@@ -24,7 +24,6 @@ def test_main_exception_always_quiesces(mocker, fs):
     mocker.patch(f"{_mock_base}mpQueue")
     ei = EndpointInterchange(
         config=Config(executors=[]),
-        funcx_client="stub",
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=num_iterations + 10,
     )
@@ -56,7 +55,6 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit):
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
         config=Config(executors=[]),
-        funcx_client="stub",
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=reconnect_attempt_limit,
     )

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -19,7 +19,7 @@ REQUIRES = [
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
     "pika>=1.2",
-    "funcx-common==0.0.23",
+    "funcx-common==0.0.24",
     "tblib==1.7.0",
 ]
 DOCS_REQUIRES = [


### PR DESCRIPTION
The last remaining use of the FuncXClient was within the *executor* interchange, to enable looking up container location information.  The required location information is now passed along with each task message, so modify the logic to look there -- the key change is in `messages_compat.py`.  Everything else is just "cleanup."

[sc-19623]