### PR TITLE
rewrite version check to account for different env setups

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -366,9 +366,9 @@ def read_config(endpoint_dir: pathlib.Path) -> Config:
     endpoint_name = endpoint_dir.name
 
     try:
-        import funcx_endpoint
+        from funcx_endpoint.version import VERSION
 
-        if Version(funcx_endpoint.__version__) < Version("2.0.0"):
+        if Version(VERSION) < Version("2.0.0"):
             msg = (
                 "To avoid compatibility issues with Globus Compute, please uninstall "
                 "funcx-endpoint or upgrade funcx-endpoint to >=2.0.0. Note that the "


### PR DESCRIPTION
For my setup, for some reason ``funcx_endpoint.__version__`` does not exist.  See error and some debug info below.  New version should work in all environments.

```
 (fix_release_funcx) $ globus-compute-endpoint start test420
Traceback (most recent call last):
  File "/Users/lei/.pyenv/versions/3.10.4/bin/globus-compute-endpoint", line 33, in <module>
    sys.exit(load_entry_point('globus-compute-endpoint', 'console_scripts', 'globus-compute-endpoint')())
  File "/Users/lei/glob/funcX/compute_endpoint/globus_compute_endpoint/cli.py", line 583, in cli_run
    app()
  File "/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/lei/glob/funcX/compute_endpoint/globus_compute_endpoint/cli.py", line 218, in start_endpoint
    _do_start_endpoint(
  File "/Users/lei/glob/funcX/compute_endpoint/globus_compute_endpoint/cli.py", line 484, in _do_start_endpoint
    ep_config = read_config(ep_dir)
  File "/Users/lei/glob/funcX/compute_endpoint/globus_compute_endpoint/cli.py", line 371, in read_config
    if Version(funcx_endpoint.__version__) < Version("2.0.0"):
AttributeError: module 'funcx_endpoint' has no attribute '__version__'
```

Printing attr, str(attr) for attr in dir(funcx_endpoint):

```
__doc__ None
__file__ None
__loader__ <_frozen_importlib_external._NamespaceLoader object at 0x10a6a7a60>
__name__ funcx_endpoint
__package__ funcx_endpoint
__path__ _NamespacePath(['/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/funcx_endpoint'])
__spec__ ModuleSpec(name='funcx_endpoint', loader=<_frozen_importlib_external._NamespaceLoader object at 0x10a6a7a60>, submodule_search_locations=_NamespacePath(['/Users/lei/.pyenv/versions/3.10.4/lib/python3.10/site-packages/funcx_endpoint']))
```