### PR TITLE
Add stdin to the daemon context

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -315,6 +315,16 @@ class Endpoint:
         )
 
         with context:
+            # Per DaemonContext implementation, and that we _don't_ pass stdin,
+            # fd 0 is already connected to devnull.  Unfortunately, there is an
+            # as-yet unknown interaction on Polaris (ALCF) that needs this
+            # connection setup *again*.  So, repeat what daemon context already
+            # did, and dup2 stdin from devnull to ... devnull.  (!@#$%^&*)
+            # On any other system, this should make no difference (same file!)
+            with open(os.devnull) as nullf:
+                if os.dup2(nullf.fileno(), 0) != 0:
+                    raise Exception("Unable to close stdin")
+
             setup_logging(
                 logfile=logfile,
                 debug=self.debug,


### PR DESCRIPTION
# Description

ALCF's PBS cluster requires that stdin be open when engaging with it. To that end, we dup2 stdin to /dev/null and set it in the daemon context. This allows funcx endpoints to perform qstat and qdel operations without error.

Fixes # [sc-21508]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
