### PR TITLE
Add `allowlist_externals` in addition to `whitelist_externals` in `tox.ini`s

### DIFF
--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -26,6 +26,7 @@ deps = build
        twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands = python -m build
            twine upload dist/*

--- a/compute_funcx/endpoint/tox.ini
+++ b/compute_funcx/endpoint/tox.ini
@@ -4,6 +4,7 @@ deps = build
        twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands = python -m build
            twine upload dist/*

--- a/compute_funcx/sdk/tox.ini
+++ b/compute_funcx/sdk/tox.ini
@@ -4,6 +4,7 @@ deps = build
        twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands = python -m build
            twine upload dist/*

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -22,6 +22,7 @@ deps = build
        twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands = python -m build
            twine upload dist/*


### PR DESCRIPTION
# Description

While rebuilding my local dev env following the compte rebranding, I installed the latest `tox`, which seems to completely ignore the old `whitelist_externals` field in favor of `allowlist_externals`.

This update fixes the issue by adding an additional field.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
