### PR TITLE
Implement EP idle timer

### DIFF
--- a/changelog.d/20230330_005243_kevin_max_idle_s_after_work.rst
+++ b/changelog.d/20230330_005243_kevin_max_idle_s_after_work.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add two items to the ``Config`` object: ``idle_heartbeats_soft`` and
+  ``idle_heartbeats_hard``.  If set, the endpoint will auto-shutdown after the
+  specified number of heartbeats with no work to do.
+

--- a/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/interchange.py
@@ -17,8 +17,14 @@ import time
 from multiprocessing.synchronize import Event as EventType
 
 import pika.exceptions
+import setproctitle
 from funcx_common.messagepack import InvalidMessageError, pack, unpack
-from funcx_common.messagepack.message_types import Result, ResultErrorDetails, Task
+from funcx_common.messagepack.message_types import (
+    EPStatusReport,
+    Result,
+    ResultErrorDetails,
+    Task,
+)
 from parsl.version import VERSION as PARSL_VERSION
 
 import funcx_endpoint.endpoint.utils.config
@@ -296,6 +302,7 @@ class EndpointInterchange:
                 self._kill_event.set()
             except Exception:
                 log.error("Unhandled exception in main kernel.")
+                log.debug("Unhandled exception in main kernel.", exc_info=True)
             finally:
                 if not self._kill_event.is_set():
                     self._reconnect_fail_counter += 1
