### PR TITLE
Help test clean up after itself

### DIFF
--- a/funcx_endpoint/tests/unit/test_endpoint_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpoint_unit.py
@@ -416,3 +416,4 @@ def test_endpoint_config_handles_umask_gracefully(tmp_path, umask):
     Endpoint.init_endpoint_dir(ep_dir)
 
     assert ep_dir.stat().st_mode & 0o777 == 0o300, "Should honor user-read bit"
+    ep_dir.chmod(0o700)  # necessary for test to cleanup after itself


### PR DESCRIPTION
The weird permission test plays havoc with pathlib's assumptions.  Help it along.

With or without this PR, the tests don't fail.  However, Pytest fails to cleanup the detritus, reporting:

```
.../.tox/py/lib/python3.10/site-packages/_pytest/pathlib.py:79: PytestWarning: (rm_rf) error removing /tmp/pytest-of-USER/garbage-53fc2dc1-949f-457e-9fd1-6cee6eb1c32e/test_endpoint_config_handles_u0
<class 'OSError'>: [Errno 39] Directory not empty: 'test_endpoint_config_handles_u0'
  warnings.warn(
```

That message is repeated for each "garbage-" directory, so for as many times as one has run pytest.

## Type of change

- Code maintenance/cleanup
