### PR TITLE
Only push to the hub if changes are to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
 
   publish:
     # only trigger on pushes to the main repo (not forks, and not PRs)
-    if: ${{ github.repository == 'funcx-faas/funcX' && github.event_name == 'push' }}
+    if: ${{ github.repository == 'funcx-faas/funcX' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs:
       - lint
       - test-sdk


### PR DESCRIPTION
No sense in creating extra bandwidth -- push only when main changes.

## Type of change

- Code maintenance/cleanup