### PR TITLE
Implement EndpointManager

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -26,6 +26,7 @@ from funcx_endpoint import __version__
 from funcx_endpoint.endpoint import default_config as endpoint_default_config
 from funcx_endpoint.endpoint.interchange import EndpointInterchange
 from funcx_endpoint.endpoint.result_store import ResultStore
+from funcx_endpoint.endpoint.utils import _redact_url_creds
 from funcx_endpoint.endpoint.utils.config import Config
 from funcx_endpoint.logging_config import setup_logging
 
@@ -288,7 +289,7 @@ class Endpoint:
             exit(os.EX_DATAERR)
 
         # sanitize passwords in logs
-        log_reg_info = re.subn(r"://.*?@", r"://***:***@", repr(reg_info))
+        log_reg_info = _redact_url_creds(repr(reg_info))
         log.debug(f"Registration information: {log_reg_info}")
 
         json_file = endpoint_dir / "endpoint.json"

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import pwd
+import queue
+import re
+import resource
+import signal
+import socket
+import sys
+import threading
+import time
+import typing as t
+from datetime import datetime
+
+import setproctitle
+from globus_sdk import GlobusAPIError, NetworkError
+
+import funcx
+from funcx_endpoint import __version__
+from funcx_endpoint.endpoint.endpoint import Endpoint
+from funcx_endpoint.endpoint.rabbit_mq.command_queue_subscriber import (
+    CommandQueueSubscriber,
+)
+from funcx_endpoint.endpoint.utils.config import Config
+
+if t.TYPE_CHECKING:
+    from pika.spec import BasicProperties
+
+
+log = logging.getLogger(__name__)
+
+
+class InvalidCommandError(Exception):
+    pass
+
+
+class EndpointManager:
+    def __init__(
+        self,
+        conf_dir: pathlib.Path,
+        endpoint_uuid: str | None,
+        config: Config,
+    ):
+        log.info("Endpoint Manager initialization")
+
+        self._reload_requested = False
+        self._time_to_stop = False
+        self._kill_event = threading.Event()
+
+        self._child_args: dict[int, tuple[int, int, str, str]] = {}
+        self._wait_for_child = False
+
+        self._command_queue: queue.SimpleQueue[
+            tuple[int, BasicProperties, bytes]
+        ] = queue.SimpleQueue()
+        self._command_stop_event = threading.Event()
+
+        endpoint_uuid = Endpoint.get_or_create_endpoint_uuid(conf_dir, endpoint_uuid)
+
+        try:
+            funcx_client_options = {
+                "funcx_service_address": config.funcx_service_address,
+                "environment": config.environment,
+            }
+
+            fxc = funcx.FuncXClient(**funcx_client_options)
+            reg_info = fxc.register_endpoint(
+                conf_dir.name,
+                endpoint_uuid,
+                metadata=EndpointManager.get_metadata(config),
+                multi_tenant=True,
+            )
+        except GlobusAPIError as e:
+            if e.http_status == 409 or e.http_status == 423:
+                # RESOURCE_CONFLICT or RESOURCE_LOCKED
+                log.warning(f"Endpoint registration blocked.  [{e.message}]")
+                exit(os.EX_UNAVAILABLE)
+            raise
+        except NetworkError as e:
+            log.exception("Network error while registering multi-tenant endpoint")
+            log.critical(f"Network failure; unable to register endpoint: {e}")
+            exit(os.EX_TEMPFAIL)
+
+        upstream_ep_uuid = reg_info.get("endpoint_id")
+        if upstream_ep_uuid != endpoint_uuid:
+            log.error(
+                "Unexpected response from server: mismatched endpoint id."
+                f"\n  Expected: {endpoint_uuid}, received: {upstream_ep_uuid}"
+            )
+            exit(os.EX_SOFTWARE)
+
+        self._endpoint_uuid_str = upstream_ep_uuid
+
+        try:
+            cq_info = reg_info["command_queue_info"]
+            _ = cq_info["connection_url"], cq_info["queue"]
+        except Exception as e:
+            log.debug("%s", reg_info)
+            log.error(
+                "Invalid or unexpected registration data structure:"
+                f" ({e.__class__.__name__}) {e}"
+            )
+            exit(os.EX_DATAERR)
+
+        # sanitize passwords in logs
+        log_reg_info = re.subn(r"://.*?@", r"://***:***@", repr(reg_info))
+        log.debug(f"Registration information: {log_reg_info}")
+
+        json_file = conf_dir / "endpoint.json"
+
+        # `endpoint_id` key kept for backward compatibility when
+        # funcx-endpoint list is called
+        ep_info = {"endpoint_id": endpoint_uuid}
+        json_file.write_text(json.dumps(ep_info))
+        log.debug(f"Registration info written to {json_file}")
+
+        # * == "multi-tenant"; not important until it is, so let it be subtle
+        ptitle = f"funcX Endpoint *({endpoint_uuid}, {conf_dir.name})"
+        if config.environment:
+            ptitle += f" - {config.environment}"
+        ptitle += f" [{setproctitle.getproctitle()}]"
+        setproctitle.setproctitle(ptitle)
+
+        self._command = CommandQueueSubscriber(
+            queue_info=cq_info,
+            command_queue=self._command_queue,
+            stop_event=self._command_stop_event,
+            thread_name="CQS",
+        )
+
+    @staticmethod
+    def get_metadata(config: Config) -> dict:
+        # Piecemeal Config settings because for MT, most of the ST items are
+        # unrelated -- the MT (aka EndpointManager) does not execute tasks
+        return {
+            "endpoint_version": __version__,
+            "hostname": socket.getfqdn(),
+            "local_user": pwd.getpwuid(os.getuid()).pw_name,
+            "config": {
+                "_type": type(config).__name__,
+                "multi_tenant": True,  # redundant, but "whatev"
+                "stdout": config.stdout,
+                "stderr": config.stderr,
+                "environment": config.environment,
+                "funcx_service_address": config.funcx_service_address,
+            },
+        }
+
+    def request_shutdown(self, sig_num, curr_stack_frame):
+        self._time_to_stop = True
+
+    def set_child_died(self, sig_num, curr_stack_fframe):
+        self._wait_for_child = True
+
+    def wait_for_children(self):
+        try:
+            self._wait_for_child = False
+            wait_flags = os.WNOHANG
+            pid, exit_status_ind = os.waitpid(-1, wait_flags)
+            while pid > 0:
+                try:
+                    rc = os.waitstatus_to_exitcode(exit_status_ind)
+                except ValueError:
+                    rc = -127  # invalid signal number
+
+                *_, proc_args = self._child_args.pop(pid, (None, None, None, None))
+                proc_args = f" [{proc_args}]" if proc_args else ""
+                if not rc:
+                    log.info(f"Command stopped normally ({pid}){proc_args}")
+                elif rc > 0:
+                    log.warning(f"Command return code: {rc} ({pid}){proc_args}")
+                elif rc == -127:
+                    log.warning(f"Command unknown return code: ({pid}){proc_args}")
+                else:
+                    log.warning(
+                        f"Command terminated by signal: {-rc} ({pid}){proc_args}"
+                    )
+                pid, exit_status_ind = os.waitpid(-1, wait_flags)
+
+        except ChildProcessError:
+            pass
+        except Exception as e:
+            log.exception(f"Failed to wait for a child process: {e}")
+
+    def _install_signal_handlers(self):
+        signal.signal(signal.SIGTERM, self.request_shutdown)
+        signal.signal(signal.SIGINT, self.request_shutdown)
+        signal.signal(signal.SIGQUIT, self.request_shutdown)
+
+        signal.signal(signal.SIGCHLD, self.set_child_died)
+
+    def start(self):
+        log.info("\n\n========== Endpoint Manager begins ==========")
+
+        msg_out = None
+        if sys.stdout.isatty():
+            msg_out = sys.stdout
+        elif sys.stderr.isatty():
+            msg_out = sys.stderr
+
+        if msg_out:
+            hl, r = "\033[104m", "\033[m"
+            pld = f"{hl}{self._endpoint_uuid_str}{r}"
+            print(f"        >>> Multi-Tenant Endpoint ID: {pld} <<<", file=msg_out)
+        log.info(f">>> Multi-Tenant Endpoint ID: {self._endpoint_uuid_str} <<<")
+
+        self._install_signal_handlers()
+
+        try:
+            self._event_loop()
+        except Exception:
+            log.exception("Unhandled exception; shutting down endpoint master")
+
+        ptitle = f"[shutdown in progress] {setproctitle.getproctitle()}"
+        setproctitle.setproctitle(ptitle)
+        self._command_stop_event.set()
+        self._kill_event.set()
+
+        os.killpg(os.getpgid(0), signal.SIGTERM)
+
+        proc_uid, proc_gid = os.getuid(), os.getgid()
+        for msg_prefix, signum in (
+            ("Signaling shutdown", signal.SIGTERM),
+            ("Forcibly killing", signal.SIGKILL),
+        ):
+            for pid, (uid, gid, uname, proc_args) in list(self._child_args.items()):
+                proc_ident = f"PID: {pid}, UID: {uid}, GID: {gid}, User: {uname}"
+                log.info(f"{msg_prefix} of user endpoint ({proc_ident}) [{proc_args}]")
+                try:
+                    os.setresgid(gid, gid, -1)
+                    os.setresuid(uid, uid, -1)
+                    os.killpg(os.getpgid(pid), signum)
+                except Exception as e:
+                    log.warning(
+                        f"User endpoint signal failed: {e} ({proc_ident}) [{proc_args}]"
+                    )
+                finally:
+                    os.setresuid(proc_uid, proc_uid, -1)
+                    os.setresgid(proc_gid, proc_gid, -1)
+
+            deadline = time.time() + 10
+            while self._child_args and time.time() < deadline:
+                time.sleep(0.5)
+                self.wait_for_children()
+
+        self._command.join(5)
+        log.info("Shutdown complete.\n---------- Endpoint Manager ends ----------\n\n")
+
+    def _event_loop(self):
+        self._command.start()
+
+        local_user_lookup = {}
+        try:
+            with open("local_user_lookup.json") as f:
+                local_user_lookup = json.load(f)
+        except Exception as e:
+            msg = (
+                f"Unable to load local users ({e.__class__.__name__}) {e}\n"
+                "  Will be unable to respond to any commands; update the lookup file"
+                f" and either restart (stop, start) or SIGHUP ({os.getpid()}) this"
+                " endpoint."
+            )
+            log.error(msg)
+
+        valid_method_name_re = re.compile(r"^[A-Za-z][0-9A-Za-z_]{0,99}$")
+        max_skew_s = 180  # 3 minutes; ignore commands with out-of-date timestamp
+        while not self._time_to_stop:
+            if self._wait_for_child:
+                self.wait_for_children()
+
+            try:
+                _command = self._command_queue.get(timeout=1.0)
+                d_tag, props, body = _command
+                if props.headers and props.headers.get("debug", False):
+                    body_log_b = re.sub(rb"://([^:]+):[^@]+@", rb"://\1:***@", body)
+                    log.warning(
+                        "Command debug requested:"
+                        f"\n  Delivery Tag: {d_tag}"
+                        f"\n  Properties: {props}"
+                        f"\n  Body bytes: {body_log_b}"
+                    )
+            except queue.Empty:
+                if self._command_stop_event.is_set():
+                    self._time_to_stop = True
+                if sys.stderr.isatty():
+                    print(
+                        f"\r{time.strftime('%c')}", end="", flush=True, file=sys.stderr
+                    )
+                continue
+
+            try:
+                server_cmd_ts = props.timestamp
+                if props.content_type != "application/json":
+                    raise ValueError("Invalid message type; expecting JSON")
+
+                msg = json.loads(body)
+                command = msg.get("command")
+                command_args = msg.get("args", [])
+                command_kwargs = msg.get("kwargs", {})
+            except Exception as e:
+                log.error(
+                    f"Unable to deserialize Globus Compute services command."
+                    f"  ({e.__class__.__name__}) {e}"
+                )
+                self._command.ack(d_tag)
+                continue
+
+            now = round(time.time())
+            if abs(now - server_cmd_ts) > max_skew_s:
+                server_pp_ts = datetime.fromtimestamp(server_cmd_ts).strftime("%c")
+                endp_pp_ts = datetime.fromtimestamp(now).strftime("%c")
+                log.warning(
+                    "Ignoring command from server"
+                    "\nCommand too old or skew between system clocks is too large."
+                    f"\n  Command timestamp:  {server_cmd_ts:,} ({server_pp_ts})"
+                    f"\n  Endpoint timestamp: {now:,} ({endp_pp_ts})"
+                )
+                self._command.ack(d_tag)
+                continue
+
+            try:
+                globus_uuid = msg["globus_uuid"]
+                globus_username = msg["globus_username"]
+            except Exception as e:
+                log.error(f"Invalid server command.  ({e.__class__.__name__}) {e}")
+                self._command.ack(d_tag)
+                continue
+
+            try:
+                local_user = local_user_lookup[globus_username]
+            except Exception as e:
+                log.warning(f"Invalid or unknown user.  ({e.__class__.__name__}) {e}")
+                self._command.ack(d_tag)
+                continue
+
+            try:
+                if not (command and valid_method_name_re.match(command)):
+                    raise InvalidCommandError(f"Unknown or invalid command: {command}")
+
+                command_func = getattr(EndpointManager, command, None)
+                if not command_func:
+                    raise InvalidCommandError(f"Unknown or invalid command: {command}")
+
+                command_func(self._child_args, local_user, command_args, command_kwargs)
+                log.info(
+                    f"Command process successfully forked for '{globus_username}'"
+                    f" ('{globus_uuid}')."
+                )
+            except InvalidCommandError as err:
+                log.error(str(err))
+
+            except Exception:
+                log.exception(
+                    f"Unable to execute command: {command}\n"
+                    f"    args: {command_args}\n"
+                    f"  kwargs: {command_kwargs}"
+                )
+            finally:
+                self._command.ack(d_tag)
+
+    @staticmethod
+    def start_endpoint(
+        child_args: dict[int, tuple[int, int, str, str]],
+        local_username: str,
+        args: list[str] | None,
+        kwargs: dict | None,
+    ):
+        try:
+            pid = os.fork()
+        except Exception as err:
+            log.error(f"Unable to fork child process: {err}")
+            return
+
+        if not args:
+            args = []
+        if not kwargs:
+            kwargs = {}
+
+        ep_name = kwargs.get("name", "")  # error check is later
+        proc_args = ["funcx-endpoint", "start", ep_name, "--die-with-parent", *args]
+
+        pw_rec = pwd.getpwnam(local_username)
+        udir, uid, gid = pw_rec.pw_dir, pw_rec.pw_uid, pw_rec.pw_gid
+        uname = pw_rec.pw_name
+
+        if pid > 0:
+            proc_args_s = f"({uname}, {ep_name}) {' '.join(proc_args)}"
+            child_args[pid] = (uid, gid, local_username, proc_args_s)
+            log.info(f"Creating new user endpoint (pid: {pid}) [{proc_args_s}]")
+            return
+        pid = os.getpid()
+
+        if not ep_name:
+            exit(os.EX_DATAERR)
+
+        exit_code = 70
+        try:
+            # TODO: PATH, which is crucial for execvpe, is currently required to
+            # be set by API call to /endpoint/command/<uuid>.  This will be
+            # addressed more thoroughly in SC-22804.
+            env = kwargs.get("env", {})
+            env.update({"HOME": udir, "USER": uname})
+            if not os.path.isdir(udir):
+                udir = "/"
+
+            wd = env.get("PWD", udir)
+
+            os.chdir("/")  # always succeeds, so start from known place
+            exit_code += 1
+
+            try:
+                # The initialization of groups is "fungible" if not a privileged user
+                log.debug("Initializing groups for %s, %s", uname, gid)
+                os.initgroups(uname, gid)
+            except PermissionError as e:
+                log.warning("Unable to initialize groups; likely not a privileged user")
+                log.debug("Exception text: (%s) %s", e.__class__.__name__, e)
+            exit_code += 1
+
+            # But actually becoming the correct UID is _not_ fungible.  If we
+            # can't -- for whatever reason -- that's a problem.  So, don't ignore the
+            # potential error.
+            log.debug("Setting process group for %s to %s", pid, gid)
+            os.setresgid(gid, gid, gid)  # raises (good!) on error
+            exit_code += 1
+            log.debug("Setting process uid for %s to %s (%s)", pid, uid, uname)
+            os.setresuid(uid, uid, uid)  # raises (good!) on error
+            exit_code += 1
+
+            os.setsid()
+
+            umask = 0o077  # Let child process set less restrictive, if desired
+            log.debug("Setting process umask for %s to 0o%04o (%s)", pid, umask, uname)
+            os.umask(umask)
+            exit_code += 1
+
+            log.debug("Changing directory to '%s'", wd)
+            os.chdir(wd)
+            exit_code += 1
+            env["PWD"] = wd
+            env["CWD"] = wd
+
+            # in case "something gets stuck," let cmdline show it
+            args_title = " ".join(proc_args)
+            startup_proc_title = f"Endpoint starting up for {uname} [{args_title}]"
+            setproctitle.setproctitle(startup_proc_title)
+
+            amqp_creds = json.dumps(kwargs.get("amqp_creds"))
+
+            log.debug("Setting up process stdin")
+            read_handle, write_handle = os.pipe()
+            exit_code += 1
+            if os.dup2(read_handle, 0) != 0:  # close old stdin, use read_handle
+                raise OSError("Unable to close stdin")
+            os.close(read_handle)
+            exit_code += 1
+
+            null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
+            while null_fd < 3:
+                # overkill, but "just in case": don't step on std in/out/err
+                null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
+            exit_code += 1
+
+            log.debug("Redirecting stdout and stderr (%s)", os.devnull)
+            with os.fdopen(null_fd, "w") as null_f:
+                if os.dup2(null_f.fileno(), 1) != 1:
+                    raise OSError("Unable to close stdout")
+                exit_code += 1
+                if os.dup2(null_f.fileno(), 2) != 2:
+                    raise OSError("Unable to close stderr")
+            exit_code += 1
+            log.debug("Writing credentials")
+            with os.fdopen(write_handle, "w") as cred_pipe:
+                # intentional side effect: close handle
+                cred_pipe.write(amqp_creds)
+
+            exit_code += 1
+            _soft_no, hard_no = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+            # Save closerange until last so that we can still get logs written
+            # to the endpoint.log.  Meanwhile, use the exit_code as a
+            # last-ditch attempt at sharing "what went wrong where" to the
+            # parent process.
+            exit_code += 1
+            os.closerange(3, hard_no)
+
+            exit_code += 1
+            os.execvpe(proc_args[0], args=proc_args, env=env)
+
+            # not executed, except perhaps in testing
+            exit_code += 1  # type: ignore
+        except Exception as e:
+            log.error(f"Unable to exec for {uname} - ({e.__class__.__name__}) {e}")
+        finally:
+            # Only executed if execvpe fails (or isn't reached)
+            exit(exit_code)

