### PR TITLE
fix serialization for nested functions

### DIFF
--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -213,7 +213,7 @@ Note that of the 3 categories of failures:
   We have agreed that we can only assist with 1) and 2)
 """
 COMBINED_SERIALIZE_METHODS = [
-    DillCodeSource.identifier,
+    # DillCodeSource.identifier,
     DillCode.identifier,
 ]
 
@@ -223,9 +223,9 @@ COMBINED_SEPARATOR = ":"
 
 METHODS_MAP_CODE = OrderedDict(
     [
-        (DillCodeSource.identifier, DillCodeSource),
+        # (DillCodeSource.identifier, DillCodeSource),
         (DillCode.identifier, DillCode),
-        (DillCodeTextInspect.identifier, DillCodeTextInspect),
+        # (DillCodeTextInspect.identifier, DillCodeTextInspect),
         (PickleCode.identifier, PickleCode),
         (CombinedCode.identifier, CombinedCode),
     ]

--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -213,7 +213,7 @@ Note that of the 3 categories of failures:
   We have agreed that we can only assist with 1) and 2)
 """
 COMBINED_SERIALIZE_METHODS = [
-    # DillCodeSource.identifier,
+    DillCodeSource.identifier,
     DillCode.identifier,
 ]
 
@@ -223,9 +223,9 @@ COMBINED_SEPARATOR = ":"
 
 METHODS_MAP_CODE = OrderedDict(
     [
-        # (DillCodeSource.identifier, DillCodeSource),
+        (DillCodeSource.identifier, DillCodeSource),
         (DillCode.identifier, DillCode),
-        # (DillCodeTextInspect.identifier, DillCodeTextInspect),
+        (DillCodeTextInspect.identifier, DillCodeTextInspect),
         (PickleCode.identifier, PickleCode),
         (CombinedCode.identifier, CombinedCode),
     ]

--- a/funcx_sdk/funcx/serialize/concretes.py
+++ b/funcx_sdk/funcx/serialize/concretes.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 import dill
 
-from funcx.serialize.base import DeserializationError, SerializeBase
+from funcx.serialize.base import DeserializationError, SerializeBase, SerializerError
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,8 @@ class DillCodeSource(SerializeBase):
         super().__init__()
 
     def serialize(self, data) -> str:
+        if data.__closure__ is not None:
+            raise SerializerError("Payload non-local variables ignored by `getsource`.")
         name = data.__name__
         body = dill.source.getsource(data, lstrip=True)
         x = codecs.encode(dill.dumps((name, body)), "base64").decode()
@@ -76,6 +78,8 @@ class DillCodeTextInspect(SerializeBase):
         super().__init__()
 
     def serialize(self, data) -> str:
+        if data.__closure__ is not None:
+            raise SerializerError("Payload non-local variables ignored by `getsource`.")
         name = data.__name__
         body = inspect.getsource(data)
         x = codecs.encode(dill.dumps((name, body)), "base64").decode()


### PR DESCRIPTION
# Description

This is a quick fix which @benclifford shared with me the other day, when I was unable to execute a dummy function which had been built by composing several smaller functions. My original slack thread asking for help is [here](https://funcx.slack.com/archives/C017637NZFA/p1680190170685589).

This was the original stack trace: 
```
FuncxTaskExecutionFailed:
    Traceback (most recent call last):
      File "/Users/owen/.local/pipx/venvs/funcx-endpoint/lib/python3.10/site-packages/funcx/serialize/facade.py", line 116, in unpack_and_deserialize
        deserialized = self.deserialize(current)
      File "/Users/owen/.local/pipx/venvs/funcx-endpoint/lib/python3.10/site-packages/funcx/serialize/facade.py", line 67, in deserialize
        result = self.methods_for_code[header].deserialize(payload)
      File "/Users/owen/.local/pipx/venvs/funcx-endpoint/lib/python3.10/site-packages/funcx/serialize/concretes.py", line 59, in deserialize
        return locals()[name]
    KeyError: 'rate_soup_COMPOSED_WITH_make_soup_COMPOSED_WITH_split_peas' 
```
(the goofy function name was unrelated the real problem)

My understanding is that the bug was due to the function being "successfully" registered and serialized via the `serializer.concretes.DillCodeSource` class, which meant just the inner function from the `compose` helper was actually sent, e.g.:
```python
def f_of_g(*args, **kwargs):
    return f(g(*args, **kwargs))
```
but because no exceptions were thrown, the serializer which *did* work for me (`serializer.concretes.DillCode`) was never tried. 

### Notes 
The "fix" in this PR seems a bit like commenting out the baby with the bathwater, but it did temporarily fix the issue blocking our ongoing garden/funcx integration. 

I wondered about just asserting that `data.__closure__ is not None` in the `DillCodeSource.serialize` method so it wouldn't "successfully" register inner functions like these, but I'm not at all sure what the real implications of that would be so I didn't include it here. 

## Type of change

- Bug fix
