### PR TITLE
Whoami PR comments

### DIFF
--- a/changelog.d/20230126_135722_LeiGlobus_whoami_sc_21319.rst
+++ b/changelog.d/20230126_135722_LeiGlobus_whoami_sc_21319.rst
@@ -5,4 +5,8 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
-- 'whoami' has been added to the cli to show the current logged in identity and linked identities
+- 'whoami' has been added to the cli to show the current logged in
+  identity and linked identities.
+    * A --linked-identities optional argument shows all linked identities
+    * ie. `funcx-endpoint whoami` or `funcx-endpoint whoami --linked-identities`
+

--- a/funcx_sdk/funcx/sdk/login_manager/whoami.py
+++ b/funcx_sdk/funcx/sdk/login_manager/whoami.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import logging
 
 from globus_sdk import AuthAPIError
 
@@ -7,16 +7,19 @@ from funcx.sdk.utils.printing import print_table
 
 NOT_LOGGED_IN_MSG = "Unable to retrieve user information. Please log in again."
 
+logger = logging.getLogger(__name__)
 
-def get_user_info(auth_client, user_id, epoch_auth):
+
+def get_user_info(auth_client, user_id):
     """
-    Parse username, name, and last authed time from response
+    Parse username, name, email from auth response and return a list of info
     """
     user_info = auth_client.get_identities(ids=user_id)
     return [
         user_info["identities"][0]["username"],
         user_info["identities"][0]["name"],
-        datetime.fromtimestamp(epoch_auth).astimezone().isoformat(),
+        user_id,
+        user_info["identities"][0]["email"],
     ]
 
 
@@ -28,9 +31,10 @@ def print_whoami_info(linked_identities: bool = False) -> None:
     try:
         auth_client = LoginManager().get_auth_client()
     except LookupError:
+        logger.debug(NOT_LOGGED_IN_MSG, exc_info=True)
         raise ValueError(NOT_LOGGED_IN_MSG)
 
-    whoami_headers = ["Username", "Name", "ID", "Auth Time"]
+    whoami_headers = ["Username", "Name", "ID", "Email"]
 
     # get userinfo from auth.
     # if we get back an error the user likely needs to log in again
@@ -38,47 +42,26 @@ def print_whoami_info(linked_identities: bool = False) -> None:
         user_info = {}
         res = auth_client.oauth2_userinfo()
         main_id = res["sub"]
-        user_info[main_id] = get_user_info(
-            auth_client, main_id, res["last_authentication"]
-        )
+        user_info[main_id] = get_user_info(auth_client, main_id)
 
+        whoami_rows = []
         if linked_identities:
-            whoami_rows = []
             if "identity_set" not in res:
                 raise ValueError(
                     "Your current login does not have the consents required "
                     "to view your full identity set. Please log in again "
-                    "to agree to the required consents."
+                    "to agree to the required consents.\n\n"
+                    "  Hint: use the --logout flag"
                 )
 
             for linked in res["identity_set"]:
                 linked_id = linked["sub"]
                 if linked_id not in user_info:
-                    user_info[linked_id] = get_user_info(
-                        auth_client,
-                        linked_id,
-                        linked["last_authentication"],
-                    )
-                whoami_rows.append(
-                    [
-                        user_info[linked_id][0],
-                        user_info[linked_id][1],
-                        main_id,
-                        user_info[linked_id][2],
-                    ]
-                )
-            print_table(whoami_headers, whoami_rows)
+                    user_info[linked_id] = get_user_info(auth_client, linked_id)
+                whoami_rows.append(user_info[linked_id])
         else:
-            print_table(
-                whoami_headers,
-                [
-                    [
-                        user_info[main_id][0],
-                        user_info[main_id][1],
-                        main_id,
-                        user_info[main_id][2],
-                    ],
-                ],
-            )
+            whoami_rows.append(user_info[main_id])
+
+        print_table(whoami_headers, whoami_rows)
     except AuthAPIError:
         raise ValueError(NOT_LOGGED_IN_MSG)

