### PR TITLE
Flesh out funcx -> Globus Compute update document

### DIFF
--- a/docs/Tutorial.rst
+++ b/docs/Tutorial.rst
@@ -1,5 +1,5 @@
 Globus Compute Tutorial
-==============
+=======================
 
 Globus Compute is a Function-as-a-Service (FaaS) platform for science that enables you to register functions in a cloud-hosted service and then reliably execute those functions on a remote Globus Compute endpoint.
 This tutorial is configured to use a tutorial endpoint hosted by the Globus Compute Team.

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1,7 +1,7 @@
-Endpoints
-=========
+Globus Compute Endpoints
+========================
 
-An endpoint is a persistent service launched by the user on a compute system to serve as a conduit for
+An Globus Compute Endpoint is a persistent service launched by the user on a compute system to serve as a conduit for
 executing functions on that computer. Globus Compute supports a range of target systems, enabling
 an endpoint to be deployed on a laptop, the login node of a campus cluster, a cloud instance,
 or a Kubernetes cluster, for example.
@@ -9,8 +9,9 @@ or a Kubernetes cluster, for example.
 The endpoint requires outbound network connectivity. That is, it must be able to connect to
 Globus Compute at `funcx.org <https://api2.funcx.org/v2>`_.
 
-The Globus Compute endpoint is available on pypi.org (and thus available via ``pip``).
-However, *we strongly recommend installing the Globus Compute endpoint into an isolated virtual environment*.
+The Globus Compute Endpoint package `is available on PyPI <https://pypi.org/project/globus-compute-endpoint/>`_
+(and thus available via ``pip``). However, *we strongly recommend installing the
+Globus Compute endpoint into an isolated virtual environment*.
 `Pipx <https://pypa.github.io/pipx/installation/>`_ automatically manages
 package-specific virtual environments for command line applications, so install Globus Compute endpoint via::
 

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -1,5 +1,5 @@
 Globus Compute Executor
-==============
+=======================
 
 The |Executor|_ class, a subclass of Python's |Executor|_, is the
 preferred approach to collecting results from the Globus Compute web services.  Over

--- a/docs/funcx_upgrade.rst
+++ b/docs/funcx_upgrade.rst
@@ -2,46 +2,240 @@
 Upgrading from funcX SDK and funcx-endpoint
 ###########################################
 
-Note
-^^^^
-This document will be expanded at a later date to include more details.
+Overview
+^^^^^^^^
 
-Background
-^^^^^^^^^^
+The Globus team has renamed `funcX` to `Globus Compute` in order to centralize
+our infrastructure under a single umbrella.
 
-The Globus team is renaming funcX to Globus Compute in order centralize our
-infrastructure under a single umbrealla.
+This migration involves changing the package names and most classes with
+some variation of ``FuncX`` in the name.
+
+TL;DR We recommend uninstalling the old packages and installing
+``globus-compute-sdk`` / ``globus-compute-endpoint`` instead.  Then change
+any import statements to reflect the name of the new packages.
+
+For the SDK, ``FuncXClient`` and ``FuncXExecutor`` have been renamed to ``Client``
+and ``Executor``.  For the Endpoint, merely using the command
+``globus-compute-endpoint`` instead of ``funcx-endpoint`` should work.
+
+.. note::
+  An alternate upgrade path is to install the latest ``funcx / funcx-endpoint``
+  packages which are a wrapper around ``globus-compute-sdk`` and
+  ``globus-compute-endpoint`` respectively. This should work as is for most
+  users. However the funcx* packages are meant to be a temporary convenience
+  and are soon to be deprecated.
+
 
 funcX SDK
 ^^^^^^^^^
 
-The `funcx` PyPI package was formerly the funcX SDK.  This is now named the `Globus
-Compute SDK` and is `available on PyPI <https://pypi.org/project/globus-compute-sdk/>`_
-under the same name.
+The ``funcx`` PyPI package was formerly the funcX SDK.  The SDK has been renamed
+to the ``Globus Compute SDK`` and is `available on PyPI <https://pypi.org/project/globus-compute-sdk/>`_.
 
