### PR TITLE
Rename `EPStatusReport.ep_status_report` to `global_state`

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/messages_compat.py
@@ -36,7 +36,7 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
     if isinstance(unpacked, InternalEPStatusReport):
         messagepack_msg = OutgoingEPStatusReport(
             endpoint_id=unpacked._header,
-            ep_status_report=unpacked.ep_status,
+            global_state=unpacked.global_state,
             task_statuses=unpacked.task_statuses,
         )
     elif isinstance(unpacked, dict):

--- a/funcx_endpoint/setup.py
+++ b/funcx_endpoint/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `funcx`
     "funcx>=1.0.8",
-    "funcx-common==0.0.24",
+    "funcx-common==0.0.25",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_messages_compat.py
+++ b/funcx_endpoint/tests/integration/funcx_endpoint/endpoint/test_messages_compat.py
@@ -23,7 +23,7 @@ from funcx_endpoint.executors.high_throughput.messages import Task as InternalTa
 
 def test_ep_status_report_conversion():
     ep_id = uuid.uuid4()
-    ep_status_report = {"looking": "good"}
+    global_state = {"looking": "good"}
     task_statuses = {
         "1": [
             TaskTransition(
@@ -41,7 +41,7 @@ def test_ep_status_report_conversion():
         ],
     }
 
-    internal = InternalEPStatusReport(str(ep_id), ep_status_report, task_statuses)
+    internal = InternalEPStatusReport(str(ep_id), global_state, task_statuses)
     message = pickle.dumps(internal)
 
     outgoing = try_convert_to_messagepack(message)
@@ -49,7 +49,7 @@ def test_ep_status_report_conversion():
 
     assert isinstance(external, OutgoingEPStatusReport)
     assert external.endpoint_id == ep_id
-    assert external.ep_status_report == ep_status_report
+    assert external.global_state == global_state
     assert external.task_statuses == task_statuses
 
 

--- a/funcx_sdk/setup.py
+++ b/funcx_sdk/setup.py
@@ -19,7 +19,7 @@ REQUIRES = [
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
     "pika>=1.2",
-    "funcx-common==0.0.24",
+    "funcx-common==0.0.25",
     "tblib==1.7.0",
     "texttable>=1.6.7",
 ]


### PR DESCRIPTION
# Description

Incorporates the change from https://github.com/funcx-faas/funcx-common/pull/78, and mirrors that change in endpoint-internal message structures.

[sc-22365]

## Type of change

- Code maintenance/cleanup