--- a/funcx_sdk/funcx/sdk/utils/printing.py
+++ b/funcx_sdk/funcx/sdk/utils/printing.py
@@ -35,9 +35,6 @@ def print_table(
     table.set_max_width(shutil.get_terminal_size().columns)
 
     for row in table_rows:
-        if len(row) < max_columns:
-            table.add_row(row + ["" for i in range(max_columns - len(row))])
-        else:
-            table.add_row(row)
+        table.add_row(row + [""] * (max_columns - len(row)))
 
     print(table.draw(), file=output_file)

--- a/funcx_sdk/tests/unit/test_whoami.py
+++ b/funcx_sdk/tests/unit/test_whoami.py
@@ -14,7 +14,32 @@ MOCK_BASE = "funcx.sdk.login_manager.whoami"
             {
                 "sub": "id_abc",
                 "last_authentication": 1674588197,
-                "identity_set": [{"sub": "id_abc", "last_authentication": 1674588197}],
+                "identity_set": [{"sub": "id_def", "last_authentication": 1674588197}],
+            },
+            {
+                "identities": [
+                    {
+                        "id": "id_abc",
+                        "username": "abc@example.com",
+                        "name": "first last",
+                        "email": "abc@example.com",
+                    },
+                ]
+            },
+            False,
+            "",
+            1,
+            ["abc@example.com", "first last", "id_abc", "abc@example.com"],
+        ],
+        [
+            True,
+            {
+                "sub": "id_abc",
+                "last_authentication": 1674588197,
+                "identity_set": [
+                    {"sub": "id_abc", "last_authentication": 1674588197},
+                    {"sub": "id_def", "last_authentication": 1674588197},
+                ],
             },
             {
                 "identities": [
@@ -22,13 +47,14 @@ MOCK_BASE = "funcx.sdk.login_manager.whoami"
                         "id": "id_def",
                         "username": "def@example.com",
                         "name": "first last",
-                    }
+                        "email": "def@example.com",
+                    },
                 ]
             },
             False,
             "",
             2,
-            "def@example.com",
+            ["def@example.com", "first last", "id_def", "def@example.com"],
         ],
         [
             True,
@@ -42,18 +68,19 @@ MOCK_BASE = "funcx.sdk.login_manager.whoami"
                         "id": "id_abc",
                         "username": "abc@example.com",
                         "name": "first last",
+                        "email": "abc@example.com",
                     }
                 ]
             },
             True,
             "full identity set",
             0,
-            "",
+            [],
         ],
     ],
 )
 def test_whoami(response_output, mocker, monkeypatch):
-    linked, resp, profile, has_err, err_msg, num_rows, username = response_output
+    linked, resp, profile, has_err, err_msg, num_rows, user_info = response_output
 
     print_mock = mocker.patch(f"{MOCK_BASE}.print_table")
     oa_mock = mocker.Mock()
@@ -69,5 +96,5 @@ def test_whoami(response_output, mocker, monkeypatch):
     else:
         print_whoami_info(linked)
         print_mock.assert_called_once()
-        assert num_rows == len(print_mock.call_args)
-        assert username == print_mock.call_args[0][1][0][0]
+        assert num_rows == len(print_mock.call_args[0][1])
+        assert user_info == print_mock.call_args[0][1][-1]


### PR DESCRIPTION
> Just thinking "out loud" ... would an example invocation be in order? Or a link to the appropriate documentation page/section?

Added example in changelog

> Is there in sharing the underlying exception in .debug()? Just thinking about the "unexpected" failure. (As opposed to the expected failure, right? ;-) ) Perhaps something like:

Didn't use logger at all in this file, so didn't do that, but sure, why not.

> Would a (Hint: use the --logout flag) pointer be of use to the end-user? I'm thinking of something like:

Added

> The funcx-endpoint list functionality puts the static-width fields first and the variable-width fields on the right. 

I used the order as globus-cli did username, name, ID.  On Josh's suggestion to keep to that, I added 'email' and removed Auth Time.

> And then this section could reduce to:

Modified get_user_info to include ID in the row so the code is a lot more concise (and the test)

> Clever approach to extend shorter rows. Another approach might be to inline the addition:

Now using ['*'] * n format.  Thanks for the reminder I often forget the simpler syntax.