### PR TITLE
Add GC_TASK_TIMEOUT to EP helm configuration

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -164,6 +164,7 @@ The deployment is configured via values.yaml file.
 | maxCPU | Maximum CPUs to allocate to worker pod | 2 |
 | maxBlocks | Maximum number of worker pods to spawn | 100 |
 | maxWorkersPerPod | How many workers will be scheduled in each pod | 1 |
+| taskTTLSeconds | (Optional) If set, will stop tasks that run longer than this value, in (fractional) seconds.  Example: 1.5 | |
 | endpointName | (Optional) Specify a name for registration with the funcX web services | The release name (Release.Name) |
 | endpointDisplayName | (Optional) Specify a display name for registration with the funcX web services | The endpoint name (endpointName) or the release name (Release.Name) |
 | endpointUUID | (Required) Specify a UUID for this endpoint. | |

--- a/helm/funcx_endpoint/Chart.yaml
+++ b/helm/funcx_endpoint/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/funcx_endpoint/templates/endpoint-deployment.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-deployment.yaml
@@ -36,11 +36,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
+        env:
         {{- if .Values.useClientCredentials }}
           {{- if not .Values.secrets }}
             {{- fail "Missing `secrets` store specification for client credentials" }}
           {{- end }}
-        env:
           - name: FUNCX_SDK_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -51,7 +51,11 @@ spec:
               secretKeyRef:
                 name: {{ .Values.secrets }}
                 key: FUNCX_SDK_CLIENT_SECRET
-        {{- end}}
+        {{- end }}
+        {{- if .Values.taskTTLSeconds }}
+          - name: GC_TASK_TIMEOUT
+            value: "{{ .Values.taskTTLSeconds }}"
+        {{- end }}
 
         volumeMounts:
           - mountPath: "/mnt"


### PR DESCRIPTION
Following up to #1121, allow setting of the `GC_TASK_TIMEOUT` variable via the `values.yaml` file.

## Type of change

- New feature (non-breaking change that adds functionality)