### PR TITLE
Rename .funcx dir to .globus_compute

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,5 @@ A clear and concise description of what you expected to happen.
 - Where are you running the funcX script from? [e.g. Laptop/Workstation, Login node, Compute node]
 - Where does the endpoint run? [e.g. Laptop/Workstation, Login node]
 - What is your endpoint-uuid?
-- Attach endpoint logs at `~/.funcx/<ENDPOINT_NAME>` if this is an endpoint issue.
+- Attach endpoint logs at `~/.globus_compute/<ENDPOINT_NAME>` if this is an endpoint issue.
   Please let us know if you'd prefer to share logs privately.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 class CommandState:
     def __init__(self):
-        self.endpoint_config_dir: str = str(pathlib.Path.home() / ".funcx")
+        self.endpoint_config_dir: str = str(pathlib.Path.home() / ".globus_compute")
         self.debug = False
         self.no_color = False
         self.log_to_console = False
@@ -191,8 +191,8 @@ def configure_endpoint(
 ):
     """Configure an endpoint
 
-    Drops a config.py template into the funcx configs directory.
-    The template usually goes to ~/.funcx/<ENDPOINT_NAME>/config.py
+    Drops a config.py template into the Globus Compute configs directory.
+    The template usually goes to ~/.globus_compute/<ENDPOINT_NAME>/config.py
     """
     compute_dir = get_config_dir()
     ep_dir = compute_dir / name

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -95,8 +95,8 @@ class Endpoint:
         try:
             # pathlib.Path does not handle unusual umasks (e.g., 0o0111) so well
             # in the parents=True case, so temporarily change it.  This is nominally
-            # only an issue for totally new users (no .funcx/!), but that is also
-            # precisely the interaction -- the first one -- that should go smoothly
+            # only an issue for totally new users (no .globus_compute/!), but that is
+            # also precisely the interaction -- the first one -- that should go smoothly
             endpoint_dir.mkdir(parents=True, exist_ok=True)
 
             config_target_path = Endpoint._config_file_path(endpoint_dir)

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -29,7 +29,7 @@ from .login_manager import LoginManager, LoginManagerProtocol, requires_login
 
 logger = logging.getLogger(__name__)
 
-_FUNCX_HOME = os.path.join("~", ".funcx")
+_FUNCX_HOME = os.path.join("~", ".globus_compute")
 
 
 class Client:

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -36,11 +36,25 @@ def invalidate_old_config() -> None:
 
 
 def _ensure_funcx_dir() -> pathlib.Path:
-    dirname = _home() / ".funcx"
-    try:
-        os.makedirs(dirname)
-    except FileExistsError:
+    legacy_dirname = _home() / ".funcx"
+    dirname = _home() / ".globus_compute"
+
+    if dirname.is_dir():
         pass
