### PR TITLE
Reduce log noise from JobStatus updates

### DIFF
--- a/funcx_endpoint/funcx_endpoint/strategies/simple.py
+++ b/funcx_endpoint/funcx_endpoint/strategies/simple.py
@@ -76,10 +76,10 @@ class SimpleStrategy(BaseStrategy):
         active_blocks = running + pending
         active_slots = active_blocks * tasks_per_node * nodes_per_block
 
-        status = str(status)
+        status = "; ".join(str(js) for js in status)
         if status != self._prev_status:
             self._prev_status = status
-            log.debug(f"Provider status: {status}")
+            log.debug(f"Provider states: {status}")
 
         cur_info = (
             active_tasks,


### PR DESCRIPTION
This basically converts numerous log lines like:

    ....ple:82 _strategize Provider status: [<parsl.providers.base.JobStatus object at 0x7f579e736f50, state=2>]
    ....ple:82 _strategize Provider status: [<parsl.providers.base.JobStatus object at 0x7f579e737730, state=2>]
    ....ple:82 _strategize Provider status: [<parsl.providers.base.JobStatus object at 0x7f579e737010, state=2>]
    ....ple:82 _strategize Provider status: [<parsl.providers.base.JobStatus object at 0x7f579e736ec0, state=2>]
    [etc.]

To a singular:

    ....ple:82 _strategize Provider states: 2

And it won't repeat again until the state *changes* -- the insight being that we care about the underlying *state*, not the JobStatus object.  :grimace:

## Type of change

- Code maintenance/cleanup
