### PR TITLE
Setting GC_TASK_TIMEOUT for the endpoint dockerfile

### DIFF
--- a/Dockerfile-endpoint
+++ b/Dockerfile-endpoint
@@ -37,3 +37,4 @@ USER compute
 WORKDIR /home/compute
 COPY helm/boot.sh .
 ENV HOME /home/compute
+ENV GC_TASK_TIMEOUT 10


### PR DESCRIPTION
# Description

Title says it all. This sets the env var enabled by #1093.
 
Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintenance/cleanup
