### PR TITLE
Enable overriding of kubelet endpoint name

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -164,7 +164,8 @@ The deployment is configured via values.yaml file.
 | maxCPU | Maximum CPUs to allocate to worker pod | 2 |
 | maxBlocks | Maximum number of worker pods to spawn | 100 |
 | maxWorkersPerPod | How many workers will be scheduled in each pod | 1 |
-| endpointUUID   | (Required) Specify a UUID for this endpoint. | |
+| endpointName | (Optional) Specify a name for registration with the funcX web services | The release name (Release.Name) |
+| endpointUUID | (Required) Specify a UUID for this endpoint | |
 | endpointCLIargs | Any additional command line arguments to give to the `funcx-endpoint` executable | |
 | maxIdleTime  | The maximum time to maintain an idle worker. After this time the SimpleStrategy will terminate the idle worker. | 3600 |
 | imagePullSecret | The K8s secret to use to deploy worker images. This can refer to an ECR secret. | |

--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -3,10 +3,10 @@
 EP_NAME="$1"; shift
 EP_UUID="$1"; shift
 
-echo -e "\n  Preparing to start kubelet Endpoint: $EP_NAME ($EP_UUID)\n"
+echo -e "\n  Preparing to start kubelet Endpoint: $EP_UUID ($EP_NAME)\n"
 
 mkdir -p "$HOME/.funcx/$EP_NAME/"
-cp /funcx/"$EP_NAME"/* "$HOME/.funcx/$EP_NAME/"
+cp /funcx/ep_instance/* "$HOME/.funcx/$EP_NAME/"
 cp /funcx/config/config.py "$HOME/.funcx/"
 
 if [[ -e "/funcx/credentials/storage.db" ]]; then

--- a/helm/funcx_endpoint/templates/endpoint-deployment.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: {{ .Release.Name }}-endpoint
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         command: [ "/bin/bash", "-c", "--" ]
-        args: [ "/home/funcx/boot.sh {{ .Release.Name }} {{ .Values.endpointUUID }} {{ .Values.endpointCLIargs }}" ]
+        args: [ "/home/funcx/boot.sh {{ coalesce .Values.endpointName .Release.Name }} {{ .Values.endpointUUID }} {{ .Values.endpointCLIargs }}" ]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -64,7 +64,7 @@ spec:
           - name: endpoint-config
             mountPath: /funcx/config
           - name: endpoint-instance-config
-            mountPath: /funcx/{{ .Release.Name }}
+            mountPath: /funcx/ep_instance
 
         ports:
           - containerPort: 5000


### PR DESCRIPTION
Set the `endpointName` to the desired name.

N.B., funcX uses the configuration directory name as the endpoint name; unfortunately, spaces are not handled robustly throughout.  For the time being then, an endpoint name with spaces will very likely fail.

[sc-22872]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
