### PR TITLE
More easily discern EP processes in process table

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -17,6 +17,7 @@ from string import Template
 import daemon
 import daemon.pidfile
 import psutil
+import setproctitle
 import texttable
 from globus_sdk import GlobusAPIError, NetworkError
 
@@ -279,6 +280,12 @@ class Endpoint:
         ep_info = {"endpoint_id": endpoint_uuid}
         json_file.write_text(json.dumps(ep_info))
         log.debug(f"Registration info written to {json_file}")
+
+        ptitle = f"funcX Endpoint ({endpoint_uuid}, {endpoint_dir.name})"
+        if endpoint_config.environment:
+            ptitle += f" - {endpoint_config.environment}"
+        ptitle += f" [{setproctitle.getproctitle()}]"
+        setproctitle.setproctitle(ptitle)
 
         log.info("Launching endpoint daemon process")
 

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -34,6 +34,7 @@ REQUIRES = [
     # pin exact versions because it does not use semver
     "parsl==2023.1.23",
     "pika>=1.2.0",
+    "setproctitle>=1.3.2,<1.4",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
Make use of setproctitle (thank you Postgres authors!) so as to more easily discern what processes are in the process table.  Help administrators help endusers with errant processes, and help endusers find their processes with an easier grep or visual search.

Example htop output:
<img src="https://user-images.githubusercontent.com/99676336/214669511-77caaf4c-96d7-435d-a038-a1ff80094486.png" width=500/>

[sc-19623]

## Type of change

- New feature (non-breaking change that adds functionality)
