### PR TITLE
Updating parsl req to 2023.03.27 

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -32,7 +32,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2023.1.23",
+    "parsl==2023.03.27",
     "pika>=1.2.0",
     "setproctitle>=1.3.2,<1.4",
 ]


### PR DESCRIPTION

# Description

This PR updates the parsl requirements for funcx_endpoint to parsl#2629. This brings in much better cleanup behavior in tests due to proper handling of signal handler inheritance in the `parsl.htex.interchange`.

This is pulled from the stack of changes in #1057 


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
