### PR TITLE
Implement flag to maintain process tree

### DIFF
--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -11,9 +11,9 @@ from click import ClickException
 
 from funcx.sdk.login_manager import LoginManager
 from funcx.sdk.login_manager.whoami import print_whoami_info
-from funcx_endpoint.endpoint.utils.config import Config
 
 from .endpoint.endpoint import Endpoint
+from .endpoint.utils.config import Config
 from .logging_config import setup_logging
 
 log = logging.getLogger(__name__)
@@ -177,8 +177,14 @@ def configure_endpoint(
 @click.option(
     "--endpoint-uuid", default=None, help="The UUID for the endpoint to register with"
 )
+@click.option(
+    "--die-with-parent",
+    is_flag=True,
+    hidden=True,
+    help="Shutdown if parent process goes away",
+)
 @common_options
-def start_endpoint(*, name: str, endpoint_uuid: str | None):
+def start_endpoint(*, name: str, endpoint_uuid: str | None, die_with_parent=False):
     """Start an endpoint
 
     This function will do:
@@ -205,6 +211,7 @@ def start_endpoint(*, name: str, endpoint_uuid: str | None):
         endpoint_uuid=endpoint_uuid,
         log_to_console=state.log_to_console,
         no_color=state.no_color,
+        die_with_parent=die_with_parent,
     )
 
 
@@ -331,6 +338,7 @@ def _do_start_endpoint(
     endpoint_uuid: str | None,
     log_to_console: bool,
     no_color: bool,
+    die_with_parent: bool = False,
 ):
     reg_info = {}
     if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
@@ -348,8 +356,15 @@ def _do_start_endpoint(
             log.debug("Invalid registration info on stdin -- (%s) %s", exc_type, e)
 
     ep_dir = get_config_dir() / name
+    ep_config = read_config(ep_dir)
     get_cli_endpoint().start_endpoint(
-        ep_dir, endpoint_uuid, read_config(ep_dir), log_to_console, no_color, reg_info
+        ep_dir,
+        endpoint_uuid,
+        ep_config,
+        log_to_console,
+        no_color,
+        reg_info,
+        die_with_parent,
     )
 
 

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -173,6 +173,7 @@ class Endpoint:
         log_to_console: bool,
         no_color: bool,
         reg_info: dict,
+        die_with_parent: bool = False,
     ):
         # This is to ensure that at least 1 executor is defined
         if not endpoint_config.executors:
@@ -301,6 +302,10 @@ class Endpoint:
         ptitle += f" [{setproctitle.getproctitle()}]"
         setproctitle.setproctitle(ptitle)
 
+        parent_pid = 0
+        if die_with_parent:
+            parent_pid = os.getppid()
+
         log.info("Launching endpoint daemon process")
 
         # NOTE
@@ -328,6 +333,7 @@ class Endpoint:
                 endpoint_config,
                 reg_info,
                 result_store,
+                parent_pid,
             )
 
     @staticmethod
@@ -337,6 +343,7 @@ class Endpoint:
         endpoint_config: Config,
         reg_info,
         result_store: ResultStore,
+        parent_pid: int,
     ):
         interchange = EndpointInterchange(
             config=endpoint_config,
@@ -345,6 +352,7 @@ class Endpoint:
             endpoint_dir=endpoint_dir,
             result_store=result_store,
             logdir=endpoint_dir,
+            parent_pid=parent_pid,
         )
 
         interchange.start()

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -57,6 +57,7 @@ class EndpointInterchange:
         endpoint_dir=".",
         result_store: ResultStore | None = None,
         reconnect_attempt_limit: int = 5,
+        parent_pid: int = 0,
     ):
         """
         Parameters
@@ -101,6 +102,7 @@ class EndpointInterchange:
         self.reconnect_attempt_limit = max(1, reconnect_attempt_limit)
         self._quiesce_event = multiprocessing.Event()
         self._kill_event = multiprocessing.Event()
+        self._parent_pid = parent_pid
 
         if result_store is None:
             result_store = ResultStore(endpoint_dir=endpoint_dir)
@@ -225,15 +227,37 @@ class EndpointInterchange:
 
     def start(self):
         """Start the Interchange"""
-        log.info("Starting EndpointInterchange")
-
-        signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGHUP, self.handle_sigterm)
         signal.signal(signal.SIGQUIT, self.handle_sigterm)  # hint: Ctrl+\
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
         # Intentionally ignoring SIGINT for now, as we're unstable enough to
         # warrant Python's default developer-friendly Ctrl+C handling
 
         self._quiesce_event.clear()
         self._kill_event.clear()
