### PR TITLE
Add required fields to final EP status report

### DIFF
--- a/changelog.d/20230420_045259_30907815+rjmello.rst
+++ b/changelog.d/20230420_045259_30907815+rjmello.rst
@@ -1,0 +1,7 @@
+Bug Fixes
+^^^^^^^^^
+
+- Required fields were missing from the final endpoint status update that
+  is sent when an endpoint is gracefully shutting down, causing issues when
+  getting the status of an endpoint.
+

--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -585,7 +585,14 @@ class EndpointInterchange:
             message = EPStatusReport(
                 endpoint_id=self.endpoint_id,
                 # 0 == "no more heartbeats coming"
-                global_state={"heartbeat_period": 0},
+                global_state={
+                    "managers": 0,
+                    "total_workers": 0,
+                    "idle_workers": 0,
+                    "pending_tasks": 0,
+                    "outstanding_tasks": {},
+                    "heartbeat_period": 0,
+                },
                 task_statuses={},
             )
             results_publisher.publish(pack(message))


### PR DESCRIPTION
# Description

Required fields were missing from the final endpoint status update that is sent when an endpoint is gracefully shutting down, causing issues when getting the status of an endpoint.

## Type of change

- Bug fix (non-breaking change that fixes an issue)