### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       # explicitly pass settings file so that isort does not try to deduce


### PR DESCRIPTION
Poetry released a breaking change which hit the `isort` pre-commit hook. See https://stackoverflow.com/a/75269701/5931898