### PR TITLE
Completely remove Endpoint.name

### DIFF
--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -63,7 +63,7 @@ def get_cli_endpoint() -> Endpoint:
     init_endpoint_configuration_dir(funcx_dir)
 
     state = CommandState.ensure()
-    endpoint = Endpoint(funcx_dir=str(funcx_dir), debug=state.debug)
+    endpoint = Endpoint(debug=state.debug)
 
     return endpoint
 
@@ -317,7 +317,7 @@ def _do_start_endpoint(
 ):
     ep_dir = get_config_dir() / name
     get_cli_endpoint().start_endpoint(
-        name, endpoint_uuid, read_config(ep_dir), log_to_console, no_color
+        ep_dir, endpoint_uuid, read_config(ep_dir), log_to_console, no_color
     )
 
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -31,36 +31,21 @@ from funcx_endpoint.logging_config import setup_logging
 log = logging.getLogger(__name__)
 
 
-_DEFAULT_FUNCX_DIR = str(pathlib.Path.home() / ".funcx")
-
-
 class Endpoint:
     """
     Endpoint is primarily responsible for configuring, launching and stopping
     the Endpoint.
     """
 
-    def __init__(self, funcx_dir=None, debug=False):
+    def __init__(self, debug=False):
         """Initialize the Endpoint
 
         Parameters
         ----------
-
-        funcx_dir: str
-            Directory path to the root of the funcx dirs. Usually ~/.funcx.
-
         debug: Bool
             Enable debug logging. Default: False
         """
         self.debug = debug
-        self.funcx_dir = funcx_dir if funcx_dir is not None else _DEFAULT_FUNCX_DIR
-        self.name = "default"
-
-        self.fx_client = None
-
-    @property
-    def _endpoint_dir(self) -> pathlib.Path:
-        return pathlib.Path(self.funcx_dir) / self.name
 
     @staticmethod
     def _config_file_path(endpoint_dir: pathlib.Path) -> pathlib.Path:
@@ -172,16 +157,12 @@ class Endpoint:
 
     def start_endpoint(
         self,
-        name,
+        endpoint_dir,
         endpoint_uuid,
         endpoint_config: Config,
         log_to_console: bool,
         no_color: bool,
     ):
-        self.name = name
-
-        endpoint_dir = self._endpoint_dir
-
         # This is to ensure that at least 1 executor is defined
         if not endpoint_config.executors:
             raise Exception(

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -54,18 +54,17 @@ def test_start_endpoint_ep_locked(mocker, fs, randomstring, patch_funcx_client):
         status=423,
     )
 
-    funcx_dir = pathlib.Path(endpoint._DEFAULT_FUNCX_DIR)
-    ep = endpoint.Endpoint()
-
-    (funcx_dir / ep.name).mkdir(parents=True, exist_ok=True)
+    ep_dir = pathlib.Path("/some/path/some_endpoint_name")
+    ep_dir.mkdir(parents=True, exist_ok=True)
 
     ep_id = str(uuid.uuid4())
     log_to_console = False
     no_color = True
     ep_conf = Config()
 
+    ep = endpoint.Endpoint()
     with pytest.raises(SystemExit):
-        ep.start_endpoint(ep.name, ep_id, ep_conf, log_to_console, no_color)
+        ep.start_endpoint(ep_dir, ep_id, ep_conf, log_to_console, no_color)
     args, kwargs = mock_log.warning.call_args
     assert "blocked" in args[0]
     assert reason_msg in args[0]

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -38,14 +38,14 @@ class TestStart:
         yield
 
     def test_configure(self):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
         manager.configure_endpoint(config_dir, None)
         assert config_dir.exists() and config_dir.is_dir()
 
     def test_double_configure(self):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
 
         manager.configure_endpoint(config_dir, None)
         assert config_dir.exists() and config_dir.is_dir()
@@ -54,8 +54,8 @@ class TestStart:
 
     @pytest.mark.parametrize("mt", [None, True, False])
     def test_configure_multi_tenant_existing_config(self, mt):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
         config_file = config_dir / "config.py"
         config_copy = str(config_dir.parent / "config2.py")
 
@@ -74,8 +74,8 @@ class TestStart:
 
     @pytest.mark.parametrize("mt", [None, True, False])
     def test_configure_multi_tenant(self, mt):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
         config_file = config_dir / "config.py"
 
         if mt is not None:
@@ -339,8 +339,8 @@ class TestStart:
 
         mock_config = mock_executors()
 
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
+        manager = Endpoint()
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
 
         manager.configure_endpoint(config_dir, None)
         with pytest.raises(
@@ -351,7 +351,7 @@ class TestStart:
             log_to_console = False
             no_color = True
             manager.start_endpoint(
-                config_dir.name, None, mock_config, log_to_console, no_color
+                config_dir, None, mock_config, log_to_console, no_color
             )
 
     @pytest.mark.skip("This test doesn't make much sense")
@@ -450,23 +450,20 @@ class TestStart:
         mock_uuid = mocker.patch("funcx_endpoint.endpoint.endpoint.uuid.uuid4")
         mock_uuid.return_value = 123456
 
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
-
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
+        manager = Endpoint()
         manager.configure_endpoint(config_dir, None)
         assert "123456" == manager.get_or_create_endpoint_uuid(config_dir, None)
 
     def test_get_or_create_endpoint_uuid_no_json_given_uuid(self):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
-
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
+        manager = Endpoint()
         manager.configure_endpoint(config_dir, None)
         assert "234567" == manager.get_or_create_endpoint_uuid(config_dir, "234567")
 
     def test_get_or_create_endpoint_uuid_given_json(self):
-        manager = Endpoint(funcx_dir=os.getcwd())
-        config_dir = pathlib.Path(manager.funcx_dir) / "mock_endpoint"
-
+        config_dir = pathlib.Path("/some/path/mock_endpoint")
+        manager = Endpoint()
         manager.configure_endpoint(config_dir, None)
 
         mock_dict = {"endpoint_id": "abcde12345"}

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
@@ -22,8 +22,8 @@ def funcx_dir(tmp_path):
     yield fxdir
 
 
-def test_endpoint_id(mocker, funcx_dir):
-    manager = Endpoint(funcx_dir=str(funcx_dir))
+def test_endpoint_id(funcx_dir):
+    manager = Endpoint()
     config_dir = funcx_dir / "mock_endpoint"
 
     manager.configure_endpoint(config_dir, None)


### PR DESCRIPTION
The name is entirely contained within the configuration directory -- the filesystem directory basename.  We don't use it, so completely remove `Endpoint.name` (i.e., `self.name`) and pass along the pathlib.Path endpoint config dir.

## Type of change

- Code maintenance/cleanup
