### PR TITLE
Clean up bottom of index page of docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,22 +78,7 @@ how to download and configure an endpoint for local (multi-process) execution. :
 
 
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-   quickstart
-   executor
-   sdk
-   endpoints
-   Tutorial
-   actionprovider
-   reference/index
-   limits
-   changelog
-
-Indices and tables
-==================
+Links
+^^^^^
 
 * :ref:`genindex`
-* :ref:`search`


### PR DESCRIPTION
# Description

`` `search` `` is broken, and the table of contents is unnecessary given the sidebar.

## Type of change

- Code maintenance/cleanup
