### PR TITLE
Support for timing out tasks at the worker 

### DIFF
--- a/changelog.d/20230418_150208_yadudoc1729_app_timeout.rst
+++ b/changelog.d/20230418_150208_yadudoc1729_app_timeout.rst
@@ -5,7 +5,7 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
  - Support for timing out tasks that exceed a walltime limit on the globus-compute-endpoint.
-   Use global variable `GC_TASK_TIMEOUT` which accepts a float to set the limit.
+   Use global variable ``GC_TASK_TIMEOUT`` which accepts a float to set the limit.
 ..
 .. Bug Fixes
 .. ^^^^^^^^^

--- a/changelog.d/20230418_150208_yadudoc1729_app_timeout.rst
+++ b/changelog.d/20230418_150208_yadudoc1729_app_timeout.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+ - Support for timing out tasks that exceed a walltime limit on the globus-compute-endpoint.
+   Use global variable `GC_TASK_TIMEOUT` which accepts a float to set the limit.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/compute_endpoint/globus_compute_endpoint/executors/high_throughput/worker.py
+++ b/compute_endpoint/globus_compute_endpoint/executors/high_throughput/worker.py
@@ -181,8 +181,8 @@ class Worker:
             task_data = task.task_buffer.decode("utf-8")  # type: ignore[attr-defined]
 
         f, args, kwargs = self.serializer.unpack_and_deserialize(task_data)
-        GC_TASK_TIMEOUT = int(os.environ.get("GC_TASK_TIMEOUT", 0))
-        if GC_TASK_TIMEOUT > 0:
+        GC_TASK_TIMEOUT = max(0.0, float(os.environ.get("GC_TASK_TIMEOUT", 0.0)))
+        if GC_TASK_TIMEOUT > 0.0:
             log.debug(f"Setting task timeout to GC_TASK_TIMEOUT={GC_TASK_TIMEOUT}s")
             f = timeout(f, GC_TASK_TIMEOUT)
         result_data = f(*args, **kwargs)

--- a/compute_endpoint/globus_compute_endpoint/executors/high_throughput/worker.py
+++ b/compute_endpoint/globus_compute_endpoint/executors/high_throughput/worker.py
@@ -182,8 +182,8 @@ class Worker:
 
         f, args, kwargs = self.serializer.unpack_and_deserialize(task_data)
         GC_TASK_TIMEOUT = int(os.environ.get("GC_TASK_TIMEOUT", 0))
-        log.warning(f"GC_TASK_TIMEOUT: {GC_TASK_TIMEOUT}")
         if GC_TASK_TIMEOUT > 0:
+            log.debug(f"Setting task timeout to GC_TASK_TIMEOUT={GC_TASK_TIMEOUT}s")
             f = timeout(f, GC_TASK_TIMEOUT)
         result_data = f(*args, **kwargs)
         serialized_data = self.serialize(result_data)

--- a/compute_endpoint/tests/unit/test_worker.py
+++ b/compute_endpoint/tests/unit/test_worker.py
@@ -160,15 +160,13 @@ def sleeper(t):
 
 def test_app_timeout(test_worker):
     task_id = uuid.uuid1()
-    task_body = ez_pack_function(test_worker.serializer, sleeper, (2,), {})
+    task_body = ez_pack_function(test_worker.serializer, sleeper, (1,), {})
     task_message = messagepack.pack(
         messagepack.message_types.Task(
             task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
         )
     )
 
-    os.environ["GC_TASK_TIMEOUT"] = "1"
-
-    with pytest.raises(AppTimeout):
-        x = test_worker.call_user_function(task_message)
-        print(x)
+    with mock.patch.dict(os.environ, {"GC_TASK_TIMEOUT": "0.1"}):
+        with pytest.raises(AppTimeout):
+            test_worker.call_user_function(task_message)

--- a/compute_endpoint/tests/unit/test_worker.py
+++ b/compute_endpoint/tests/unit/test_worker.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import uuid
 from unittest import mock
@@ -6,6 +7,7 @@ import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.executors.high_throughput.messages import Task
 from globus_compute_endpoint.executors.high_throughput.worker import Worker
+from parsl.app.errors import AppTimeout
 
 
 def hello_world():
@@ -147,3 +149,26 @@ def test_execute_function_exceeding_result_size_limit(test_worker):
     assert len(result["error_details"]) == 2
     assert result["error_details"][0] == "MaxResultSizeExceeded"
     assert result["error_details"][1].startswith("remote error: ")
+
+
+def sleeper(t):
+    import time
+
+    time.sleep(t)
+    return True
+
+
+def test_app_timeout(test_worker):
+    task_id = uuid.uuid1()
+    task_body = ez_pack_function(test_worker.serializer, sleeper, (2,), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(
+            task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
+        )
+    )
+
+    os.environ["GC_TASK_TIMEOUT"] = "1"
+
+    with pytest.raises(AppTimeout):
+        x = test_worker.call_user_function(task_message)
+        print(x)


### PR DESCRIPTION


# Description

This PR adds support for timing out tasks that exceed a configurable task timeout set globally at the endpoint.
The timeout is set using `GC_TASK_TIMEOUT` env var to be set on the endpoint. When a task exceeds the timeout
an exception is injected into it and this results in the task showing up as failed on the client side like this:

```
Traceback (most recent call last):
  File "/Users/yadu/.globus_compute/gc_1/tester.py", line 15, in <module>
    print(f"Result : {x.result()}")
  File "/Users/yadu/opt/anaconda3/envs/funcx_py3.9/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/Users/yadu/opt/anaconda3/envs/funcx_py3.9/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
globus_compute_sdk.errors.error_types.TaskExecutionFailed:
    Traceback (most recent call last):
      File "/Users/yadu/opt/anaconda3/envs/funcx_py3.9/lib/python3.9/site-packages/parsl/app/python.py", line 32, in wrapper
        result = f(*args, **kwargs)
      File "<string>", line 3, in sleeper
    parsl.app.errors.AppTimeout
```

Do we want a changelog entry for this? My guess is that it's not necessary for now as this is intended for the tutorial endpoint only at this point.

Fixes # (issue)
[sc-23725]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
