### PR TITLE
Refactor to queue.Queue from mp.Queue

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -38,7 +38,6 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
 )
 from globus_compute_endpoint.endpoint.result_store import ResultStore
 from globus_compute_endpoint.exception_handling import get_result_error_details
-from globus_compute_endpoint.executors.high_throughput.mac_safe_queue import mpQueue
 from globus_compute_sdk import __version__ as funcx_sdk_version
 from parsl.version import VERSION as PARSL_VERSION
 
@@ -136,7 +135,9 @@ class EndpointInterchange:
         }
         log.info(f"Platform info: {self.current_platform}")
 
-        self.results_passthrough = mpQueue()
+        self.results_passthrough: queue.Queue[
+            dict[str, bytes | str | None]
+        ] = queue.Queue()
         self.executor: HighThroughputExecutor = self.config.executors[0]
         self._test_start = False
 

--- a/compute_endpoint/globus_compute_endpoint/executors/high_throughput/executor.py
+++ b/compute_endpoint/globus_compute_endpoint/executors/high_throughput/executor.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import concurrent.futures
 import ipaddress
 import logging
-import multiprocessing
 import os
 import queue
 import threading
@@ -315,7 +314,7 @@ class HighThroughputExecutor(RepresentationMixin):
         self.outgoing_q: zmq_pipes.TasksOutgoing | None = None
         self.incoming_q: zmq_pipes.ResultsIncoming | None = None
         self.command_client: zmq_pipes.CommandClient | None = None
-        self.results_passthrough: multiprocessing.Queue | None = None
+        self.results_passthrough: queue.Queue | None = None
         self._queue_management_thread: threading.Thread | None = None
 
         self.is_alive = False
@@ -358,7 +357,7 @@ class HighThroughputExecutor(RepresentationMixin):
         *args,
         endpoint_id: uuid.UUID | None = None,
         run_dir: str | None = None,
-        results_passthrough: multiprocessing.Queue | None = None,
+        results_passthrough: queue.Queue[dict[str, bytes | str | None]] | None = None,
         **kwargs,
     ):
         """Create the Interchange process and connect to it."""

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -19,7 +19,6 @@ def test_main_exception_always_quiesces(mocker, fs, reset_signals):
         return next(false_true_g)
 
     mocker.patch(f"{_mock_base}multiprocessing")
-    mocker.patch(f"{_mock_base}mpQueue")
     ei = EndpointInterchange(
         config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
@@ -49,7 +48,6 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
         return next(false_true_g)
 
     mocker.patch(f"{_mock_base}multiprocessing")
-    mocker.patch(f"{_mock_base}mpQueue")
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
         config=Config(executors=[mocker.Mock()]),


### PR DESCRIPTION
No sense in shunting the messages out of process only to return again.  Just use a `queue.Queue`.

While here, add some typing.  (Mypy demanded it, actually.)

[sc-17278]

## Type of change

- Code maintenance/cleanup