-If you currently have funcX installed, we recommend these steps to upgrade to
-Globus Compute:
+If you currently have ``funcx`` installed, we recommend these steps for upgrading:
 
   | $ pip uninstall funcx
   | $ mv ~/.funcx ~/.globus_compute   # Optional
-  | $ Install Globus Compute SDK in its own venv `as detailed here <quickstart.rst#_install_gc_sdk>`__
+  | $ `Install Globus Compute SDK in its own venv <quickstart.html#installing-the-globus-compute-endpoint-optional>`_
 
-The `funcx` package is still available on PyPI but will merely be a wrapper
-around the Globus Compute SDK.  The wrapper will only be available for
-a limited time to assist users as an easier migration path.
+SDK Usage Changes
+-----------------
+
+Most users utilize only the ``FuncXClient`` and ``FuncXExecutor`` classes.
+These have been renamed to ``Client`` and ``Executor`` respectively. The
+required import changes are:
+
+.. code-block:: python
+
+  from funcx import FuncXClient
+  from funcx import FuncXExecutor
+
+to
+
+.. code-block:: python
+
+  from globus_compute_sdk import Client
+  from globus_compute_sdk import Executor
+
+All other module and classes that had ``"FuncX"`` in their names have been renamed
+to ``Compute*``.  These changes `are detailed below <#SDK-Module-and-Class-Changes>`_.
+
+The directory used for local cache storage is now ``~/.globus_compute`` instead of
+``~/.funcx``.  We recommend renaming ~/.funcx to ``~/.globus_compute`` after
+installing the new package.  Otherwise, first usage of the new SDK will
+automatically rename it and create a symlink from the old to the new.
+
+For other, less relevant changes, `also see below <#SDK-Module-and-Class-Changes>`_.
 
 funcX Endpoint
 ^^^^^^^^^^^^^^
 
-`funcx-endpoint` on PyPI was the former funcX endpoint package.  This is now called
-the `Globus Compute Endpoint` and is
-`available on PyPI <https://pypi.org/project/globus-compute-client/>`_.
+`funcx-endpoint` on PyPI was the former funcX endpoint package.  This is now
+`Globus Compute Endpoint` and is available on
+`PyPI here <https://pypi.org/project/globus-compute-endpoint/>`_.
+
+If you currently have ``funcx-endpoint`` installed, we recommend these steps for
+upgrading:
 
   | $ pip uninstall funcx-endpoint
   | $ mv ~/.funcx ~/.globus_compute   # Optional
-  | $ Install Globus Compute Endpoint `using pipx <quickstart.rst#_install_gc_endpoint>`__
+  | $ `Install Globus Compute Endpoint using pipx <quickstart.html#installing-the-globus-compute-endpoint-optional>`_
 
-The `funcx-endpoint` package is still available on PyPI but will merely be a wrapper
-around Globus Compute Endpoint.  The wrapper will only be available for
-a limited time to assist users as an easier migration path.
+Endpoint Usage Changes
+----------------------
 
