### PR TITLE
Fix recently introduced bug

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -415,9 +415,6 @@ class EndpointInterchange:
                         task_id: str | None = result["task_id"]
                         packed_result: bytes = result["message"]
 
-                        if not task_id:
-                            raise AssertionError("task_id: empty or None")
-
                     except queue.Empty:
                         # Empty queue!  Let's see if we have any prior results to send
                         continue
@@ -435,6 +432,13 @@ class EndpointInterchange:
                         message = try_convert_to_messagepack(packed_result)
 
                     except Exception as exc:
+                        if not task_id:
+                            log.exception(
+                                "Unable to parse result message; no task id, so"
+                                " likely a garbled EPStatusReport; ignoring"
+                            )
+                            continue
+
                         log.exception(
                             f"Unable to parse result message for task {task_id}."
                             "   Marking task as failed."


### PR DESCRIPTION
The change in 7c93e631dad9ec5a1eeaece1cac73539d66dad5c forgot that non-Results also come through the `results_passthrough` queue, and blithely ignored messages with no task_ids.  This is incorrect, and temporarily disabled the endpoint's ability to pass EPStatusReports.  Addressed, and added an expected-case automated test.

## Type of change

- Bug fix (non-breaking change that fixes an issue)