### PR TITLE
Correct data structure traversal

### DIFF
--- a/changelog.d/20230202_002915_kevin_htex_interchange_bad_manager_iteration_fix.rst
+++ b/changelog.d/20230202_002915_kevin_htex_interchange_bad_manager_iteration_fix.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fix idle-executor handling in manager that was broken in v1.0.9


### PR DESCRIPTION
# Description

Broken in `fadc76b2be`&nbsp;&mdash;&nbsp;an Executor unused for too long will trigger cleanup of the Interchange data structures.  The refactor in the ancestor commit inappropriately modified the data structure traversal.  Fix the traversal.

[sc-21819]

## Type of change

- Bug fix (non-breaking change that fixes an issue)