### PR TITLE
add note about scope for globus auth

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -232,6 +232,15 @@ The LoginManager is responsible for serving tokens to the FuncXClient as needed.
 
 A custom LoginManager can be used to simply return static tokens and enable programmatic use of the FuncXClient.
 
+.. note::
+    To access the funcX API the scope that needs to be requested from
+    Globus auth is FuncXClient.FUNCXSCOPE, which is:
+
+    .. code::
+
+      https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all
+
+
 More details on the funcX login manager prototcol are available `here. <https://github.com/funcx-faas/funcX/blob/main/funcx_sdk/funcx/sdk/login_manager/protocol.py>`_
 
 


### PR DESCRIPTION
Adding documentation about the funcX scope re: https://app.shortcut.com/funcx/story/22600/add-required-scope-to-api-documentation

Is there a better page to put this?

[sc-22600]