+
+    elif dirname.is_file():
+        raise FileExistsError(
+            f"Error creating directory {dirname}, "
+            "please remove or rename the conflicting file"
+        )
+
+    elif legacy_dirname.is_dir():
+        legacy_dirname.replace(dirname)
+        legacy_dirname.symlink_to(dirname, target_is_directory=True)
+
+    else:
+        dirname.mkdir(parents=True, exist_ok=True)
+
     return dirname
 
 

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -32,6 +32,7 @@ TEST_REQUIRES = [
     "flake8==3.8.0",
     "pytest>=7.2",
     "pytest-mock",
+    "pyfakefs",
     "coverage",
     # easy mocking of the `requests` library
     "responses",

--- a/docs/funcx_upgrade.rst
+++ b/docs/funcx_upgrade.rst
@@ -23,7 +23,7 @@ If you currently have funcX installed, we recommend these steps to upgrade to
 Globus Compute:
 
   | $ pip uninstall funcx
-  | $ mv ~/.funcx ~/.compute   # Optional
+  | $ mv ~/.funcx ~/.globus_compute   # Optional
   | $ Install Globus Compute SDK in its own venv `as detailed here <quickstart.rst#_install_gc_sdk>`__
 
 The `funcx` package is still available on PyPI but will merely be a wrapper
@@ -38,7 +38,7 @@ the `Globus Compute Endpoint` and is
 `available on PyPI <https://pypi.org/project/globus-compute-client/>`_.
 
   | $ pip uninstall funcx-endpoint
-  | $ mv ~/.funcx ~/.compute   # Optional
+  | $ mv ~/.funcx ~/.globus_compute   # Optional
   | $ Install Globus Compute Endpoint `using pipx <quickstart.rst#_install_gc_endpoint>`__
 
 The `funcx-endpoint` package is still available on PyPI but will merely be a wrapper

--- a/helm/README.md
+++ b/helm/README.md
@@ -85,10 +85,10 @@ will already have generated the credential file.
     A prompt beginning "Please authenticate with Globus here:" and with a long
     URL to a Globus authentication workflow will print to the terminal; follow
     the URL and paste the resulting token back into the terminal.  This will
-    create the credential file at `$HOME/.funcx/storage.db`.
+    create the credential file at `$HOME/.globus_compute/storage.db`.
 1. Create a Kubernetes secret named `compute-sdk-tokens` with this file:
     ```shell
-    $ kubectl create secret generic compute-sdk-tokens --from-file=$HOME/.funcx/storage.db
+    $ kubectl create secret generic compute-sdk-tokens --from-file=$HOME/.globus_compute/storage.db
     ```
     It is important to name the secret `compute-sdk-tokens` as this chart looks
     for that secret name, specifically.

--- a/helm/boot.sh
+++ b/helm/boot.sh
@@ -5,13 +5,13 @@ EP_UUID="$1"; shift
 
 echo -e "\n  Preparing to start kubelet Endpoint: $EP_UUID ($EP_NAME)\n"
 
-mkdir -p "$HOME/.funcx/$EP_NAME/"
-cp /compute/"$EP_NAME"/* "$HOME/.funcx/$EP_NAME/"
-cp /compute/config/config.py "$HOME/.funcx/"
+mkdir -p "$HOME/.globus_compute/$EP_NAME/"
+cp /compute/"$EP_NAME"/* "$HOME/.globus_compute/$EP_NAME/"
+cp /compute/config/config.py "$HOME/.globus_compute/"
 
 if [[ -e "/compute/credentials/storage.db" ]]; then
-    cp /compute/credentials/storage.db "$HOME/.funcx/"
-    chmod 600 "$HOME/.funcx/storage.db"
+    cp /compute/credentials/storage.db "$HOME/.globus_compute/"
+    chmod 600 "$HOME/.globus_compute/storage.db"
 fi
 
 exec globus-compute-endpoint start "$EP_NAME" --endpoint-uuid "$EP_UUID" "$@"

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -16,8 +16,8 @@ from globus_sdk import AccessTokenAuthorizer, AuthClient, ConfidentialAppAuthCli
 #
 #  1. `--endpoint` opt
 #  2. COMPUTE_LOCAL_ENDPOINT_ID (seen here)
-#  3. COMPUTE_LOCAL_ENDPOINT_NAME (the name of a dir in `~/.funcx/`)
-#  4. An endpoint ID found in ~/.funcx/default/endpoint.json
+#  3. COMPUTE_LOCAL_ENDPOINT_NAME (the name of a dir in `~/.globus_compute/`)
+#  4. An endpoint ID found in ~/.globus_compute/default/endpoint.json
 #
 #  this var starts with the ID env var load
 _LOCAL_ENDPOINT_ID = os.getenv("COMPUTE_LOCAL_ENDPOINT_ID")
@@ -61,7 +61,7 @@ def _get_local_endpoint_id():
     #  - `--endpoint` is not passed
     local_endpoint_name = os.getenv("COMPUTE_LOCAL_ENDPOINT_NAME", "default")
     data_path = os.path.join(
-        os.path.expanduser("~"), ".funcx", local_endpoint_name, "endpoint.json"
+        os.path.expanduser("~"), ".globus_compute", local_endpoint_name, "endpoint.json"
     )
 
     try:

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -4,7 +4,7 @@ set -e
 
 env="smoke_test_environment"
 
-conf_dir="$(eval echo ~"/.funcx/smoke_test")"
+conf_dir="$(eval echo ~"/.globus_compute/smoke_test")"
 
 cleanup(){
     [[ -d $conf_dir ]] && rm -rf "$conf_dir"


### PR DESCRIPTION
# Description

The `.funcx` directory is now `.globus_compute`. If `.funcx`  is present when `globus-compute-sdk` is installed and used, we rename it and create a symlink to avoid breaking existing workflows. Otherwise, we create a fresh `.globus_compute` directory.

> Note:  The changelog for this work and #1067 will be created in a separate PR.

[sc-22439]