--- a/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/command_queue_subscriber.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/rabbit_mq/command_queue_subscriber.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import random
+import threading
+import time
+import typing as t
+
+import pika
+
+if t.TYPE_CHECKING:
+    from pika.channel import Channel
+    from pika.frame import Method
+    from pika.spec import Basic, BasicProperties
+
+log = logging.getLogger(__name__)
+
+
+class CommandQueueSubscriber(threading.Thread):
+    def __init__(
+        self,
+        *,
+        queue_info: dict,
+        command_queue: queue.SimpleQueue[tuple[int, BasicProperties, bytes]],
+        stop_event: threading.Event,
+        poll_period_s: float = 0.5,
+        connect_attempt_limit: int = 3,
+        channel_close_window_s: int = 10,
+        channel_close_window_limit: int = 3,
+        thread_name: str | None = None,
+    ):
+        """
+        Parameters
+        ----------
+        :param queue_info: the AMQP connection credentials, as received from upstream
+        :param command_queue: Messages from upstream will be placed in this queue;
+            consumers of this queue must call .to_ack() with the message id when
+            finished processing
+        :param stop_event: When set, the thread (CommandQueueSubscriber object) will
+            shut down.  When the CQS' thread stops, this event will be summarily set.
+            (Useful to know if the thread has shutdown prematurely.)
+        :param poll_period_s: How often to perform housekeeping tasks (ACKing
+            messages upstream, checking stop_event, etc.)
+        :param connect_attempt_limit: Number of connection attempts to fail before
+            giving up.  The connection counter will reset to 0 after the connection
+            is sustained for 60s, so transient network errors should not build up
+            to a future failure.)
+        :param channel_close_window_s: Window of time to count channel close events
+        :param channel_close_window_limit: Limit of channel close events (within
+            ``channel_close_window_s``) before shutting down the thread.
+        :param thread_name: Name the backing thread; per Python's implementation,
+            this name has no semantics; default: implementation generated value.
+        """
+        super().__init__()
+
+        self.queue_info = queue_info
+        self._command_queue = command_queue
+        self._stop_event = stop_event
+        self._to_ack: queue.SimpleQueue[int] = queue.SimpleQueue()
+        self._channel_closed = threading.Event()
+
+        self._connection: pika.SelectConnection | None = None
+        self._channel: Channel | None = None
+        self._consumer_tag: str | None = None
+
+        # how many times to attempt connection before giving up and shutting
+        # down the thread
+        self.connect_attempt_limit = connect_attempt_limit
+        self._connection_tries = 0  # count of connection events; reset on success
+
+        # invalid until set in start_consuming
+        self._connected_at: int | None = None
+
+        # list of times that channel was last closed
+        self._channel_closes: list[float] = []
+
+        # how long a time frame to keep previous channel close times
+        self.channel_close_window_s = channel_close_window_s
+
+        # how many times allowed to retry opening a channel in the above time
+        # window before giving up and shutting down the thread
+        self.channel_close_window_limit = channel_close_window_limit
+
+        self._poll_period_s = poll_period_s
+        if thread_name:
+            self.name = thread_name
+
+    def __repr__(self):
+        return "{}<{}; pid={}>".format(
+            self.__class__.__name__,
+            "✓" if self._consumer_tag else "✗",
+            os.getpid(),
+        )
+
+    def run(self):
+        log.debug("%s AMQP thread begins", self)
+        idle_for_s = 0.0
+        while self._connection_tries < self.connect_attempt_limit and not (
+            self._stop_event.is_set()
+        ):
+            if self._connection or self._connection_tries:
+                idle_for_s = random.uniform(0.5, 10)
+                msg = f"%s AMQP reconnecting in {idle_for_s:.1f}s."
+                log.debug(msg, self)
+                if self._connection_tries == self.connect_attempt_limit - 1:
+                    log.warning(f"{msg}  (final attempt)", self)
+
+            if self._stop_event.wait(idle_for_s):
+                break
+
+            self._connection_tries += 1
+            try:
+                log.debug(
+                    "%s Opening connection to AMQP service.  Attempt: %s (of %s)",
+                    self,
+                    self._connection_tries,
+                    self.connect_attempt_limit,
+                )
+                self._connection = self._connect()
+                self._event_watcher()
+                self._connection.ioloop.start()
+            except Exception:
+                log.exception("%s Unhandled exception: shutting down connection.", self)
+        self._stop_event.set()
+        log.debug("%s Shutdown complete", self)
+
+    def _connect(self) -> pika.SelectConnection:
+        pika_params = pika.URLParameters(self.queue_info["connection_url"])
+        return pika.SelectConnection(
+            pika_params,
+            on_close_callback=self._on_connection_closed,
+            on_open_error_callback=self._on_open_failed,
+            on_open_callback=self._on_connection_open,
+        )
+
+    def _on_open_failed(self, mq_conn: pika.BaseConnection, exc: str | Exception):
+        count = f"[attempt {self._connection_tries} (of {self.connect_attempt_limit})]"
+        pid = f"(pid: {os.getpid()})"
+        exc_text = f"Failed to open connection - ({exc.__class__.__name__}) {exc}"
+        msg = f"{count} {pid} {exc_text}"
+        log.debug("%s %s", self, msg)
+
+        if not (self._connection_tries < self.connect_attempt_limit):
+            self._stop_event.set()
+            log.warning("%s %s", self, msg)
+        mq_conn.ioloop.stop()
+
+    def _on_connection_closed(self, mq_conn: pika.BaseConnection, exc: Exception):
+        log.debug("%s Connection closed: %s", self, exc)
+        self._consumer_tag = None
+        mq_conn.ioloop.stop()
+
+    def _on_connection_open(self, _mq_conn: pika.BaseConnection):
+        log.debug("%s Connection established; creating channel", self)
+        self._open_channel()
+
+    def _open_channel(self):
+        if self._connection and self._connection.is_open:
+            self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, mq_chan: Channel):
+        self._channel = mq_chan
+
+        mq_chan.add_on_close_callback(self._on_channel_closed)
+        mq_chan.add_on_cancel_callback(self._on_consumer_cancelled)
+
+        log.debug(
+            "%s Channel %s opened (%s)",
+            self,
+            mq_chan.channel_number,
+            mq_chan.connection.params,
+        )
+        self._start_consuming()
+
+    def _on_channel_closed(self, mq_chan: Channel, exc: Exception):
+        self._consumer_tag = None
+        now = time.monotonic()
+        then = now - self.channel_close_window_s
+        self._channel_closes = [cc for cc in self._channel_closes if cc > then]
+        self._channel_closes.append(now)
+        if len(self._channel_closes) < self.channel_close_window_limit:
+            if self._stop_event.is_set():
+                return
+            msg = f"{self} Channel closed  [{mq_chan}\n  ({exc})]"
+            log.debug(msg, exc_info=exc)
+            log.warning(msg)
+            mq_chan.connection.ioloop.call_later(1, self._open_channel)
+
+        else:
+            log.error(
+                f"{self} Unable to sustain channel after {len(self._channel_closes)}"
+                f" attempts in {self.channel_close_window_limit} seconds. ({exc})"
+            )
+            self._stop_event.set()
+
+    def _on_consumer_cancelled(self, frame: Method[Basic.CancelOk]):
+        log.debug("%s Consumer cancelled remotely, shutting down: %r", self, frame)
+        if self._channel:
+            self._channel.close()
+
+    def _start_consuming(self):
+        try:
+            self._consumer_tag = self._channel.basic_consume(
+                queue=self.queue_info["queue"],
+                on_message_callback=self._on_message,
+            )
+            self._connected_at = time.time()
+        except Exception as e:
+            log.warning(
+                f"{self} Unable to start consuming messages:"
+                f" ({e.__class__.__name__}) {e}"
+            )
+            self._stop_ioloop()
+        else:
+            log.debug("%s Awaiting messages", self)
+
+    def _on_message(
+        self,
+        mq_chan: Channel,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        try:
+            d_tag = basic_deliver.delivery_tag
+        except Exception as e:
+            log.debug(
+                "Invalid Basic.Deliver; unable to process message.  (%s) %s",
+                e.__class__.__name__,
+                e,
+            )
+            return
+
+        try:
+            log.debug(
+                "%s Received message from %s: %s, %s",
+                self,
+                d_tag,
+                properties.app_id,
+                body,
+            )
+            self._command_queue.put((d_tag, properties, body))
+        except Exception:
+            # No sense in waiting for the RMQ default 30m timeout; let it know
+            # *now* that this message failed.
+            log.exception("%s Command queue put failed", self)
+            mq_chan.basic_nack(d_tag, requeue=True)
+
+    def ack(self, msg_tag: int):
+        self._to_ack.put(msg_tag)
+
+    def _on_cancelok(self, _frame: Method[Basic.CancelOk]):
+        self._close_channel()
+
+    def _close_channel(self):
+        log.debug("%s Closing the channel", self)
+        self._channel.close()
+
+    def _stop_ioloop(self):
+        """
+        Gracefully stop the ioloop.
+
+        In an effort play nice with upstream, attempt to follow the AMQP protocol
+        by closing the channel and connections gracefully.  This method will
+        rearm itself while the connection is still open, continually working
+        toward eventually and gracefully stopping the connection, before finally
+        stopping the ioloop.
+        """
+        if self._connection:
+            self._connection.ioloop.call_later(0.1, self._stop_ioloop)
+            if self._connection.is_open:
+                if self._channel:
+                    if self._channel.is_open:
+                        self._channel.close()
+                    elif self._channel.is_closed:
+                        self._channel = None
+                else:
+                    self._connection.close()
+            elif self._connection.is_closed:
+                self._connection.ioloop.stop()
+                self._connection = None
+
+    def _event_watcher(self):
+        """Polls the stop_event periodically to trigger a shutdown"""
+        if self._stop_event.is_set():
+            log.debug("%s Shutting down per stop event", self)
+            self._stop_ioloop()
+            return
+
+        if self._connection_tries and self._consumer_tag and self._connected_at:
+            # we're connected ...
+            if time.time() - self._connected_at > 60:
+                # ... and connection stable for 60s; good to reset connection tries
+                self._connection_tries = 0
+
+        delivery_tags = []
+        try:
+            while True:
+                delivery_tags.append(self._to_ack.get(block=False))
+        except queue.Empty:
+            pass
+        if delivery_tags:
+            delivery_tags.sort()  # nominally a no-op
+            latest_msg_id = delivery_tags[-1]
+            self._channel.basic_ack(latest_msg_id, multiple=True)
+            log.debug("%s Acknowledged through message: %s", self, latest_msg_id)
+
+        self._connection.ioloop.call_later(self._poll_period_s, self._event_watcher)

--- a/funcx_endpoint/funcx_endpoint/endpoint/utils/__init__.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/utils/__init__.py
@@ -1,0 +1,29 @@
+import re as _re
+import typing as t
+
+_url_user_pass_pattern = r"://([^:]+):[^@]+@"
+_url_user_pass_re = _re.compile(_url_user_pass_pattern)
+_urlb_user_pass_re = _re.compile(_url_user_pass_pattern.encode())
+
+_T = t.TypeVar("_T", str, bytes)
+
+
+def _redact_url_creds(raw: _T, redact_user=True, repl="***", count=0) -> _T:
+    """
+    Redact URL credentials found in `raw`, by replacing the password and
+    (optionally) username with `repl`.
+
+    (A wrapper over `re.sub()`)
+
+    :param raw: The raw string to be redacted.
+    :param redact_user: If false, do not redact the username
+    :param count: If 0, replace all found occurrences; otherwise, replace only count
+    :return: A string (or bytes) with URL credentials redacted
+    """
+    if redact_user:
+        repl = rf"://{repl}:{repl}@"
+    else:
+        repl = rf"://\1:{repl}@"
+    if isinstance(raw, str):
+        return _url_user_pass_re.sub(repl=repl, string=raw, count=count)
+    return _urlb_user_pass_re.sub(repl=repl.encode(), string=raw, count=count)

--- a/funcx_endpoint/tests/conftest.py
+++ b/funcx_endpoint/tests/conftest.py
@@ -77,3 +77,11 @@ def randomstring():
         return "".join(random.choice(alphabet) for _ in range(length))
 
     return func
+
+
+@pytest.fixture
+def noop():
+    def _wrapped(*args, **kwargs):
+        pass
+
+    return _wrapped

--- a/funcx_endpoint/tests/unit/test_command_queue_subscriber.py
+++ b/funcx_endpoint/tests/unit/test_command_queue_subscriber.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import os
+import queue
+import random
+import threading
+from unittest import mock
+
+import pytest as pytest
+from pika.spec import Basic, BasicProperties
+from tests.utils import try_assert
+
+import funcx_endpoint.endpoint.rabbit_mq.command_queue_subscriber as cqs
+
+_MOCK_BASE = "funcx_endpoint.endpoint.rabbit_mq.command_queue_subscriber."
+
+
+class MockedCommandQueueSubscriber(cqs.CommandQueueSubscriber):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._time_to_stop_mock = threading.Event()
+
+    def start(self) -> None:
+        super().start()
+        try_assert(lambda: self._connection is not None)
+
+    def run(self):
+        self._connection = mock.MagicMock()
+        self._channel = mock.MagicMock()
+        self._time_to_stop_mock.wait()  # simulate thread work
+
+    def join(self, timeout: float | None = None) -> None:
+        if self._stop_event.is_set():  # important to identify bugs
+            self._time_to_stop_mock.set()
+        super().join(timeout=timeout)
+
+
+@pytest.fixture
+def mock_cqs():
+    q = {"queue": None}
+    mq = mock.Mock(spec=queue.SimpleQueue)
+    se = threading.Event()
+
+    mcqs = MockedCommandQueueSubscriber(queue_info=q, command_queue=mq, stop_event=se)
+    mcqs.start()
+
+    yield q, mq, se, mcqs
+
+    mcqs._stop_event.set()
+    if mcqs.is_alive():
+        mcqs.join()
+
+
+def test_cqs_repr():
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=None, stop_event=None
+    )
+    assert "<✗;" in repr(cq)
+    cq._consumer_tag = "asdf"
+    assert "<✓;" in repr(cq)
+    cq._consumer_tag = None
+    assert "<✗;" in repr(cq)
+
+    assert repr(cq).startswith(cq.__class__.__name__)
+    assert f"pid={os.getpid()}" in repr(cq)
+
+
+def test_cqs_stops_if_unable_to_connect(mocker):
+    mock_rnd = mocker.patch(f"{_MOCK_BASE}random")
+    mock_rnd.uniform.return_value = 0  # don't wait during test
+    mock_stop = mock.Mock(spec=threading.Event)
+    mock_stop.is_set.return_value = False
+    mock_stop.wait.return_value = None
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=None, stop_event=mock_stop
+    )
+    cq._connect = mock.Mock()
+
+    cq.run()
+    assert mock_rnd.uniform.call_count == cq.connect_attempt_limit - 1, "Random idle"
+    assert cq._connection_tries >= cq.connect_attempt_limit
+    assert cq._stop_event.wait.call_count == cq.connect_attempt_limit, "Should idle"
+
+
+def test_cqs_gracefully_handles_unexpected_exception(mocker):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    mock_rnd = mocker.patch(f"{_MOCK_BASE}random")
+    mock_rnd.uniform.return_value = 0  # don't wait during test
+    mock_stop = mock.Mock(spec=threading.Event)
+    mock_stop.is_set.return_value = False
+    mock_stop.wait.return_value = None
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=None, stop_event=mock_stop
+    )
+    cq._connect = mock.Mock()
+    cq._event_watcher = mock.Mock(side_effect=Exception)
+
+    cq.run()
+
+    assert mock_log.exception.call_count == cq.connect_attempt_limit
+    args, _kwargs = mock_log.exception.call_args
+    assert "shutting down" in args[0]
+
+
+def test_on_message_puts_to_queue(randomstring):
+    mock_q = mock.Mock(spec=queue.SimpleQueue)
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=mock_q, stop_event=None
+    )
+    mock_chan = mock.Mock()
+    bd = Basic.Deliver(delivery_tag=random.randint(1, 1000))
+    props = BasicProperties()
+    body = randomstring().encode()
+    cq._on_message(mock_chan, bd, props, body)
+
+    assert mock_q.put.called
+    assert mock_q.put.call_args[0][0] == (bd.delivery_tag, props, body)
+
+
+def test_on_message_gracefully_handles_garbled_packet(mocker):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=None, stop_event=None
+    )
+    cq._on_message(None, None, None, None)
+
+    assert mock_log.debug.called
+    assert "Invalid Basic.Deliver" in mock_log.debug.call_args[0][0]
+
+
+def test_on_message_nacks_on_failure(mocker):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    cq = cqs.CommandQueueSubscriber(
+        queue_info=None, command_queue=None, stop_event=None
+    )
+    mock_chan = mock.Mock()
+    bd = Basic.Deliver(delivery_tag=random.randint(1, 1000))
+    cq._on_message(mock_chan, bd, None, None)
+
+    assert mock_log.exception.called
+    assert "put failed" in mock_log.exception.call_args[0][0]
+    assert mock_chan.basic_nack.called
+    assert bd.delivery_tag == mock_chan.basic_nack.call_args[0][0]
+
+
+@pytest.mark.parametrize("exc", (MemoryError("some description"), "some description"))
+def test_cqs_stops_loop_on_open_failure(mocker, mock_cqs, exc):
+    *_, mcqs = mock_cqs
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    assert not mcqs._connection.ioloop.stop.called, "Test setup verification"
+
+    while not mcqs._stop_event.is_set():
+        mcqs._connection_tries += 1
+
+        assert not mock_log.warning.called
+        mcqs._connection.ioloop.stop.reset_mock()
+        mock_log.debug.reset_mock()
+
+        mcqs._on_open_failed(mcqs._connection, exc)  # kernel of test
+
+        assert mcqs._connection.ioloop.stop.called
+        assert mock_log.debug.called
+        (fmt, *args), *_ = mock_log.debug.call_args
+        msg = fmt % tuple(args)
+        assert "Failed to open connection" in msg
+        assert str(exc) in msg
+        assert exc.__class__.__name__ in msg
+
+    assert mcqs._connection_tries == mcqs.connect_attempt_limit
+    assert mock_log.warning.called, "Expected warning only on watcher quit"
+
+
+def test_cqs_connection_closed_stops_loop(mock_cqs):
+    exc = MemoryError("some description")
+    *_, mcqs = mock_cqs
+    assert not mcqs._connection.ioloop.stop.called
+    mcqs._on_connection_closed(mcqs._connection, exc)
+    assert mcqs._connection.ioloop.stop.called
+
+
+def test_cqs_channel_closed_retries_then_shuts_down(mock_cqs):
+    exc = Exception("some pika reason")
+    *_, mcqs = mock_cqs
+
+    for i in range(1, mcqs.channel_close_window_limit):
+        mcqs._connection.ioloop.call_later.reset_mock()
+        mcqs._on_channel_closed(mcqs._connection, exc)
+        assert len(mcqs._channel_closes) == i
+    mcqs._on_channel_closed(mcqs._connection, exc)
+
+    # and finally, no error if called "too many" times
+    mcqs._on_channel_closed(mcqs._connection, exc)
+
+
+def test_cqs_stable_connection_resets_fail_counter(mocker, mock_cqs):
+    mock_time = mocker.patch(f"{_MOCK_BASE}time")
+    mock_time.time.side_effect = [1000, 1061]  # 60 seconds passed
+    *_, mcqs = mock_cqs
+
+    mcqs._connection_tries = 57
+    mcqs._start_consuming()
+    mcqs._event_watcher()
+    assert mcqs._connection_tries == 0
+
+
+def test_cqs_channel_opened_starts_consuming(mock_cqs):
+    mock_channel = mock.Mock()
+    *_, mcqs = mock_cqs
+
+    assert mcqs._consumer_tag is None
+    mcqs._on_channel_open(mock_channel)
+    assert mock_channel is mcqs._channel
+    assert mcqs._consumer_tag is not None  # kernel: basic_consume() returns tag
+
+
+def test_cqs_start_consuming_error_shutsdown(mock_cqs):
+    *_, mcqs = mock_cqs
+
+    assert not mcqs._connection.ioloop.call_later.called
+    assert mcqs._consumer_tag is None
+    mcqs._channel.is_open = False  # not strictly necessary, but increase coverage
+    mcqs._channel.is_closed = False  # not strictly necessary, but increase coverage
+    mcqs._channel.basic_consume.side_effect = ValueError("Silly Goose!")
+    mcqs._start_consuming()
+    assert mcqs._connection.ioloop.call_later.called
+    assert mcqs._consumer_tag is None
+
+
+def test_cqs_amqp_acks_in_bulk(mock_cqs):
+    *_, mcqs = mock_cqs
+
+    num_messages = random.randint(1, 200)
+    for i in range(num_messages):
+        mcqs.ack(i)
+    assert mcqs._to_ack.qsize() == num_messages, "Verify test setup"
+    assert mcqs._channel.basic_ack.call_count == 0
+    mcqs._event_watcher()
+    assert mcqs._to_ack.qsize() == 0
+    assert mcqs._channel.basic_ack.call_count == 1
+
+
+def test_event_watcher_initiates_shutdown(mock_cqs):
+    *_, stop_event, mcqs = mock_cqs
+
+    stop_event.set()
+    assert not mcqs._channel.close.called, "Verify test setup"
+    mcqs._event_watcher()
+    assert mcqs._channel.close.called

