### PR TITLE
Whoami sc 21319

### DIFF
--- a/changelog.d/20230126_135722_LeiGlobus_whoami_sc_21319.rst
+++ b/changelog.d/20230126_135722_LeiGlobus_whoami_sc_21319.rst
@@ -1,0 +1,8 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- 'whoami' has been added to the cli to show the current logged in identity and linked identities

--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -8,6 +8,7 @@ import click
 from click import ClickException
 
 from funcx.sdk.login_manager import LoginManager
+from funcx.sdk.login_manager.whoami import print_whoami_info
 from funcx_endpoint.endpoint.utils.config import Config
 
 from .endpoint.endpoint import Endpoint
@@ -221,6 +222,20 @@ def logout_endpoints(force: bool):
             # Generic unsuccessful if no reason was given
             msg = "Logout unsuccessful"
         raise ClickException(msg)
+
+
+@app.command("whoami", help="Show the currently logged-in identity")
+@click.option(
+    "--linked-identities",
+    is_flag=True,
+    default=False,
+    help="Also show identities linked to the currently logged-in primary identity.",
+)
+def whoami(linked_identities: bool) -> None:
+    try:
+        print_whoami_info(linked_identities)
+    except ValueError as ve:
+        raise ClickException(str(ve))
 
 
 def _do_logout_endpoints(

--- a/funcx_sdk/funcx/sdk/login_manager/whoami.py
+++ b/funcx_sdk/funcx/sdk/login_manager/whoami.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from globus_sdk import AuthAPIError
+
+from funcx.sdk.login_manager import LoginManager
+from funcx.sdk.utils.printing import print_table
+
+NOT_LOGGED_IN_MSG = "Unable to retrieve user information. Please log in again."
+
+
+def get_user_info(auth_client, user_id, epoch_auth):
+    """
+    Parse username, name, and last authed time from response
+    """
+    user_info = auth_client.get_identities(ids=user_id)
+    return [
+        user_info["identities"][0]["username"],
+        user_info["identities"][0]["name"],
+        datetime.fromtimestamp(epoch_auth).astimezone().isoformat(),
+    ]
+
+
+def print_whoami_info(linked_identities: bool = False) -> None:
+    """
+    Display information for the currently logged-in user.
+    """
+
+    try:
+        auth_client = LoginManager().get_auth_client()
+    except LookupError:
+        raise ValueError(NOT_LOGGED_IN_MSG)
+
+    whoami_headers = ["Username", "Name", "ID", "Auth Time"]
+
+    # get userinfo from auth.
+    # if we get back an error the user likely needs to log in again
+    try:
+        user_info = {}
+        res = auth_client.oauth2_userinfo()
+        main_id = res["sub"]
+        user_info[main_id] = get_user_info(
+            auth_client, main_id, res["last_authentication"]
+        )
+
+        if linked_identities:
+            whoami_rows = []
+            if "identity_set" not in res:
+                raise ValueError(
+                    "Your current login does not have the consents required "
+                    "to view your full identity set. Please log in again "
+                    "to agree to the required consents."
+                )
+
+            for linked in res["identity_set"]:
+                linked_id = linked["sub"]
+                if linked_id not in user_info:
+                    user_info[linked_id] = get_user_info(
+                        auth_client,
+                        linked_id,
+                        linked["last_authentication"],
+                    )
+                whoami_rows.append(
+                    [
+                        user_info[linked_id][0],
+                        user_info[linked_id][1],
+                        main_id,
+                        user_info[linked_id][2],
+                    ]
+                )
+            print_table(whoami_headers, whoami_rows)
+        else:
+            print_table(
+                whoami_headers,
+                [
+                    [
+                        user_info[main_id][0],
+                        user_info[main_id][1],
+                        main_id,
+                        user_info[main_id][2],
+                    ],
+                ],
+            )
+    except AuthAPIError:
+        raise ValueError(NOT_LOGGED_IN_MSG)

--- a/funcx_sdk/funcx/sdk/utils/printing.py
+++ b/funcx_sdk/funcx/sdk/utils/printing.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import shutil
+
+import texttable
+
+
+def print_table(
+    headers: list,
+    table_rows: list,
+    output_file=None,
+) -> None:
+    """
+    A thin wrapper around texttable that adds optional file as output.
+      Also pads header/rows to equalize width with padding of cells
+
+     :param headers: Headings for the table.  If not given, will be auto
+                      generated with generic 'column #' text
+     :param table_rows: Rows of the table, each a list of cells
+     :param output_file: Output file like object (stream).  If None, use stdout
+    """
+    # Calculate max columns
+    max_columns = len(headers)
+    for row in table_rows:
+        if len(row) > max_columns:
+            max_columns = len(row)
+
+    if len(headers) < max_columns:
+        headers = headers + [f"Column {i+1}" for i in range(max_columns - len(headers))]
+
+    table = texttable.Texttable()
+    table.header(headers)
+
+    # make table terminal wide.  (Not setting a min width as done elsewhere)
+    table.set_max_width(shutil.get_terminal_size().columns)
+
+    for row in table_rows:
+        if len(row) < max_columns:
+            table.add_row(row + ["" for i in range(max_columns - len(row))])
+        else:
+            table.add_row(row)
+
+    print(table.draw(), file=output_file)

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -21,6 +21,7 @@ REQUIRES = [
     "pika>=1.2",
     "funcx-common==0.0.24",
     "tblib==1.7.0",
+    "texttable>=1.6.7",
 ]
 DOCS_REQUIRES = [
     "sphinx<5",

--- a/funcx_sdk/tests/unit/test_printing.py
+++ b/funcx_sdk/tests/unit/test_printing.py
@@ -1,0 +1,61 @@
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from funcx.sdk.utils.printing import print_table
+
+
+@pytest.mark.parametrize(
+    "table_input",
+    [
+        [
+            [],
+            [
+                ["a", "b", "c", "d"],
+                ["1", "2", "3"],
+            ],
+            [
+                "| Column 1 | Column 2 | Column 3 | Column 4 |",
+                "| a        | b        | c        | d        |",
+                "| 1        | 2        | 3        |          |",
+            ],
+        ],
+        [
+            ["a", "b", "c"],
+            [
+                [
+                    "123456789 123456789 123456789 1234567890",
+                ],
+                ["a", "b", "d"],
+                ["1", "2", "3"],
+            ],
+            [
+                "|                    a                     | b | c |",
+                "| 123456789 123456789 123456789 1234567890 |   |   |",
+                "| a                                        | b | d |",
+            ],
+        ],
+        [
+            ["a", "b", "c"],
+            [
+                ["1", "2", "3", "4"],
+                ["a", "b"],
+            ],
+            [
+                "| a | b | c | Column 1 |",
+                "| 1 | 2 | 3 | 4        |",
+                "| a | b |   |          |",
+            ],
+        ],
+    ],
+)
+def test_print_table(table_input):
+    f = io.StringIO()
+    with redirect_stdout(f):
+        header, rows, rows_out = table_input
+        print_table(header, rows)
+        s = f.getvalue().split("\n")
+        assert rows_out[0] == s[1]
+        assert rows_out[1] == s[3]
+        assert rows_out[2] == s[5]

--- a/funcx_sdk/tests/unit/test_whoami.py
+++ b/funcx_sdk/tests/unit/test_whoami.py
@@ -1,0 +1,73 @@
+import pytest
+
+import funcx.sdk.login_manager
+from funcx.sdk.login_manager.whoami import print_whoami_info
+
+MOCK_BASE = "funcx.sdk.login_manager.whoami"
+
+
+@pytest.mark.parametrize(
+    "response_output",
+    [
+        [
+            False,
+            {
+                "sub": "id_abc",
+                "last_authentication": 1674588197,
+                "identity_set": [{"sub": "id_abc", "last_authentication": 1674588197}],
+            },
+            {
+                "identities": [
+                    {
+                        "id": "id_def",
+                        "username": "def@example.com",
+                        "name": "first last",
+                    }
+                ]
+            },
+            False,
+            "",
+            2,
+            "def@example.com",
+        ],
+        [
+            True,
+            {
+                "sub": "abc",
+                "last_authentication": 1674588197,
+            },
+            {
+                "identities": [
+                    {
+                        "id": "id_abc",
+                        "username": "abc@example.com",
+                        "name": "first last",
+                    }
+                ]
+            },
+            True,
+            "full identity set",
+            0,
+            "",
+        ],
+    ],
+)
+def test_whoami(response_output, mocker, monkeypatch):
+    linked, resp, profile, has_err, err_msg, num_rows, username = response_output
+
+    print_mock = mocker.patch(f"{MOCK_BASE}.print_table")
+    oa_mock = mocker.Mock()
+    oa_mock.return_value.oauth2_userinfo.return_value = resp
+    oa_mock.return_value.get_identities.return_value = profile
+    monkeypatch.setattr(
+        funcx.sdk.login_manager.LoginManager, "get_auth_client", oa_mock
+    )
+
+    if has_err:
+        with pytest.raises(ValueError, match=err_msg):
+            print_whoami_info(linked)
+    else:
+        print_whoami_info(linked)
+        print_mock.assert_called_once()
+        assert num_rows == len(print_mock.call_args)
+        assert username == print_mock.call_args[0][1][0][0]


### PR DESCRIPTION
Adding the 'whoami' command to the cli.

Has a '--linked-identities' option to show all identities in "identity_set".  Includes a think wrapper around texttable to print the output, modeled after the endpoint printing, but put in the SDK side.  TODO in another PR is to consider merging the two, if it makes sense.

The key business logic is in login_manager.whoami.py, parsing the responses from auth_client.oauth2_userinfo() and  auth_client.get_identities(ids=user_id), with some minor caching of id:profile_info in a local dict named user_info.

An example usage is as follows:


```

$ funcx-endpoint whoami
+----------------+----------+--------------------------------------+---------------------------+
|    Username    |   Name   |                  ID                  |         Auth Time         |
+================+==========+======================================+===========================+
| lei@globus.org | Lei Wang | 3959f743-9323-4fe6-93ef-eca6f9ff05d2 | 2023-01-26T13:06:08-06:00 |
```