### PR TITLE
Move print statement to before daemonization

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -323,6 +323,18 @@ class Endpoint:
             self.debug,
         )
 
+        ostream = None
+        if sys.stdout.isatty():
+            ostream = sys.stdout
+        elif sys.stderr.isatty():
+            ostream = sys.stderr
+        if ostream:
+            msg = f"Starting local interchange with endpoint id: {endpoint_uuid}"
+            if log_to_console:
+                # make more prominent against other drab gray text ...
+                msg = f"\n    {msg}\n"
+            print(msg, file=ostream)
+
         with context:
             # Per DaemonContext implementation, and that we _don't_ pass stdin,
             # fd 0 is already connected to devnull.  Unfortunately, there is an

--- a/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
+++ b/funcx_endpoint/funcx_endpoint/executors/high_throughput/executor.py
@@ -405,7 +405,6 @@ class HighThroughputExecutor(RepresentationMixin):
         get the worker task and result ports that the interchange has bound to.
         """
         comm_q = mpQueue(maxsize=10)
-        print(f"Starting local interchange with endpoint id: {self.endpoint_id}")
         self.queue_proc = Process(
             target=interchange.starter,
             name="Executor-Interchange",


### PR DESCRIPTION
Ensure that the endpoint uuid is always printed to the TTY.  This was never tested, and worked by chance until a few months ago.  Turns out that folks largely rely on this as a shortcut over delving into the logs, so ensure that it is printed to the console.

[sc-22869]

## Type of change

- Bug fix (non-breaking change that fixes an issue)