### PR TITLE
Also include config.py in umask handling

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -98,20 +98,20 @@ class Endpoint:
             # only an issue for totally new users (no .funcx/!), but that is also
             # precisely the interaction -- the first one -- that should go smoothly
             endpoint_dir.mkdir(parents=True, exist_ok=True)
+
+            config_target_path = Endpoint._config_file_path(endpoint_dir)
+
+            if endpoint_config is None:
+                endpoint_config = pathlib.Path(endpoint_default_config.__file__)
+
+            Endpoint.update_config_file(
+                endpoint_dir.name,
+                endpoint_config,
+                config_target_path,
+                multi_tenant,
+            )
         finally:
             os.umask(user_umask)
-
-        config_target_path = Endpoint._config_file_path(endpoint_dir)
-
-        if endpoint_config is None:
-            endpoint_config = pathlib.Path(endpoint_default_config.__file__)
-
-        Endpoint.update_config_file(
-            endpoint_dir.name,
-            endpoint_config,
-            config_target_path,
-            multi_tenant,
-        )
 
     @staticmethod
     def configure_endpoint(


### PR DESCRIPTION
This is mostly to address test cleanup, but also going for "first user experience" despite a malformed setup (i.e., "weird umask").

The item of note for local-dev tests is that pytest was unable to cleanup after itself, resulting in messages like:

```
[...]/_pytest/pathlib.py:79: PytestWarning: (rm_rf) error removing /tmp/pytest-of-kevin/garbage-00f00fd5-4e73-469f-9354-5a5e492ee7d1
<class 'OSError'>: [Errno 39] Directory not empty: '/tmp/pytest-of-kevin/garbage-00f00fd5-4e73-469f-9354-5a5e492ee7d1'
  warnings.warn(
```

[sc-22042]

## Type of change

- Code maintenance/cleanup