+
+        if self._parent_pid:
+            if self._parent_pid != os.getppid():
+                # initial check to save extra noise
+                log.warning(f"Pid {self._parent_pid} not parent; refusing to start")
+                self.stop()
+                return
+
+            def _parent_watcher(ppid: int):
+                while ppid == os.getppid():
+                    if not self._quiesce_event.wait(timeout=1):
+                        return
+                log.warning(f"Parent ({ppid}) has gone away; initiating shut down")
+                self.stop()
+
+            threading.Thread(
+                target=_parent_watcher,
+                args=(self._parent_pid,),  # copy; to discourage shenanigans
+                daemon=True,
+                name="ParentPidWatcher",
+            ).start()
+
+        log.info("Starting EndpointInterchange")
 
         # NOTE: currently we only start the executors once because
         # the current behavior is to keep them running decoupled while

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_interchange.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import threading
 import uuid
@@ -9,7 +10,7 @@ from funcx_common.messagepack.message_types import Result, Task
 from tests.utils import try_for_timeout
 
 from funcx_endpoint.endpoint.endpoint import Endpoint
-from funcx_endpoint.endpoint.interchange import EndpointInterchange
+from funcx_endpoint.endpoint.interchange import EndpointInterchange, log
 from funcx_endpoint.endpoint.utils.config import Config
 
 _MOCK_BASE = "funcx_endpoint.endpoint.interchange."
@@ -76,3 +77,42 @@ def test_invalid_message_result_returned(mocker):
     result: Result = unpack(msg)
     assert result.task_id == task.task_id
     assert "Failed to start task" in result.data
+
+
+def test_die_with_parent_refuses_to_start_if_not_parent(mocker):
+    ei = EndpointInterchange(
+        config=Config(executors=[]),
+        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        parent_pid=os.getpid(),  # _not_ ppid; that's the test.
+    )
+    mock_warn = mocker.patch.object(log, "warning")
+    assert not ei._kill_event.is_set()
+    ei.start()
+    assert ei._kill_event.is_set()
+
+    warn_msg = str(list(a[0] for a, _ in mock_warn.call_args_list))
+    assert "refusing to start" in warn_msg
+
+
+def test_die_with_parent_goes_away_if_parent_dies(mocker):
+    ppid = os.getppid()
+
+    mocker.patch(f"{_MOCK_BASE}ResultQueuePublisher")
+    mocker.patch(f"{_MOCK_BASE}convert_to_internaltask")
+    mocker.patch(f"{_MOCK_BASE}time.sleep")
+    mock_ppid = mocker.patch(f"{_MOCK_BASE}os.getppid")
+    mock_ppid.side_effect = (ppid, 1)
+    ei = EndpointInterchange(
+        config=Config(executors=[]),
+        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+        parent_pid=ppid,
+    )
+    ei.executors = {"mock_executor": mocker.Mock()}
+    mock_warn = mocker.patch.object(log, "warning")
+    assert not ei._kill_event.is_set()
+    ei.start()
+    assert ei._kill_event.is_set()
+
+    warn_msg = str(list(a[0] for a, _ in mock_warn.call_args_list))
+    assert "refusing to start" not in warn_msg
+    assert f"Parent ({ppid}) has gone away" in warn_msg

--- a/funcx_endpoint/tests/unit/test_cli_behavior.py
+++ b/funcx_endpoint/tests/unit/test_cli_behavior.py
@@ -111,7 +111,7 @@ def test_start_ep_reads_stdin(
     run_line("start foo")
     mock_ep, _ = mock_cli_state
     assert mock_ep.start_endpoint.called
-    reg_info_found = mock_ep.start_endpoint.call_args[0][-1]
+    reg_info_found = mock_ep.start_endpoint.call_args[0][5]
 
     if data_is_valid:
         assert reg_info_found == json.loads(reg_info)


### PR DESCRIPTION
We want to be able to force&nbsp;&mdash;&nbsp;despite a misconfiguration&nbsp;&mdash;&nbsp;that an administrator can see a hierarchical view of all Globus Compute endpoints.  In particular, if the parent process crashes, the child processes should gracefully shutdown rather than hang around as orphans.  Thus, implement `--die-with-parent` as a flag to the cli to indicate that if the parent PID changes&nbsp;&mdash;&nbsp;so the child process was reparented or the parent process died&nbsp;&mdash;&nbsp;then it is time to shutdown.

[sc-19623]

## Type of change

- New feature (non-breaking change that adds functionality)