### PR TITLE
Bump versions for release

### DIFF
--- a/changelog.d/20230327_121223_chris_remove_sdk_support_for_function_search.rst
+++ b/changelog.d/20230327_121223_chris_remove_sdk_support_for_function_search.rst
@@ -1,9 +1,0 @@
-Removed
-^^^^^^^
-
-- Removed all Search-related functionality.
-
-Deprecated
-^^^^^^^^^^
-
-- Deprecated all Search-related arguments to ``FuncXClient`` methods.

--- a/changelog.d/20230330_005243_kevin_max_idle_s_after_work.rst
+++ b/changelog.d/20230330_005243_kevin_max_idle_s_after_work.rst
@@ -1,7 +1,0 @@
-New Functionality
-^^^^^^^^^^^^^^^^^
-
-- Add two items to the ``Config`` object: ``idle_heartbeats_soft`` and
-  ``idle_heartbeats_hard``.  If set, the endpoint will auto-shutdown after the
-  specified number of heartbeats with no work to do.
-

--- a/changelog.d/20230403_125849_kevin_broken_endpoint_for_new_users.rst
+++ b/changelog.d/20230403_125849_kevin_broken_endpoint_for_new_users.rst
@@ -1,6 +1,0 @@
-Bug Fixes
-^^^^^^^^^
-
-- Address broken login-flow, introduced in v1.0.12 when attempting to start an
-  endpoint.  This affected users with invalid or missing credentials.  (e.g.,
-  new users or new installs).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,35 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-1.0.13:
+
+funcx & funcx-endpoint v1.0.13
+------------------------------
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Add two items to the ``Config`` object: ``idle_heartbeats_soft`` and
+  ``idle_heartbeats_hard``.  If set, the endpoint will auto-shutdown after the
+  specified number of heartbeats with no work to do.
+
+Bug Fixes
+^^^^^^^^^
+
+- Address broken login-flow, introduced in v1.0.12 when attempting to start an
+  endpoint.  This affected users with invalid or missing credentials.  (e.g.,
+  new users or new installs).
+
+Removed
+^^^^^^^
+
+- Removed all Search-related functionality.
+
+Deprecated
+^^^^^^^^^^
+
+- Deprecated all Search-related arguments to ``FuncXClient`` methods.
+
 .. _changelog-1.0.12:
 
 funcx & funcx-endpoint v1.0.12

--- a/funcx_endpoint/funcx_endpoint/version.py
+++ b/funcx_endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 
 # TODO: remove after a `funcx` release
 # this variable is needed because it's imported by `funcx` to do the version check

--- a/funcx_sdk/funcx/version.py
+++ b/funcx_sdk/funcx/version.py
@@ -4,7 +4,7 @@ from funcx.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 
 
 def compare_versions(


### PR DESCRIPTION
Preparing release; includes changes since v1.0.12.  Most notable: a stdin issue preventing the native login flow when initiated by the endpoint.
