### PR TITLE
Removing obsolete classvar

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -146,14 +146,12 @@ class EndpointInterchange:
     def load_config(self):
         """Load the config"""
         log.info("Loading endpoint local config")
-
         self.results_passthrough = mpQueue()
         self.executors: dict[
             str, globus_compute_endpoint.executors.HighThroughputExecutor
         ] = {}
         for executor in self.config.executors:
             log.info(f"Initializing executor: {executor.label}")
-            executor.funcx_service_address = self.config.funcx_service_address
             if not executor.endpoint_id:
                 executor.endpoint_id = self.endpoint_id
             else:


### PR DESCRIPTION
This PR removes an obsolete class var that HTEX no longer needs the funcx_service_address with changes from PR #1022

I'm breaking up PR#1057 into smaller bits on @khk-globus 's recommendation.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
