### PR TITLE
EPInterchange uses exactly one executor

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -36,18 +36,15 @@ def test_endpoint_id(funcx_dir):
     endpoint_config = SourceFileLoader(
         "config", str(funcx_dir / "mock_endpoint" / "config.py")
     ).load_module()
-
-    for executor in endpoint_config.config.executors:
-        executor.passthrough = False
+    endpoint_config.config.executors[0].passthrough = False
 
     ic = EndpointInterchange(
         endpoint_config.config,
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         endpoint_id="mock_endpoint_id",
     )
-
-    for executor in ic.executors.values():
-        assert executor.endpoint_id == "mock_endpoint_id"
+    ic.start()
+    assert ic.executor.endpoint_id == "mock_endpoint_id"
 
 
 def test_start_requires_pre_registered(funcx_dir):
@@ -121,7 +118,7 @@ def test_invalid_result_received(mocker, endpoint_uuid):
 
 def test_die_with_parent_refuses_to_start_if_not_parent(mocker):
     ei = EndpointInterchange(
-        config=Config(executors=[]),
+        config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         parent_pid=os.getpid(),  # _not_ ppid; that's the test.
     )
@@ -143,7 +140,7 @@ def test_die_with_parent_goes_away_if_parent_dies(mocker):
     mock_ppid = mocker.patch(f"{_MOCK_BASE}os.getppid")
     mock_ppid.side_effect = (ppid, 1)
     ei = EndpointInterchange(
-        config=Config(executors=[]),
+        config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         parent_pid=ppid,
     )

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 import unittest.mock
+import uuid
 
 import dill
 from globus_compute_common.messagepack.message_types import Result, Task
@@ -17,11 +18,15 @@ class MockExecutor(unittest.mock.Mock):
 
     def start(
         self,
+        endpoint_id: uuid.UUID | None = None,
+        run_dir: str | None = None,
         results_passthrough: multiprocessing.Queue = None,
         funcx_client: Client = None,
     ):
         self.results_passthrough = results_passthrough
         self.funcx_client = funcx_client
+        self.endpoint_id = endpoint_id
+        self.run_dir = run_dir
 
     def submit_raw(self, packed_task: bytes):
         task: Task = Message.unpack(packed_task)

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -1,5 +1,4 @@
 import random
-from unittest.mock import MagicMock
 
 import pytest
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
@@ -22,12 +21,12 @@ def test_main_exception_always_quiesces(mocker, fs, reset_signals):
     mocker.patch(f"{_mock_base}multiprocessing")
     mocker.patch(f"{_mock_base}mpQueue")
     ei = EndpointInterchange(
-        config=Config(executors=[]),
+        config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=num_iterations + 10,
     )
-    ei._task_puller_proc = MagicMock()
-    ei._start_threads_and_main = MagicMock()
+    ei._task_puller_proc = mocker.MagicMock()
+    ei._start_threads_and_main = mocker.MagicMock()
     ei._start_threads_and_main.side_effect = Exception("Woot")
     ei._kill_event.is_set = false_true
     ei.start()
@@ -53,12 +52,12 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     mocker.patch(f"{_mock_base}mpQueue")
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
-        config=Config(executors=[]),
+        config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=reconnect_attempt_limit,
     )
-    ei._task_puller_proc = MagicMock()
-    ei._start_threads_and_main = MagicMock()
+    ei._task_puller_proc = mocker.MagicMock()
+    ei._start_threads_and_main = mocker.MagicMock()
     ei._start_threads_and_main.side_effect = Exception("Woot")
     ei._kill_event.is_set = false_true
     ei.start()


### PR DESCRIPTION
The code previously thought it _might_, one day, have support for multiple executors.  That has not happened in practice, so now remove some unnecessary logic.

[sc-17278]

## Type of change

- New feature (non-breaking change that adds functionality)