### PR TITLE
Teach endpoint to read credentials via stdin

### DIFF
--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
 import pathlib
+import sys
 
 import click
 from click import ClickException
@@ -315,9 +317,24 @@ def _do_start_endpoint(
     log_to_console: bool,
     no_color: bool,
 ):
+    reg_info = {}
+    if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
+        try:
+            stdin_data = json.loads(sys.stdin.read())
+            if not isinstance(stdin_data, dict):
+                type_name = stdin_data.__class__.__name__
+                raise ValueError(
+                    "Expecting JSON dictionary with endpoint registration info; got"
+                    f" {type_name} instead"
+                )
+            reg_info = stdin_data
+        except Exception as e:
+            exc_type = e.__class__.__name__
+            log.debug("Invalid registration info on stdin -- (%s) %s", exc_type, e)
+
     ep_dir = get_config_dir() / name
     get_cli_endpoint().start_endpoint(
-        ep_dir, endpoint_uuid, read_config(ep_dir), log_to_console, no_color
+        ep_dir, endpoint_uuid, read_config(ep_dir), log_to_console, no_color, reg_info
     )
 
 

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -64,7 +64,7 @@ def test_start_endpoint_ep_locked(mocker, fs, randomstring, patch_funcx_client):
 
     ep = endpoint.Endpoint()
     with pytest.raises(SystemExit):
-        ep.start_endpoint(ep_dir, ep_id, ep_conf, log_to_console, no_color)
+        ep.start_endpoint(ep_dir, ep_id, ep_conf, log_to_console, no_color, reg_info={})
     args, kwargs = mock_log.warning.call_args
     assert "blocked" in args[0]
     assert reason_msg in args[0]

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint_manager.py
@@ -351,7 +351,7 @@ class TestStart:
             log_to_console = False
             no_color = True
             manager.start_endpoint(
-                config_dir, None, mock_config, log_to_console, no_color
+                config_dir, None, mock_config, log_to_console, no_color, reg_info={}
             )
 
     @pytest.mark.skip("This test doesn't make much sense")


### PR DESCRIPTION
Enable a parent process to securely pass credentials to the endpoint, removing the need for the endpoint to instantiate a FuncXClient (and thereby removing the need for user credentials).

[sc-19623]

## Type of change

- New feature (non-breaking change that adds functionality)
