### PR TITLE
Prefix commands methods with `cmd_`

### DIFF
--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint_manager.py
@@ -269,7 +269,7 @@ class EndpointManager:
             )
             log.error(msg)
 
-        valid_method_name_re = re.compile(r"^[A-Za-z][0-9A-Za-z_]{0,99}$")
+        valid_method_name_re = re.compile(r"^cmd_[A-Za-z][0-9A-Za-z_]{0,99}$")
         max_skew_s = 180  # 3 minutes; ignore commands with out-of-date timestamp
         while not self._time_to_stop:
             if self._wait_for_child:
@@ -344,7 +344,7 @@ class EndpointManager:
                 if not (command and valid_method_name_re.match(command)):
                     raise InvalidCommandError(f"Unknown or invalid command: {command}")
 
-                command_func = getattr(EndpointManager, command, None)
+                command_func = getattr(self.__class__, command, None)
                 if not command_func:
                     raise InvalidCommandError(f"Unknown or invalid command: {command}")
 
@@ -366,7 +366,7 @@ class EndpointManager:
                 self._command.ack(d_tag)
 
     @staticmethod
-    def start_endpoint(
+    def cmd_start_endpoint(
         child_args: dict[int, tuple[int, int, str, str]],
         local_username: str,
         args: list[str] | None,

--- a/funcx_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/funcx_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -101,7 +101,7 @@ def successful_exec(mocker, epmanager):
     pld = {
         "globus_uuid": "a",
         "globus_username": "a",
-        "command": "start_endpoint",
+        "command": "cmd_start_endpoint",
         "kwargs": {"name": "some_ep_name"},
     }
     queue_item = (1, props, json.dumps(pld).encode())
@@ -649,7 +649,9 @@ def test_handles_invalid_command_gracefully(mocker, epmanager, cmd_name):
 
 def test_handles_failed_command(mocker, epmanager):
     mock_log = mocker.patch(f"{_MOCK_BASE}log")
-    mocker.patch(f"{_MOCK_BASE}EndpointManager.start_endpoint", side_effect=Exception())
+    mocker.patch(
+        f"{_MOCK_BASE}EndpointManager.cmd_start_endpoint", side_effect=Exception()
+    )
     conf_dir, mock_conf, mock_client, em = epmanager
 
     with open("local_user_lookup.json", "w") as f:
@@ -662,7 +664,7 @@ def test_handles_failed_command(mocker, epmanager):
         expiration="10000",
     )
 
-    pld = {"globus_uuid": "a", "globus_username": "a", "command": "start_endpoint"}
+    pld = {"globus_uuid": "a", "globus_username": "a", "command": "cmd_start_endpoint"}
     queue_item = (1, props, json.dumps(pld).encode())
 
     em._command_queue = mocker.Mock()


### PR DESCRIPTION
Coming out of a post-merge review and walk-through, there was some fear that just ensuring the method existed on the class and was not private was not enough of a safe-guard, API wise.  An additional clue to the next dev when creating new functions is that they must now be prefixed with `cmd_`, which means the dev is aware of what they're implementing, and it will be much, much more difficult for a rogue execution to slip through.
    
Note that this is *in addition* to the web-side validation, which includes a specific allow-list (rather than a catch-all, like a regular expression).

[sc-19623]

## Type of change

- Code maintenance/cleanup