+For most users, the only change necessary is to use ``globus-compute-endpoint``
+instead of ``funcx-endpoint`` when invoking endpoint commands.  i.e.
+
+  | $ ``globus-compute-endpoint configure my_new_great_endpoint``
+  | $ ``globus-compute-endpoint start my_new_great_endpoint``
+
+The directory used to store endpoint info is now ``~/.globus_compute`` instead of
+``~/.funcx``.  We recommend renaming your existing ``~/.funcx`` to
+``~/.globus_compute`` after installing the new package.  On first start,
+``globus-compute-endpoint`` will rename the directory and create a symlink from
+the old to the new, if ``~.globus_compute`` doesn't already exist.
+
+For other, less relevant changes, please `see below <#Endpoint-Module-and-Class-Changes>`_.
+
+Detailed Change/Upgrade Reference
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following is not necessarily a comprehensive list of all changes. It is
+only meant to detail items of relevance to most users.
+
+funcx -> globus-compute-sdk
+---------------------------
+
+SDK Module and Class Changes
+............................
+
+These modules and classes have been renamed:
+
+.. code-block:: python
+
+  from funcx import FuncXClient
+  from funcx import FuncXExecutor
+  from funcx.errors import FuncxError
+  from funcx.errors import FuncxTaskExecutionFailed
+  from funcx.sdk.web_client import FuncXWebClient
+  from funcx.sdk.asynchronous.funcx_task import FuncXTask
+  from funcx.sdk.asynchronous.funcx_future import FuncXFuture  # Deprecated
+  from funcx.serialize import FuncXSerializer
+  from funcx.sdk.login_manager import FuncxScopes
+  from funcx.sdk.login_manager import FuncxScopeBuilder
+
+to
+
+.. code-block:: python
+
+  from globus_compute_sdk import Client
+  from globus_compute_sdk import Executor
+  from globus_compute_sdk.errors import ComputeError
+  from globus_compute_sdk.errors import TaskExecutionFailed
+  from globus_compute_sdk.sdk.web_client import WebClient
+  from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture  # Deprecated
+  from globus_compute_sdk.sdk.asynchronous.compute_task import ComputeTask
+  from globus_compute_sdk.serialize import ComputeSerializer
+  from globus_compute_sdk.sdk.login_manager import ComputeScopes
+  from globus_compute_sdk.sdk.login_manager import ComputeScopeBuilder
+
+Other SDK notes
+...............
+
+* ``LoginManager.get_funcx_web_client()`` has been renamed to ``.get_web_client()``
+
+Most constants and variable names with ``FuncX`` in their names have **not**
+changed in order to simply the migration process:
+
+* Client.FUNCX_SCOPE
+* Client.FUNCX_SDK_CLIENT_ID
+* Client.funcx_service_address,
+* Client.funcx_home
+* Client.fx_authorizer
+* Client.fx_serializer
+* Executor.funcx_client
+* WebSocketPollingTask.funcx_client
+
+The Scope value for the ``Globus Compute`` services has not changed with
+respect to Globus Auth.
+
+
+Using the new funcx wrapper package
+...................................
+
+* The `funcx` package is still available for a limited time on PyPI but
+  will merely be a wrapper around the ``Globus Compute SDK``.  The wrapper can
+  serve as an easier migration path for some users looking for minimal
+  migration effort in the short term.
+
+
+The updated `funcx <https://pypi.org/project/funcx/>`_ package
+begins with version 2.0.0, built on top of ``Globus Compute SDK`` 2.0.0.
+
+These frequently used classes maintain their module hierarchy by linking to their
+``Globus Compute SDK`` counterparts and do not require modification of scripts
+that reference them:
+
+.. code-block:: python
+
+  from funcx import FuncXClient
+  from funcx import FuncXExecutor
+  import funcx.sdk.web_client
+  from funcx.sdk.web_client import FuncXWebClient
+  from funcx.sdk.login_manager import FuncxScopes
+  from funcx.sdk.login_manager import LoginManager
+  from funcx.sdk.login_manager import LoginManagerProtocol
+  from funcx.sdk.login_manager import requires_login
+  from funcx.sdk.serialize import FuncXSerializer
+
+funcx-endpoint -> globus-compute-endpoint
+-----------------------------------------
+
+Endpoint Module and Class Changes
+.................................
+
+These modules and classes have been renamed:
+
+.. code-block:: python
+
+  from funcx_endpoint.logging_config import FXLogger
+  from funcx_endpoint.logging_config import FuncxConsoleFormatter
+  from funcx_endpoint.executors.high_throughput.funcx_worker import FuncXWorker
+
+
+to
+
+.. code-block:: python
+
+  from globus_compute_endpoint.logging_config import ComputeLogger
+  from globus_compute_endpoint.logging_config import ComputeConsoleFormatter
+  from globus_compute_endpoint.executors.high_throughput.worker import Worker
+
+Other endpoint notes
+......................
+
+* ``Config.funcx_service_address`` in ``globus_compute_endpoint.endpoint.utils.config`` has not been renamed.
+
+Using the new funcx-endpoint wrapper package
+............................................
+
+* The `funcx-endpoint` package is still available for a limited time on
+  PyPI but will merely be a wrapper around the ``Globus Compute Endpoint``.  The
+  wrapper can serve as an easier migration path for some users looking for
+  minimal interruptions of service in the short term.
+
+The updated `funcx-endpoint <https://pypi.org/project/funcx-endpoint/>`_ package
+begins with version 2.0.0, built on top of ``Globus Compute Endpoint`` 2.0.0.
+
+These frequently used classes maintain their module hierarchy by linking to
+Globus Compute Endpoint counterparts and do not require modification of scripts
+that reference them:
+
+.. code-block:: python
+
+  from funcx_endpoint.endpoint.utils.config import Config
+  from funcx_endpoint.executors import HighThroughputExecutor
+  from funcx_endpoint.executors.high_throughput import Manager
+  from funcx_endpoint.executors.high_throughput import FuncXWorker

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,14 +31,14 @@ This should return a version string, for example: ``"1.0.5"``
 .. note:: The Globus Compute client is supported on MacOS, Linux, and Windows. The globus-compute-endpoint
    is only supported on Linux.
 
