### PR TITLE
Teach FuncXExecutor to use container_id natively

### DIFF
--- a/changelog.d/20230126_125531_kevin_reteach_executor_how_to_specify_containers.rst
+++ b/changelog.d/20230126_125531_kevin_reteach_executor_how_to_specify_containers.rst
@@ -1,0 +1,18 @@
+Bug Fixes
+^^^^^^^^^
+
+- FuncXExecutor no longer ignores the specified ``container_id``.  The same
+  function may now be utilized in containers via the normal workflow:
+
+    .. code-block:: python
+        import funcx
+
+        def some_func():
+            return 1
+        with funcx.FuncXExecutor() as fxe:
+            fxe.endpoint_id = "some-endpoint-uuid"
+            fxe.container_id = "some-container_uuid"
+            fxe.submit(some_func)
+            fxe.container_id = "some-other-container-uuid"
+            fxe.submit(some_func)  # same function, different container!
+            # ...

--- a/funcx_sdk/tests/unit/test_executor.py
+++ b/funcx_sdk/tests/unit/test_executor.py
@@ -166,7 +166,7 @@ def test_property_task_group_id_is_isolated(fxexecutor):
     assert fxe.task_group_id != fxc.session_task_group_id
 
 
-def test_multiple_register_function_fails(fxexecutor, mocker):
+def test_multiple_register_function_fails(fxexecutor):
     fxc, fxe = fxexecutor
 
     fxc.register_function.return_value = "abc"
@@ -228,7 +228,7 @@ def test_submit_auto_registers_function(fxexecutor):
     fxe.endpoint_id = "some_ep_id"
     fxe.submit(noop)
 
-    fxc.register_function.assert_called()
+    assert fxc.register_function.called
 
 
 def test_submit_value_error_if_no_endpoint(fxexecutor):
@@ -241,6 +241,18 @@ def test_submit_value_error_if_no_endpoint(fxexecutor):
     assert "No endpoint_id set" in str(err)
     assert "    fxe = FuncXExecutor(endpoint_id=" in str(err), "Expected hint"
     try_assert(_is_stopped(fxe._task_submitter), "Expected graceful shutdown on error")
+
+
+def test_same_function_different_containers_allowed(fxexecutor):
+    fxc, fxe = fxexecutor
+    c1_id, c2_id = str(uuid.uuid4()), str(uuid.uuid4())
+
+    fxe.container_id = c1_id
+    fxe.register_function(noop)
+    fxe.container_id = c2_id
+    fxe.register_function(noop)
+    with pytest.raises(ValueError, match="already registered"):
+        fxe.register_function(noop)
 
 
 def test_map_raises(fxexecutor):


### PR DESCRIPTION
The ability for the FuncXExecutor to use containers was not *completely* lost in the recent FuncXExecutor refactor (81811a97e0), but was not enabled in the default workflow.  In particular, the expectation from the refactor is that the `endpoint_id` and `container_id` are specified as FuncXExecutor attributes, and _not_ as part of `.submit()`.  But that implies that `.submit()` will transparently use them -- it mistakenly did not.

Previously, one would have had to use `.register_function()` manually and know to specifically specify the `container_uuid` kwarg (eww!), or manually associated the function with a container via the FuncXClient methods.  Further, the same function could only be associated with a single container.  Addressed by updating the internal function registry to also take into account the `container_id`.

[sc-21526]

## Type of change

- Bug fix (non-breaking change that fixes an issue)