### PR TITLE
Delete endpoints from web service via CLI

### DIFF
--- a/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
+++ b/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
@@ -3,3 +3,12 @@ New Functionality
 
 - Created `FuncxWebClient` and `FuncXClient` methods to delete endpoints
   from the web service.
+- Added a `--force` flag for the `funcx-endpoint delete` command, which 
+  ensures that the endpoint is deleted locally even if the web service
+  returns an error or is unreachable.
+
+Bug Fixes
+^^^^^^^^^
+
+- The `funcx-endpoint delete` command now deletes the endpoint both locally and 
+  from the web service.

--- a/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
+++ b/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Created `FuncxWebClient` and `FuncXClient` methods to delete endpoints
+  from the web service.

--- a/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
+++ b/changelog.d/20230221_104931_30907815+rjmello_delete_ep.rst
@@ -3,12 +3,14 @@ New Functionality
 
 - Created `FuncxWebClient` and `FuncXClient` methods to delete endpoints
   from the web service.
-- Added a `--force` flag for the `funcx-endpoint delete` command, which 
+- Added a `--force` flag for the `funcx-endpoint delete` command, which
   ensures that the endpoint is deleted locally even if the web service
   returns an error or is unreachable.
 
 Bug Fixes
 ^^^^^^^^^
 
-- The `funcx-endpoint delete` command now deletes the endpoint both locally and 
+- The `funcx-endpoint delete` command now deletes the endpoint both locally and
   from the web service.
+- If a user attempts to start an endpoint that has already been marked as
+  deleted in the web service, the process will exit with an error.

--- a/funcx_endpoint/funcx_endpoint/cli.py
+++ b/funcx_endpoint/funcx_endpoint/cli.py
@@ -412,9 +412,17 @@ def list_endpoints():
 
 @app.command("delete")
 @name_arg
-@click.option("--yes", is_flag=True, help="Do not ask for confirmation to delete.")
+@click.option(
+    "--force",
+    default=False,
+    is_flag=True,
+    help="Deletes the local endpoint even if the web service returns an error.",
+)
+@click.option(
+    "--yes", default=False, is_flag=True, help="Do not ask for confirmation to delete."
+)
 @common_options
-def delete_endpoint(*, name: str, yes: bool):
+def delete_endpoint(*, name: str, force: bool, yes: bool):
     """Deletes an endpoint and its config."""
     if not yes:
         click.confirm(
@@ -422,7 +430,7 @@ def delete_endpoint(*, name: str, yes: bool):
         )
 
     ep_dir = get_config_dir() / name
-    Endpoint.delete_endpoint(ep_dir)
+    Endpoint.delete_endpoint(ep_dir, read_config(ep_dir), force)
 
 
 def cli_run():

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -249,8 +249,8 @@ class Endpoint:
                 )
 
             except GlobusAPIError as e:
-                if e.http_status == 409 or e.http_status == 423:
-                    # RESOURCE_CONFLICT or RESOURCE_LOCKED
+                if e.http_status in (409, 410, 423):
+                    # CONFLICT, GONE or LOCKED
                     log.warning(f"Endpoint registration blocked.  [{e.message}]")
                     exit(os.EX_UNAVAILABLE)
                 raise

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_endpoint.py
@@ -25,8 +25,11 @@ def test_non_configured_endpoint(mocker):
     assert "not configured" in result.stdout
 
 
+@pytest.mark.parametrize("status_code", [409, 410, 423])
 @responses.activate
-def test_start_endpoint_ep_locked(mocker, fs, randomstring, patch_funcx_client):
+def test_start_endpoint_blocked(
+    mocker, fs, randomstring, patch_funcx_client, status_code
+):
     # happy-path tested in tests/unit/test_endpoint_unit.py
 
     fx_addy = "http://api.funcx/"
@@ -51,7 +54,7 @@ def test_start_endpoint_ep_locked(mocker, fs, randomstring, patch_funcx_client):
         responses.POST,
         fx_addy + "endpoints",
         json={"reason": reason_msg},
-        status=423,
+        status=status_code,
     )
 
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")

--- a/funcx_endpoint/tests/unit/test_cli_behavior.py
+++ b/funcx_endpoint/tests/unit/test_cli_behavior.py
@@ -158,3 +158,10 @@ def test_start_ep_incorrect(run_line, mock_cli_state, make_endpoint_dir):
     conf.write_text("asdf = 5")  # syntactically correct
     res = run_line("start foo", assert_exit_code=1)
     assert "modified incorrectly?" in res.stderr
+
+
+@mock.patch("funcx_endpoint.cli.read_config")
+def test_delete_endpoint(read_config, run_line, mock_cli_state):
+    run_line("delete foo --yes")
+    mock_ep, _ = mock_cli_state
+    mock_ep.delete_endpoint.assert_called_once()

--- a/funcx_sdk/funcx/sdk/client.py
+++ b/funcx_sdk/funcx/sdk/client.py
@@ -838,3 +838,19 @@ class FuncXClient:
             The response of the request
         """
         return self.web_client.stop_endpoint(endpoint_id)
+
+    @requires_login
+    def delete_endpoint(self, endpoint_id: str):
+        """Delete an endpoint
+
+        Parameters
+        ----------
+        endpoint_id : str
+            The uuid of the endpoint
+
+        Returns
+        -------
+        json
+            The response of the request
+        """
+        return self.web_client.delete_endpoint(endpoint_id)

--- a/funcx_sdk/funcx/sdk/web_client.py
+++ b/funcx_sdk/funcx/sdk/web_client.py
@@ -239,3 +239,6 @@ class FuncxWebClient(globus_sdk.BaseClient):
 
     def stop_endpoint(self, endpoint_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
         return self.post(f"/endpoints/{endpoint_id}/lock", data={})
+
+    def delete_endpoint(self, endpoint_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
+        return self.delete(f"/endpoints/{endpoint_id}")


### PR DESCRIPTION
# Description

The `funcx-endpoint delete` command now deletes the endpoint both locally and from the web service. This includes the `--force` flag, which ensures the endpoint is deleted locally even if the web service returns an error or is unreachable.

Also, if a user attempts to start an endpoint that has already been marked as deleted in the web service, the process will exit with an error.

[sc-20468]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
