### PR TITLE
Put docs sidebar navigation back

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,7 +78,22 @@ how to download and configure an endpoint for local (multi-process) execution. :
 
 
 
-Links
-^^^^^
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   quickstart
+   executor
+   sdk
+   endpoints
+   Tutorial
+   actionprovider
+   reference/index
+   limits
+   changelog
+
+Indices and tables
+==================
 
 * :ref:`genindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ how to download and configure an endpoint for local (multi-process) execution. :
 
 
 .. toctree::
+   :hidden:
    :maxdepth: 2
    :caption: Contents:
 
@@ -96,4 +97,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`search`


### PR DESCRIPTION
# Description

Put back the navigation sidebar, which was unintentionally removed in #1071.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update