-.. _install_gc_sdk:
 Installing Globus Compute in a Virtual Environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While ``pip`` and ``pip3`` can be used to install Globus Compute we suggest the following approach
 for reliable installation to avoid python package dependency conflicts.
 
-1. Install the Globus Compute client in its own `venv <https://docs.python.org/3/tutorial/venv.html>`_ environment::
+Install the Globus Compute client in its own `venv <https://docs.python.org/3/tutorial/venv.html>`_ environment::
+.................................................................................................................
 
     $ python3 -m venv path/to/globus_compute_venv
     $ source path/to/globus_compute_venv/bin/activate
@@ -48,8 +48,9 @@ for reliable installation to avoid python package dependency conflicts.
 
     (globus_compute_venv) $ python3 -m pip install -U globus-compute-sdk
 
-.. _install_gc_endpoint:
-2. (Optional) The Globus Compute endpoint can be installed using `Pipx <https://pypa.github.io/pipx/installation/>`_ or using pip in the venv::
+Installing the Globus Compute Endpoint (Optional)
+.................................................
+The Globus Compute endpoint can be installed using `Pipx <https://pypa.github.io/pipx/installation/>`_ or using pip in the venv::
 
      $ python3 -m pipx install globus-compute-endpoint
 
@@ -57,7 +58,9 @@ for reliable installation to avoid python package dependency conflicts.
 
      (globus_compute_venv) $ python3 -m pip install globus-compute-endpoint
 
-3. (Optional) Install Jupyter for Tutorial notebooks in the venv::
+Installing Jupyter for Tutorial notebooks (Optional)
+....................................................
+Install Jupyter for Tutorial notebooks in the venv::
 
      (globus_compute_venv) $ python3 -m pip install jupyter
 


### PR DESCRIPTION
This adds detail to the Globus Compute package upgrade document.

Also includes some minor corrections to the formats of other pages to lessen Sphinx warnings, and change some occurrences of 'Endpoint' to 'Globus Compute Endpoint' in the index heading display.

A separate PR reuses a summary of the info to add smaller entries to the package changelogs.

You can see what the upgrade doc roughly looks like at https://globus-compute.readthedocs.io/en/latest/funcx_upgrade.html  (linked a prior version of this branch to readthedocs).  