### PR TITLE
Add logic in case error reason non existent

### DIFF
--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -449,7 +449,10 @@ class FuncXClient:
 
                 # Checking for 'Failed' is how FuncxResponseError.unpack
                 # originally checked for errors.
-                raise FuncxTaskExecutionFailed(result.get("reason"))
+
+                # All errors should have 'reason' but just in case
+                error_reason = result.get("reason", "Unknown execution failure")
+                raise FuncxTaskExecutionFailed(error_reason)
 
         if self.asynchronous:
             task_group_id = r["task_group_id"]

--- a/funcx_sdk/tests/unit/test_client.py
+++ b/funcx_sdk/tests/unit/test_client.py
@@ -199,6 +199,29 @@ def test_batch_error():
     assert error_reason in str(excinfo)
 
 
+def test_batch_no_reason():
+    fxc = funcx.FuncXClient(do_version_check=False, login_manager=mock.Mock())
+    fxc.web_client = mock.MagicMock()
+
+    error_results = {
+        "response": "batch",
+        "results": [
+            {
+                "http_status_code": 500,
+                "status": "Failed",
+                "task_uuid": "def",
+            },
+        ],
+        "task_group_id": "tg_id",
+    }
+    fxc.web_client.submit = mock.MagicMock(return_value=error_results)
+
+    with pytest.raises(FuncxTaskExecutionFailed) as excinfo:
+        fxc.run(endpoint_id="fid", function_id="fid")
+
+    assert "Unknown execution failure" in str(excinfo)
+
+
 @pytest.mark.parametrize("asynchronous", [True, False, None])
 def test_single_run_websocket_queue_depend_async(asynchronous):
     if asynchronous is None:


### PR DESCRIPTION
While testing related to https://github.com/globusonline/funcx-services/pull/270 the 'reason' may not be returned from the web client as part of batch results.  This was causing some issues with FuncxTaskExecutionFailed requiring a str as reason instead of None, and also FuncxTaskExecutionFailed(None) isn't ideal to show to the user.

Added a string in place in case 'reason' is missing.