--- a/funcx_endpoint/tests/unit/test_endpoint_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpoint_unit.py
@@ -209,7 +209,7 @@ def test_register_endpoint_locked_error(
 
 @pytest.mark.parametrize("multi_tenant", [None, True, False])
 @responses.activate
-def test_register_endpoint_multi_tenant(
+def test_register_endpoint_is_not_multitenant(
     mocker,
     fs,
     endpoint_uuid,
@@ -240,10 +240,7 @@ def test_register_endpoint_multi_tenant(
     assert ep_json_p.exists()
 
     request_body = json.loads(responses.calls[1].request.body)
-    if multi_tenant is True:
-        assert request_body["multi_tenant"] is True
-    else:
-        assert "multi_tenant" not in request_body
+    assert "multi_tenant" not in request_body, "endpoint.py is single-tenant logic only"
 
 
 def test_list_endpoints_none_configured(mock_ep_buf):

--- a/funcx_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -1,0 +1,777 @@
+import getpass
+import json
+import os
+import pathlib
+import queue
+import random
+import re
+import resource
+import signal
+import time
+import uuid
+from unittest import mock
+
+import pika
+import pytest as pytest
+import responses
+from globus_sdk import GlobusAPIError, NetworkError
+
+from funcx_endpoint.endpoint.endpoint_manager import EndpointManager
+from funcx_endpoint.endpoint.utils.config import Config
+
+_MOCK_BASE = "funcx_endpoint.endpoint.endpoint_manager."
+
+
+@pytest.fixture
+def conf_dir(fs):
+    conf_dir = pathlib.Path("/some/path/mock_endpoint")
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    yield conf_dir
+
+
+@pytest.fixture
+def mock_conf():
+    yield Config(executors=[])
+
+
+@pytest.fixture(autouse=True)
+def mock_setproctitle(mocker, randomstring):
+    orig_proc_title = randomstring()
+    mock_spt = mocker.patch(f"{_MOCK_BASE}setproctitle")
+    mock_spt.getproctitle.return_value = orig_proc_title
+    yield mock_spt, orig_proc_title
+
+
+@pytest.fixture
+def mock_client(mocker):
+    ep_uuid = str(uuid.uuid1())
+    mock_fxc = mocker.Mock()
+    mock_fxc.register_endpoint.return_value = {
+        "endpoint_id": ep_uuid,
+        "command_queue_info": {"connection_url": "", "queue": ""},
+    }
+    mocker.patch(f"{_MOCK_BASE}funcx.FuncXClient", return_value=mock_fxc)
+    yield ep_uuid, mock_fxc
+
+
+@pytest.fixture
+def epmanager(mocker, conf_dir, mock_conf, mock_client):
+    ep_uuid, mock_fxc = mock_client
+    em = EndpointManager(conf_dir, ep_uuid, mock_conf)
+    em._command = mocker.Mock()
+
+    yield conf_dir, mock_conf, mock_client, em
+
+
+@pytest.fixture
+def register_endpoint_failure_response():
+    def create_response(status_code: int = 200, err_msg: str = "some error msg"):
+        responses.add(
+            method=responses.POST,
+            url="https://api2.funcx.org/v2/endpoints",
+            headers={"Content-Type": "application/json"},
+            json={"error": err_msg},
+            status=status_code,
+        )
+
+    return create_response
+
+
+@pytest.fixture
+def successful_exec(mocker, epmanager):
+    mock_os = mocker.patch(f"{_MOCK_BASE}os")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    mock_os.fork.return_value = 0
+    mock_os.pipe.return_value = 40, 41
+    mock_os.dup2.side_effect = [0, 1, 2]
+    mock_os.open.return_value = 4
+
+    with open("local_user_lookup.json", "w") as f:
+        json.dump({"a": getpass.getuser()}, f)
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    pld = {
+        "globus_uuid": "a",
+        "globus_username": "a",
+        "command": "start_endpoint",
+        "kwargs": {"name": "some_ep_name"},
+    }
+    queue_item = (1, props, json.dumps(pld).encode())
+
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+
+    yield mock_os, conf_dir, mock_conf, mock_client, em
+
+
+@pytest.mark.parametrize("env", [None, "blar", "local", "production"])
+def test_sets_process_title(
+    randomstring, conf_dir, mock_conf, mock_client, mock_setproctitle, env
+):
+    mock_spt, orig_proc_title = mock_setproctitle
+
+    ep_uuid, mock_fxc = mock_client
+    mock_conf.environment = env
+
+    EndpointManager(conf_dir, ep_uuid, mock_conf)
+    assert mock_spt.setproctitle.called, "Sanity check"
+
+    a, *_ = mock_spt.setproctitle.call_args
+    assert a[0].startswith("funcX Endpoint"), "Expect easily identifiable process name"
+    assert "*(" in a[0], "Expected asterisk as subtle clue of 'multi-tenant'"
+    assert f"{ep_uuid}, {conf_dir.name}" in a[0], "Can find process by conf"
+
+    if env:
+        assert f" - {env}" in a[0], "Expected environment name in title"
+    else:
+        assert " - " not in a[0], "Default is not 'do not show env' for prod"
+    assert a[0].endswith(f"[{orig_proc_title}]"), "Save original cmdline for debugging"
+
+
+@responses.activate
+@pytest.mark.parametrize("status_code", [409, 423, 418])
+def test_gracefully_exits_if_in_conflict_or_locked(
+    mocker,
+    register_endpoint_failure_response,
+    conf_dir,
+    mock_conf,
+    endpoint_uuid,
+    randomstring,
+    get_standard_funcx_client,
+    status_code,
+):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    mock_fxc = get_standard_funcx_client()
+    mocker.patch(f"{_MOCK_BASE}funcx.FuncXClient", return_value=mock_fxc)
+
+    some_err = randomstring()
+    register_endpoint_failure_response(status_code, some_err)
+
+    with pytest.raises((GlobusAPIError, SystemExit)) as pyexc:
+        EndpointManager(conf_dir, endpoint_uuid, mock_conf)
+
+    if status_code in (409, 423):
+        assert pyexc.value.code == os.EX_UNAVAILABLE, "Expecting meaningful exit code"
+        assert mock_log.warning.called
+        a, *_ = mock_log.warning.call_args
+        assert some_err in str(a), "Expected upstream response still shared"
+    else:
+        # The other route tests SystemExit; nominally this route is an unhandled
+        # traceback -- good.  We should _not_ blanket hide all exceptions.
+        assert pyexc.value.http_status == status_code
+
+
+def test_sends_metadata_during_registration(conf_dir, mock_conf, mock_client):
+    ep_uuid, mock_fxc = mock_client
+    EndpointManager(conf_dir, ep_uuid, mock_conf)
+
+    assert mock_fxc.register_endpoint.called
+    _a, k = mock_fxc.register_endpoint.call_args
+    for key in ("endpoint_version", "hostname", "local_user", "config"):
+        assert key in k["metadata"], "Expected minimal metadata"
+
+    for key in (
+        "_type",
+        "multi_tenant",
+        "stdout",
+        "stderr",
+        "environment",
+        "funcx_service_address",
+    ):
+        assert key in k["metadata"]["config"]
+
+    assert k["metadata"]["config"]["multi_tenant"] is True
+
+
+def test_handles_network_error_scriptably(
+    mocker,
+    conf_dir,
+    mock_conf,
+    endpoint_uuid,
+    randomstring,
+):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    some_err = randomstring()
+    mocker.patch(
+        f"{_MOCK_BASE}funcx.FuncXClient",
+        side_effect=NetworkError(some_err, Exception()),
+    )
+
+    with pytest.raises(SystemExit) as pyexc:
+        EndpointManager(conf_dir, endpoint_uuid, mock_conf)
+
+    assert pyexc.value.code == os.EX_TEMPFAIL, "Expecting meaningful exit code"
+    assert mock_log.exception.called, "Expected usable traceback"
+    assert mock_log.critical.called
+    a = mock_log.critical.call_args[0][0]
+    assert "Network failure" in a
+    assert some_err in a
+
+
+def test_mismatched_id_gracefully_exits(
+    mocker, randomstring, conf_dir, mock_conf, mock_client
+):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    wrong_uuid, mock_fxc = mock_client
+    ep_uuid = str(uuid.uuid4())
+    assert wrong_uuid != ep_uuid, "Verify test setup"
+
+    with pytest.raises(SystemExit) as pyexc:
+        EndpointManager(conf_dir, ep_uuid, mock_conf)
+
+    assert pyexc.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
+    assert mock_log.error.called
+    a = mock_log.error.call_args[0][0]
+    assert "mismatched endpoint" in a
+    assert f"Expected: {ep_uuid}" in a
+    assert f"received: {wrong_uuid}" in a
+
+
+@pytest.mark.parametrize(
+    "received_data",
+    (
+        [False, {"command_queue_info": {"connection_url": ""}}],
+        [False, {"command_queue_info": {"queue": ""}}],
+        [False, {"typo-ed_cqi": {"connection_url": "", "queue": ""}}],
+        [True, {"command_queue_info": {"connection_url": "", "queue": ""}}],
+    ),
+)
+def test_handles_invalid_reg_info(
+    mocker, randomstring, conf_dir, mock_conf, mock_client, received_data
+):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    ep_uuid, mock_fxc = mock_client
+    received_data[1]["endpoint_id"] = ep_uuid
+    should_succeed, mock_fxc.register_endpoint.return_value = received_data
+
+    if not should_succeed:
+        with pytest.raises(SystemExit) as pyexc:
+            EndpointManager(conf_dir, ep_uuid, mock_conf)
+            assert pyexc.value.code == os.EX_DATAERR, "Expected meaningful exit code"
+            assert mock_log.error.called
+            a = mock_log.error.call_args[0][0]
+            assert "Invalid or unexpected" in a
+    else:
+        # "null" test
+        EndpointManager(conf_dir, ep_uuid, mock_conf)
+
+
+def test_writes_endpoint_uuid(epmanager):
+    conf_dir, _mock_conf, mock_client, _em = epmanager
+    _ep_uuid, mock_fxc = mock_client
+
+    returned_uuid = mock_fxc.register_endpoint.return_value["endpoint_id"]
+
+    ep_json_path = conf_dir / "endpoint.json"
+    assert ep_json_path.exists()
+
+    ep_data = json.loads(ep_json_path.read_text())
+    assert ep_data["endpoint_id"] == returned_uuid
+
+
+def test_log_contains_sentinel_lines(mocker, epmanager, noop):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    mocker.patch(f"{_MOCK_BASE}os")
+    em._event_loop = noop
+    em.start()
+
+    beg_re = re.compile(r"\n\n=+ Endpoint Manager begins =+\n")
+    end_re = re.compile(r"\n-+ Endpoint Manager ends -+\n\n")
+    log_str = "\n".join(a[0] for a, _ in mock_log.info.call_args_list)
+    assert log_str.startswith("\n\n"), "Expect visual separation for log trawlers"
+    assert beg_re.search(log_str) is not None, "Expected visual sentinel of begin"
+    assert "\nShutdown complete.\n" in log_str
+    assert end_re.search(log_str) is not None, "Expected visual sentinel of end"
+
+
+def test_title_changes_for_shutdown(mocker, epmanager, noop, mock_setproctitle):
+    conf_dir, mock_conf, mock_client, em = epmanager
+    mock_spt, orig_proc_title = mock_setproctitle
+
+    em._event_loop = noop
+    mocker.patch(f"{_MOCK_BASE}os")
+
+    mock_spt.reset_mock()
+    assert not mock_spt.setproctitle.called, "Verify test setup"
+    em.start()
+
+    assert mock_spt.setproctitle.called
+    a = mock_spt.setproctitle.call_args[0][0]
+    assert a.startswith("[shutdown in progress]"), "Let admin know action in progress"
+    assert a.endswith(orig_proc_title)
+
+
+def test_children_signaled_at_shutdown(mocker, epmanager, randomstring, noop):
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    em._event_loop = mocker.Mock()
+    em.wait_for_children = noop
+    mock_os = mocker.patch(f"{_MOCK_BASE}os")
+    mock_time = mocker.patch(f"{_MOCK_BASE}time")
+    mock_time.time.side_effect = [0, 10, 20, 30]  # don't _actually_ wait.
+    mock_os.getuid.side_effect = ["us"]  # fail if called more than once; intentional
+    mock_os.getgid.side_effect = ["us"]  # fail if called more than once; intentional
+    mock_os.getpgid = lambda pid: pid
+
+    expected = []
+    for _ in range(random.randrange(0, 10)):
+        uid, gid, pid = tuple(random.randint(1, 2**30) for _ in range(3))
+        uname = randomstring()
+        expected.append((uid, gid, uname, "some process command line"))
+        em._child_args[pid] = expected[-1]
+
+    gid_expected_calls = (
+        a
+        for b in zip(
+            ((gid, gid, -1) for _uid, gid, *_ in expected),
+            [("us", "us", -1)] * len(expected),  # return to root gid after signal
+        )
+        for a in b
+    )
+    uid_expected_calls = (
+        a
+        for b in zip(
+            ((uid, uid, -1) for uid, _gid, *_ in expected),
+            [("us", "us", -1)] * len(expected),  # return to root uid after signal
+        )
+        for a in b
+    )
+
+    # test that SIGTERM, *then* SIGKILL sent
+    killpg_expected_calls = [(pid, signal.SIGTERM) for pid in em._child_args]
+    killpg_expected_calls.extend((pid, signal.SIGKILL) for pid in em._child_args)
+
+    em.start()
+    assert em._event_loop.called, "Verify test setup"
+
+    resgid = mock_os.setresgid.call_args_list
+    resuid = mock_os.setresuid.call_args_list
+    killpg = mock_os.killpg.call_args_list[1:]
+
+    for setgid_call, exp_args in zip(resgid, gid_expected_calls):
+        assert setgid_call[0] == exp_args, "Signals only sent by _same_ user, NOT root"
+    for setuid_call, exp_args in zip(resuid, uid_expected_calls):
+        assert setuid_call[0] == exp_args, "Signals only sent by _same_ user, NOT root"
+    for killpg_call, exp_args in zip(killpg, killpg_expected_calls):
+        assert killpg_call[0] == exp_args, "Expected SIGTERM, *then* SIGKILL"
+
+
+def test_emits_endpoint_id_if_isatty(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    *_, em = epmanager
+
+    mocker.patch.object(em, "_install_signal_handlers", side_effect=Exception)
+
+    mock_sys = mocker.patch(f"{_MOCK_BASE}sys")
+    mock_sys.stdout.isatty.return_value = True
+    mock_sys.stderr.isatty.return_value = True
+    with pytest.raises(Exception):
+        em.start()
+
+    assert mock_log.info.called, "Always emitted to log"
+    a = mock_log.info.call_args[0][0]
+    assert em._endpoint_uuid_str in a
+    assert mock_sys.stdout.write.called
+    assert not mock_sys.stderr.write.called, "Expect ID not emitted twice"
+    written = "".join(a[0] for a, _ in mock_sys.stdout.write.call_args_list)
+    assert em._endpoint_uuid_str in written
+
+    mock_log.reset_mock()
+    mock_sys.reset_mock()
+    mock_sys.stdout.isatty.return_value = False
+    mock_sys.stderr.isatty.return_value = True
+    with pytest.raises(Exception):
+        em.start()
+
+    assert mock_log.info.called, "Always emitted to log"
+    a = mock_log.info.call_args[0][0]
+    assert em._endpoint_uuid_str in a
+    assert not mock_sys.stdout.write.called, "Expect ID not emitted twice"
+    assert mock_sys.stderr.write.called
+    written = "".join(a[0] for a, _ in mock_sys.stderr.write.call_args_list)
+    assert em._endpoint_uuid_str in written
+
+    mock_log.reset_mock()
+    mock_sys.reset_mock()
+    mock_sys.stdout.isatty.return_value = False
+    mock_sys.stderr.isatty.return_value = False
+    with pytest.raises(Exception):
+        em.start()
+
+    assert mock_log.info.called, "Always emitted to log"
+    a = mock_log.info.call_args[0][0]
+    assert em._endpoint_uuid_str in a
+    assert not mock_sys.stdout.write.called
+    assert not mock_sys.stderr.write.called
+
+
+def test_warns_of_no_local_lookup(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    em._time_to_stop = True
+    em._event_loop()
+
+    assert mock_log.error.called
+    a = mock_log.error.call_args[0][0]
+    assert "FileNotFoundError" in a, "Expected class name in error output -- help dev!"
+    assert " unable to respond " in a
+    assert " restart " in a
+    assert f"{os.getpid()}" in a
+
+
+def test_iterates_even_if_no_commands(mocker, epmanager):
+    conf_dir, mock_conf, mock_client, em = epmanager
+    mocker.patch(f"{_MOCK_BASE}log")  # silence logs
+
+    em._command_stop_event.set()
+    em._event_loop()  # subtest is that it iterates and doesn't block
+
+    em._time_to_stop = False
+    em._command_queue = mocker.Mock()
+    em._command_queue.get.side_effect = queue.Empty()
+    em._event_loop()
+
+    assert em._command_queue.get.called
+
+
+def test_emits_command_requested_debug(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    queue_item = [1, props, json.dumps({"asdf": 123}).encode()]
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    assert not mock_log.warning.called
+
+    props.headers = {"debug": False}
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._time_to_stop = False
+    em._event_loop()
+    assert not mock_log.warning.called
+
+    props.headers = {"debug": True}
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._time_to_stop = False
+    em._event_loop()
+    assert mock_log.warning.called
+    a = mock_log.warning.call_args[0][0]
+
+    assert "Command debug requested" in a
+    assert f"Delivery Tag: {queue_item[0]}" in a
+    assert f"Properties: {queue_item[1]}" in a
+    assert f"Body bytes: {queue_item[2]}" in a
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_emitted_debug_command_credentials_removed(mocker, epmanager, randomstring):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+        headers={"debug": True},
+    )
+
+    pword = randomstring()
+    pld = {"creds": f"scheme://user:{pword}@some.fqdn:1234/some/path"}
+    queue_item = [1, props, json.dumps(pld).encode()]
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    assert mock_log.warning.called
+
+    expected = re.sub(rf"{pword}@", "***@", pld["creds"])
+    a = mock_log.warning.call_args[0][0]
+    assert "Body bytes:" in a, "Verify test setup"
+    assert pld["creds"] not in a
+    assert pword not in a
+    assert expected in a
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_command_verifies_content_type(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+
+    props = pika.BasicProperties(
+        content_type="asdfasdfasdfasd",  # the test
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    queue_item = [1, props, json.dumps({"asdf": 123}).encode()]
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    assert mock_log.error.called
+    a = mock_log.error.call_args[0][0]
+    assert "Unable to deserialize Globus Compute services command" in a
+    assert "Invalid message type; expecting JSON" in a
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_ignores_stale_commands(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+
+    with open("local_user_lookup.json", "w") as f:
+        json.dump({"a": "a_user"}, f)
+
+    props = pika.BasicProperties(
+        content_type="application/json",  # the test
+        content_encoding="utf-8",
+        timestamp=round(time.time()) + 10 * 60,  # ten-minute clock skew, "apparently"
+        expiration="10000",
+    )
+
+    queue_item = [1, props, json.dumps({"asdf": 123}).encode()]
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    assert mock_log.warning.called
+    a = mock_log.warning.call_args[0][0]
+    assert "Ignoring command from server" in a
+    assert "Command too old or skew between" in a
+    assert "Command timestamp: " in a
+    assert "Endpoint timestamp: " in a
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_handles_invalid_server_msg_gracefully(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    queue_item = (1, props, json.dumps({"asdf": 123}).encode())
+
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    a = mock_log.error.call_args[0][0]
+    assert "Invalid server command" in a
+    assert "KeyError" in a, "Expected exception name in log line"
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_handles_unknown_user_gracefully(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    pld = {"globus_uuid": 1, "globus_username": 1}
+    queue_item = (1, props, json.dumps(pld).encode())
+
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    a = mock_log.warning.call_args[0][0]
+    assert "Invalid or unknown user" in a
+    assert "KeyError" in a, "Expected exception name in log line"
+    assert em._command.ack.called, "Command always ACKed"
+
+
+@pytest.mark.parametrize(
+    "cmd_name", ("", "_private", "9c", "valid_but_do_not_exist", " ", "a" * 101)
+)
+def test_handles_invalid_command_gracefully(mocker, epmanager, cmd_name):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    with open("local_user_lookup.json", "w") as f:
+        json.dump({"a": "a_user"}, f)
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    pld = {"globus_uuid": "a", "globus_username": "a", "command": cmd_name}
+    queue_item = (1, props, json.dumps(pld).encode())
+
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    a = mock_log.error.call_args[0][0]
+    assert "Unknown or invalid command" in a
+    assert str(cmd_name) in a
+    assert em._command.ack.called, "Command always ACKed"
+
+
+def test_handles_failed_command(mocker, epmanager):
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    mocker.patch(f"{_MOCK_BASE}EndpointManager.start_endpoint", side_effect=Exception())
+    conf_dir, mock_conf, mock_client, em = epmanager
+
+    with open("local_user_lookup.json", "w") as f:
+        json.dump({"a": "a_user"}, f)
+
+    props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        timestamp=round(time.time()),
+        expiration="10000",
+    )
+
+    pld = {"globus_uuid": "a", "globus_username": "a", "command": "start_endpoint"}
+    queue_item = (1, props, json.dumps(pld).encode())
+
+    em._command_queue = mocker.Mock()
+    em._command_stop_event.set()
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+    em._event_loop()
+    a = mock_log.exception.call_args[0][0]
+    assert "Unable to execute command" in a
+    assert pld["command"] in a, "Expected debugging help in log"
+    assert "   args: " in a, "Expected debugging help in log"
+    assert " kwargs: " in a, "Expected debugging help in log"
+    assert em._command.ack.called, "Command always ACKed"
+
+
+@pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT, signal.SIGQUIT])
+def test_handles_shutdown_signal(successful_exec, sig):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+
+    with mock.patch.object(em, "_install_signal_handlers") as mock_install:
+        mock_install.side_effect = Exception()
+        with pytest.raises(Exception):
+            em.start()
+        assert mock_install.called, "Ensure hookup that installs signal handlers ..."
+
+    em._install_signal_handlers()  # ... now install them for real ...
+    assert em._time_to_stop is False
+    os.kill(os.getpid(), sig)
+    em._event_loop()
+
+    assert em._time_to_stop is True
+    assert not em._command_queue.get.called, " ... that we've now confirmed works"
+
+
+def test_start_endpoint_children_die_with_parent(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+    a, k = mock_os.execvpe.call_args
+    assert a[0] == "funcx-endpoint", "Sanity check"
+    assert k["args"][0] == a[0], "Expect transparency for admin"
+    assert k["args"][-1] == "--die-with-parent"  # trust flag to do the hard work
+
+
+def test_start_endpoint_children_have_own_session(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+    assert mock_os.setsid.called
+
+
+def test_start_endpoint_privileges_dropped(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+
+    expected_user = getpass.getuser()
+    expected_gid = os.getgid()  # "cheating"; exploit knowledge of test setup
+    expected_uid = os.getuid()  # "cheating"; exploit knowledge of test setup
+    assert mock_os.initgroups.called
+    (uname, gid), _ = mock_os.initgroups.call_args
+    assert uname == expected_user
+    assert gid == expected_gid
+
+    assert mock_os.setresgid.called, "Do NOT save gid; truly change user"
+    a, _ = mock_os.setresgid.call_args
+    assert a == (expected_gid, expected_gid, expected_gid)
+
+    assert mock_os.setresuid.called, "Do NOT save uid; truly change user"
+    a, _ = mock_os.setresuid.call_args
+    assert a == (expected_uid, expected_uid, expected_uid)
+
+
+def test_default_to_secure_umask(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+
+    assert mock_os.umask.called
+    umask = mock_os.umask.call_args[0][0]
+    assert umask == 0o77
+
+
+def test_start_from_user_dir(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+
+    ud = mock_os.chdir.call_args[0][0]
+    assert ud == str(pathlib.Path.home())  # "cheating"; exploit knowledge of test setup
+
+
+def test_all_files_closed(successful_exec):
+    mock_os, _conf_dir, _mock_conf, _mock_client, em = successful_exec
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == 85, "Q&D: verify we exec'ed, based on '+= 1'"
+
+    _soft_no, hard_no = resource.getrlimit(resource.RLIMIT_NOFILE)
+    assert mock_os.closerange.called
+    (low, hi), _ = mock_os.closerange.call_args
+    assert low == 3, "Starts from first FD number after std* files"
+    assert low < hi
+    assert hi >= hard_no, "Expect ALL open files closed"
+
+    assert mock_os.dup2.call_count == 3, "Expect to close 3 std* files"
+    closed = [std_to_close for (_fd, std_to_close), _ in mock_os.dup2.call_args_list]
+    assert closed == [0, 1, 2]

--- a/funcx_endpoint/tests/unit/test_utils.py
+++ b/funcx_endpoint/tests/unit/test_utils.py
@@ -1,0 +1,23 @@
+from funcx_endpoint.endpoint.utils import _redact_url_creds
+
+
+def test_url_redaction(randomstring):
+    scheme = randomstring()
+    uname = randomstring()
+    pword = randomstring()
+    fqdn = randomstring()
+    somepath = randomstring()
+    some_url = f"{scheme}://{uname}:{pword}@{fqdn}/{somepath}"
+    for redact_user in (True, False):
+        kwargs = {"redact_user": redact_user}
+        for repl in (None, "XxX", "*", "---"):
+            if repl:
+                kwargs["repl"] = repl
+            else:
+                repl = "***"  # default replacement
+
+            if redact_user:
+                expected = f"{scheme}://{repl}:{repl}@{fqdn}/{somepath}"
+            else:
+                expected = f"{scheme}://{uname}:{repl}@{fqdn}/{somepath}"
+            assert _redact_url_creds(some_url, **kwargs) == expected

--- a/funcx_endpoint/tests/utils.py
+++ b/funcx_endpoint/tests/utils.py
@@ -1,5 +1,66 @@
+import itertools
+import sys
 import time
+import types
 import typing as t
+
+
+def create_traceback(start: int = 0) -> types.TracebackType:
+    """
+    Dynamically create a traceback.
+
+    Builds a traceback from the top of the stack (the currently executing frame) on
+    down to the root frame.  Optionally, use start to build from an earlier stack
+    frame.
+    """
+    tb = None
+    for depth in itertools.count(start + 1, 1):
+        try:
+            frame = sys._getframe(depth)
+            tb = types.TracebackType(tb, frame, frame.f_lasti, frame.f_lineno)
+        except ValueError:
+            break
+    return tb
+
+
+def try_assert(
+    test_func: t.Callable[[], bool],
+    fail_msg: str = "",
+    timeout_ms: float = 5000,
+    attempts: int = 0,
+    check_period_ms: int = 20,
+):
+    tb = create_traceback(start=1)
+    timeout_s = abs(timeout_ms) / 1000.0
+    check_period_s = abs(check_period_ms) / 1000.0
+    if attempts > 0:
+        for _attempt_no in range(attempts):
+            if test_func():
+                return
+            time.sleep(check_period_s)
+        else:
+            att_fail = (
+                f"\n  (Still failing after attempt limit [{attempts}], testing every"
+                f" {check_period_ms}ms)"
+            )
+            raise AssertionError(f"{str(fail_msg)}{att_fail}".strip()).with_traceback(
+                tb
+            )
+
+    elif timeout_s > 0:
+        end = time.monotonic() + timeout_s
+        while time.monotonic() < end:
+            if test_func():
+                return
+            time.sleep(check_period_s)
+        att_fail = (
+            f"\n  (Still failing after timeout [{timeout_ms}ms], with attempts "
+            f"every {check_period_ms}ms)"
+        )
+        raise AssertionError(f"{str(fail_msg)}{att_fail}".strip()).with_traceback(tb)
+
+    else:
+        raise AssertionError("Bad test configuration: no attempts or timeout period")
 
 
 def try_for_timeout(


### PR DESCRIPTION
The `EndpointManager` connects to the Globus Compute web services to register as a multi-tenant endpoint, and then listens for commands from upstream via an AMQP queue.

Commands are verified via:

- Command names must follow the regex `^[A-Za-z][0-9A-Za-z_]{0,99}$`

    - Roughly, a valid, non-private Python method name

- Commands must have an implemented class method on `EndpointManager`

- Commands must be associated with a Globus username

- The local machine must have a mapping of the Globus username to the local username

After validation (the above 4 bullet points), the command is then forked to a child process, and that child process drops all privileges by becoming the local user (i.e., `os.setres*id()`)

After forking, child processes are not double-forked before execing, with the intent of maintaining the process hierarchy tree for easier administrative understanding and maintenance.  Similarly, child processes are signalled to shutdown (SIGTERM) if the parent process shuts down.  After a 10 second grace period, the child processes are sent the SIGKILL method.  Notably, signals are sent strictly from the same user as which owns the child processes&nbsp;&mdash;&nbsp;the parent process user does *not* send the signals.

As of this commit, the only implemented command is `start_endpoint`.

[sc-19623]

## Type of change

- New feature (non-breaking change that adds functionality)
