### PR TITLE
Re-allow endpoints to instantiate credentials

### DIFF
--- a/changelog.d/20230403_125849_kevin_broken_endpoint_for_new_users.rst
+++ b/changelog.d/20230403_125849_kevin_broken_endpoint_for_new_users.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address broken login-flow, introduced in v1.0.12 when attempting to start an
+  endpoint.  This affected users with invalid or missing credentials.  (e.g.,
+  new users or new installs).

--- a/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
+++ b/funcx_endpoint/funcx_endpoint/endpoint/endpoint.py
@@ -200,11 +200,6 @@ class Endpoint:
 
         result_store = ResultStore(endpoint_dir=endpoint_dir)
 
-        # From this point on, we don't read from stdin;
-        with open(os.devnull) as stdin:
-            if os.dup2(stdin.fileno(), 0) != 0:
-                raise Exception("Unable to close stdin")
-
         # Create a daemon context
         # If we are running a full detached daemon then we will send the output to
         # log files, otherwise we can piggy back on our stdout

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -34,7 +34,29 @@ One can also run tests against a local webservice setup.  Use the make targets
     make local_with_published_sdk
     make local_with_dev_sdk
 
-As with the above make targets, these are just wrappers around tox; can do the above by invoking tox direcly:
+As with the above make targets, these are just wrappers around tox; can do the
+above by invoking tox direcly:
 
     tox -- --funcx-config local
     tox -e localdeps -- --funcx-config local
+
+## Non-Pytest tests
+
+For those tests that require "raw" access to resources -- without the harness
+afforded by Pytest -- we have implemented a simple shell-script runner in
+`tests/sh/`.  To add new tests, create a shell-script in that directory that is
+prefixed with `test_`, suffixed with `.sh`, and is executable.  For example:
+
+    touch tests/sh/test_cool_new_test.sh
+    chmod +x tests/sh/test_cool_new_test.sh
+
+These tests are completely independent of any harness, so it is more incumbent
+upon the developer (than usual) to ensure that the tests clean up after
+themselves.
+
+For running the non-Pytests without running the other tests, invoke the
+`runner.sh` file (to run them all), or invoke the specific test of interest
+directly:
+
+    tests/sh/runner.sh           # invoke them all
+    tests/sh/test_endpoint.sh    # invoke a single test

--- a/smoke_tests/tests/sh/runner.sh
+++ b/smoke_tests/tests/sh/runner.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run shell scripts found in this directory and subdirectories.
+# N.B. this script searches for *executable* files only.
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$script_dir"
+
+find . -type f -name "test_*.sh" -executable -exec /bin/echo -n "({}) " \; -exec {} \;

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+env="smoke_test_environment"
+
+conf_dir="$(eval echo ~"/.funcx/smoke_test")"
+
+cleanup(){
+    [[ -d $conf_dir ]] && rm -rf "$conf_dir"
+    pkill -P $$
+}
+
+(sleep 10s; echo >&2 "Test took too long; killing."; cleanup; pkill -9 -g 0) &
+
+trap cleanup EXIT
+
+echo -n "New install initiates native login flow: "
+
+funcx-endpoint configure smoke_test > /dev/null # 2>&1
+
+if [[ ! -d "$conf_dir/" ]]; then
+    echo "Failed to make directory: $conf_dir/"
+    exit 2
+fi
+
+cat > "$conf_dir/config.py" <<EOF
+from parsl.providers import LocalProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            provider=LocalProvider(init_blocks=1, min_blocks=0, max_blocks=1),
+            heartbeat_period=10,
+        )
+    ],
+    environment="$env",
+    detach_endpoint=False,
+)
+EOF
+
+exit_code=3
+while read -r line; do
+    if [[ "Please authenticate with Globus here" = *"$line"* ]]; then
+       exit_code=0
+       break
+    fi
+done < <(exec timeout -k 1 5 funcx-endpoint start smoke_test 2>&1 || true)
+
+[[ $exit_code -eq 0 ]] && msg="32mPASSED" || msg="31mFAILED"
+echo -e "\033[$msg\033[0m"
+exit $exit_code

--- a/smoke_tests/tox.ini
+++ b/smoke_tests/tox.ini
@@ -16,7 +16,10 @@ deps =
     funcx-endpoint
     funcx-common
     pytest
-commands = pytest -v {posargs}
+allowlist_externals = /bin/bash
+commands =
+    pytest -v {posargs}
+    /bin/bash tests/sh/runner.sh
 
 [testenv:localdeps]
 passenv =
@@ -31,7 +34,10 @@ deps =
     -e ../funcx_sdk
     -e ../funcx_endpoint
     pytest
-commands = pytest -v {posargs}
+allowlist_externals = /bin/bash
+commands =
+    pytest -v {posargs}
+    /bin/bash tests/sh/runner.sh
 
 [flake8]  # black-compatible
 ignore = W503, W504, E203, B008


### PR DESCRIPTION
The fix is simple: remove the errantly added five lines in `endpoint.py`. However, testing this particular scenario proved difficult in standard pytest, so instead, opt for an outside-of-pytest approach: simple shell scripts.

This is not a complete solution for non-Pytest tests&nbsp;&mdash;&nbsp;in particular, there's currently no distinction between prod and dev or local&nbsp;&mdash;&nbsp;but there's also not a current need for it.  Assume we'll update the `runner.sh` (and specific tests) as/when the need is obviated.

[sc-23429]

## Type of change

- Bug fix (non-breaking change that fixes an issue)