### PR TITLE
Use util from SDK to initialize endpoint config dir

### DIFF
--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import pathlib
 import shlex
 from unittest import mock
 
 import pytest
+from click import ClickException
 from click.testing import CliRunner
-from globus_compute_endpoint.cli import app
+from globus_compute_endpoint.cli import app, init_config_dir
 
 
 @pytest.fixture
@@ -58,6 +60,21 @@ def run_line(cli_runner):
         return result
 
     return func
+
+
+def test_init_config_dir(fs):
+    home_dir = pathlib.Path.home()
+    config_dir = init_config_dir()
+    assert config_dir == home_dir / ".globus_compute"
+
+
+def test_init_config_dir_file_conflict(fs):
+    filename = pathlib.Path.home() / ".globus_compute"
+    fs.create_file(filename)
+
+    with pytest.raises(ClickException) as exc:
+        init_config_dir()
+    assert "Error creating directory" in str(exc)
 
 
 def test_start_ep_corrupt(run_line, mock_cli_state, make_endpoint_dir):

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -35,7 +35,7 @@ def invalidate_old_config() -> None:
             os.remove(token_file)
 
 
-def _ensure_funcx_dir() -> pathlib.Path:
+def ensure_compute_dir() -> pathlib.Path:
     legacy_dirname = _home() / ".funcx"
     dirname = _home() / ".globus_compute"
 
@@ -59,7 +59,7 @@ def _ensure_funcx_dir() -> pathlib.Path:
 
 
 def _get_storage_filename():
-    datadir = _ensure_funcx_dir()
+    datadir = ensure_compute_dir()
     return os.path.join(datadir, "storage.db")
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -53,7 +53,7 @@ def ensure_compute_dir() -> pathlib.Path:
         legacy_dirname.symlink_to(dirname, target_is_directory=True)
 
     else:
-        dirname.mkdir(parents=True, exist_ok=True)
+        dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     return dirname
 

--- a/compute_sdk/tests/unit/test_login_manager.py
+++ b/compute_sdk/tests/unit/test_login_manager.py
@@ -15,8 +15,8 @@ from globus_compute_sdk.sdk.login_manager.client_login import (
     is_client_login,
 )
 from globus_compute_sdk.sdk.login_manager.tokenstore import (
-    _ensure_funcx_dir,
     _resolve_namespace,
+    ensure_compute_dir,
 )
 
 CID_KEY = "FUNCX_SDK_CLIENT_ID"
@@ -71,7 +71,7 @@ def test_ensure_compute_dir(fs, legacy_dir_exists, dir_exists):
     if dir_exists:
         fs.create_dir(dirname)
 
-    compute_dirname = _ensure_funcx_dir()
+    compute_dirname = ensure_compute_dir()
 
     assert compute_dirname.is_dir()
     assert compute_dirname == dirname
@@ -84,7 +84,7 @@ def test_conflicting_compute_file(fs):
     fs.create_file(filename)
 
     with pytest.raises(FileExistsError) as exc:
-        _ensure_funcx_dir()
+        ensure_compute_dir()
     assert "Error creating directory" in str(exc)
 
 


### PR DESCRIPTION
# Description

To ensure we properly handle the endpoint configuration directory when using the endpoint CLI (see #1086), we call the relevant SDK function when initializing a `CommandState` object. 

[sc-22439]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