@@ -338,9 +345,7 @@ class EndpointInterchange:
         """
         log.debug("_main_loop begins")
 
-        results_publisher = ResultQueuePublisher(
-            queue_info=self.result_q_info,
-        )
+        results_publisher = ResultQueuePublisher(queue_info=self.result_q_info)
 
         with results_publisher:
             executor = list(self.executors.values())[0]
@@ -371,7 +376,7 @@ class EndpointInterchange:
             def process_pending_tasks():
                 # Pull tasks from upstream (RMQ) and send them down the ZMQ pipe to the
                 # funcx-manager.  In terms of shutting down (or "rebooting") gracefully,
-                # iterate once a second whether or not a task has arrived.
+                # iterate once a second -- regardless of whether a task has arrived.
                 nonlocal num_tasks_forwarded
                 ctype = executor.container_type
                 while not self._quiesce_event.is_set():
@@ -431,7 +436,7 @@ class EndpointInterchange:
 
                     try:
                         # This either works or it doesn't; if it doesn't, then
-                        # serialize an execption and send _that_
+                        # serialize an exception and send _that_
                         # will be a packed EPStatusReport or Result
                         message = try_convert_to_messagepack(packed_result)
 
@@ -459,7 +464,8 @@ class EndpointInterchange:
 
                     try:
                         results_publisher.publish(message)
-                        num_results_forwarded += 1  # Safe given GIL
+                        if task_id:
+                            num_results_forwarded += 1  # Safe given GIL
 
                     except Exception:
                         # Publishing didn't work -- quiesce and see if a simple restart
@@ -487,22 +493,90 @@ class EndpointInterchange:
             task_processor_thread.start()
             result_processor_thread.start()
 
-            log.debug("_main_loop entered running state")
             last_t, last_r = 0, 0
+
+            soft_idle_limit = max(0, self.config.idle_heartbeats_soft)
+            hard_idle_limit = max(soft_idle_limit + 1, self.config.idle_heartbeats_hard)
+            soft_idle_heartbeats = 0  # "happy path" idle timeout
+            hard_idle_heartbeats = 0  # catch-all idle timeout
+
+            live_proc_title = setproctitle.getproctitle()
+            log.debug("_main_loop entered running state")
             while not self._quiesce_event.wait(self.heartbeat_period):
                 # Possibly TOCTOU here, but we don't need to be super precise.  The
                 # point here is to mention "still alive" and that we're still working
                 num_t, num_r = num_tasks_forwarded, num_results_forwarded
+                diff_t, diff_r = num_t - last_t, num_r - last_r
                 log.debug(
                     "Heartbeat.  Approximate Tasks and Results forwarded since last "
                     "heartbeat: %s (T), %s (R)",
-                    num_t - last_t,
-                    num_r - last_r,
+                    diff_t,
+                    diff_r,
                 )
                 last_t, last_r = num_t, num_r
 
                 # only reset come heartbeat and still alive
                 self._reconnect_fail_counter = 0
+
+                if not soft_idle_limit:
+                    # idle timeout not enabled; "always on"
+                    continue
+
+                if diff_t or diff_r:
+                    # a task moved; reset idle heartbeat counter
+                    if soft_idle_heartbeats or hard_idle_heartbeats:
+                        log.info(
+                            "Moved to active state (due to tasks processed since"
+                            " last heartbeat)."
+                        )
+                    setproctitle.setproctitle(live_proc_title)
+                    soft_idle_heartbeats = 0
+                    hard_idle_heartbeats = 0
+                    continue
+
+                # only start "timer" if we've at least done *some* work
+                hard_idle_heartbeats += 1
+                if (num_t or num_r) and num_r >= num_t:
+                    # similar to above, only start "timer" if *idle* ... but
+                    # note that given self.result_store, it's possible to
+                    # have forwarded more results than tasks received.
+                    soft_idle_heartbeats += 1
+                    shutdown_s = soft_idle_limit - soft_idle_heartbeats
+                    shutdown_s *= self.heartbeat_period
+
+                    if soft_idle_heartbeats == 1:
+                        log.info(
+                            "In idle state (due to no task or result movement);"
+                            f" shut down in {shutdown_s:,}s.  (idle_heartbeats_soft)"
+                        )
+                    idle_proc_title = "[idle; shut down in {:,}s] {}"
+                    setproctitle.setproctitle(
+                        idle_proc_title.format(shutdown_s, live_proc_title)
+                    )
+
+                    if soft_idle_heartbeats >= soft_idle_limit:
+                        log.info("Idle heartbeats reached.  Shutting down.")
+                        self.time_to_quit = True
+                        self.stop()
+
+                elif hard_idle_heartbeats > hard_idle_limit:
+                    log.warning("Shutting down due to idle heartbeats HARD limit.")
+                    self.time_to_quit = True
+                    self.stop()
+
+                elif hard_idle_heartbeats > soft_idle_limit:
+                    shutdown_s = hard_idle_limit - hard_idle_heartbeats
+                    shutdown_s *= self.heartbeat_period
+                    if hard_idle_heartbeats == soft_idle_limit + 1:
+                        # only log the first time; no sense in filling logs
+                        log.info(
+                            "Possibly idle -- no task or result movement.  Will"
+                            f" shut down in {shutdown_s:,}s.  (idle_heartbeats_hard)"
+                        )
+                    idle_proc_title = "[possibly idle; shut down in {:,}s] {}"
+                    setproctitle.setproctitle(
+                        idle_proc_title.format(shutdown_s, live_proc_title)
+                    )
 
             # The timeouts aren't nominally necessary because if the above loop has
             # quit, then the _quiesce_event is set, and both threads check that event
@@ -510,3 +584,14 @@ class EndpointInterchange:
             stored_processor_thread.join(timeout=5)
             task_processor_thread.join(timeout=5)
             result_processor_thread.join(timeout=5)
+
+            # let higher-level error handling take over if the following excepts
+            message = EPStatusReport(
+                endpoint_id=self.endpoint_id,
+                # 0 == "no more heartbeats coming"
+                global_state={"heartbeat_period": 0},
+                task_statuses={},
+            )
+            results_publisher.publish(pack(message))
+
+            log.debug("_main_loop exits")


### PR DESCRIPTION
The timer functionality is based around the heartbeat period&nbsp;&mdash;&nbsp;if, after a specified number of heartbeats, nothing has happened, then shutdown.

There are two timers:

- `idle_heartbeats_soft`&nbsp;&mdash;&nbsp;This is the number of heartbeats after which to shutdown, assuming the following conditions:
    1. at least one task has been received,
    1. all received tasks have had their results forwarded to the web-service, and
    1. no new tasks have been received.

    In short, "if nothing to do" appears to be the new state, then shut down.

- `idle_heartbeats_hard`&nbsp;&mdash;&nbsp;The _hard_ timer is the same concept as the soft timer, except that it attempts to handle lost tasks as well&nbsp;&ndash;&nbsp;that is, if the number of tasks received is greater than the results received.  For example, this might occur if a worker process unexpectedly dies.  Assuming a heartbeat period of 30s, this value defaults to 5760, which equates to 30 * 5760; in other words, if no tasks or results are received for 2 whole days, then assume progress has stopped and shutdown.

If `idle_heartbeats_soft` is 0 (which is the default value), then the endpoint must be shut down manually (for example, SIGTERM or SIGINT).

The values may be set in the endpoint's `config.py` file:

    ```sh
        $ cat ~/.funcx/<ep_name>/config.py
        ...
        config = Config(
            executors=[ ... ],
            heartbeat_period=90,        # Do heartbeat check every 90 seconds
            idle_heartbeats_soft=5,     # After 5 heartbeats (so, 7.5m) with no work, shut down
            idle_heartbeats_hard=100,   # In case we get stuck, stop after 100 heartbeats
                                        # (100 * 90s == 2.5h) of no data movement
        )
        ...
    
[sc-22064]

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update
- Code maintenance/cleanup
