### PR TITLE
Avoid modifying data in structures

### DIFF
--- a/funcx_endpoint/funcx_endpoint/logging_config.py
+++ b/funcx_endpoint/funcx_endpoint/logging_config.py
@@ -3,6 +3,7 @@ This module contains logging configuration for the funcx-endpoint application.
 """
 from __future__ import annotations
 
+import copy
 import logging
 import logging.config
 import logging.handlers
@@ -10,6 +11,7 @@ import os
 import pathlib
 import re
 import sys
+import uuid
 
 log = logging.getLogger(__name__)
 
@@ -118,10 +120,16 @@ class FuncxConsoleFormatter(logging.Formatter):
             try:
                 record.msg = self.uuid_re.sub(repl, record.msg)
                 if isinstance(record.args, dict):
+                    record.args = copy.deepcopy(record.args)
                     for k, v in record.args.items():
-                        record.args[k] = self.uuid_re.sub(repl, str(v))
+                        if isinstance(v, (str, uuid.UUID)):
+                            record.args[k] = self.uuid_re.sub(repl, str(v))
                 elif record.args:
-                    args = tuple(self.uuid_re.sub(repl, str(a)) for a in record.args)
+                    uu_sub = self.uuid_re.sub
+                    args = tuple(
+                        uu_sub(repl, str(a)) if isinstance(a, (str, uuid.UUID)) else a
+                        for a in record.args
+                    )
                     record.args = args
             except Exception as exc:
                 # Basically, inform, but ignore


### PR DESCRIPTION
`--log-to-console`&nbsp;&mdash;&nbsp;together with `--debug`&nbsp;&mdash;&nbsp;colorizes the log messages before emitting them to stdout.  However, in searching for uuid strings, it inadvertently changed the data _within passed data structures_.  Address this by copying before munging the strings.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
