### PR TITLE
Remove an unnecessary traceback

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -289,17 +289,21 @@ class EndpointInterchange:
 
             try:
                 self._start_threads_and_main()
+            except pika.exceptions.ConnectionClosedByBroker as e:
+                log.warning(f"AMQP service closed connection: {e}")
             except pika.exceptions.ProbableAuthenticationError as e:
                 log.error(f"Unable to connect to AMQP service: {e}")
                 self._kill_event.set()
             except Exception:
-                self._reconnect_fail_counter += 1
-                log.exception("Unhandled exception in main kernel.")
-                log.info(
-                    "Reconnection count: %s (of %s)",
-                    self._reconnect_fail_counter,
-                    self.reconnect_attempt_limit,
-                )
+                log.error("Unhandled exception in main kernel.")
+            finally:
+                if not self._kill_event.is_set():
+                    self._reconnect_fail_counter += 1
+                    log.info(
+                        "Reconnection count: %s (of %s)",
+                        self._reconnect_fail_counter,
+                        self.reconnect_attempt_limit,
+                    )
 
             self.quiesce()
 

--- a/funcx_endpoint/tests/unit/test_endpointinterchange.py
+++ b/funcx_endpoint/tests/unit/test_endpointinterchange.py
@@ -14,7 +14,7 @@ def test_main_exception_always_quiesces(mocker, fs):
 
     # [False, False] * num because _kill_event and _quiesce_event are the same mock;
     #  .is_set() is called twice per loop
-    is_set_returns = [False, False] * num_iterations + [True]
+    is_set_returns = [False, False, False] * num_iterations + [True]
     false_true_g = iter(is_set_returns)
 
     def false_true():


### PR DESCRIPTION
And refactor the logging case to a single-branch&nbsp;&mdash;&nbsp;always do it!

The traceback in question:

```python
1678414266.450186 2023-03-09 21:11:06 ERROR MainProcess-3390136 MainThread-139902600003584 funcx_endpoint.endpoint.interchange:303 start Unhandled
 exception in main kernel.
Traceback (most recent call last):
  File "funcx_endpoint/endpoint/interchange.py", line 291, in start
    self._start_threads_and_main()
  File "funcx_endpoint/endpoint/interchange.py", line 323, in _start_threads_and_main
    self._main_loop()
  File "funcx_endpoint/endpoint/interchange.py", line 347, in _main_loop
    with results_publisher:
  File "funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py", line 49, in __exit__
    self.close()
  File "funcx_endpoint/endpoint/rabbit_mq/result_queue_publisher.py", line 88, in close
    self._connection.close()
  File "VENV/pika/adapters/blocking_connection.py", line 809, in close
    channel.close(reply_code, reply_text)
  File "VENV/pika/adapters/blocking_connection.py", line 1539, in close
    self._flush_output(lambda: self.is_closed)
  File "VENV/pika/adapters/blocking_connection.py", line 1353, in _flush_output
    self._connection._flush_output(lambda: self.is_closed, *waiters)
  File "VENV/pika/adapters/blocking_connection.py", line 523, in _flush_output
    raise self._closed_result.value.error
pika.exceptions.ConnectionClosedByBroker: (320, "CONNECTION_FORCED - user '[...]' is deleted")
```

Not nominally likely to see much of this in the wild, but possible, multiple registrations of the same endpoint (e.g., competing nodes).

## Type of change

- Code maintenance/cleanup
