### PR TITLE
Fix typo in class name from funcx_endpoint

### DIFF
--- a/compute_funcx/endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
+++ b/compute_funcx/endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py
@@ -1,3 +1,3 @@
 from globus_compute_endpoint.executors.high_throughput.manager import (  # noqa: F401
-    Manager as FuncXManager,
+    Manager,
 )


### PR DESCRIPTION
The old funcx_endpoint package used Manager, not FuncXManager.  (Confusing because FuncXWorker has the prefix).

[Old funcx_manager.py: ](https://github.com/funcx-faas/funcX/blob/3c30f16ad0c6a9f05b21262d7e2def784995fd19/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_manager.py)

[Old funcx_worker.py:](https://github.com/funcx-faas/funcX/blob/3c30f16ad0c6a9f05b21262d7e2def784995fd19/funcx_endpoint/funcx_endpoint/executors/high_throughput/funcx_worker.py)


When adding backwards compatibility we need to match what we used before.  This was a typo in the rebranding PR.

