### PR TITLE
Lock-prevent concurrent modification

### DIFF
--- a/changelog.d/20230421_111659_kevin_address_concurrent_data_structure_modification.rst
+++ b/changelog.d/20230421_111659_kevin_address_concurrent_data_structure_modification.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address a concurrent data structure modification error that resulted in
+  stalled processing and lost tasks


### PR DESCRIPTION
Without this lock in place, was getting the following traceback while attempting to run a large number of noop tasks (e.g., 100k):

```python
Process Executor-Interchange:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/.../globus_compute_endpoint/executors/high_throughput/interchange.py", line 1161, in starter
    ic.start()
  File "/.../globus_compute_endpoint/executors/high_throughput/interchange.py", line 958, in start
    del self.task_status_deltas[r["task_id"]]
KeyError: '388a6642-2086-4d04-92dd-ed3a5396f77e'
Exception in thread STATUS_THREAD:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/.../globus_compute_endpoint/executors/high_throughput/interchange.py", line 565, in _status_report_loop
    status_report_queue.put(msg.pack())
  File "/.../globus_compute_endpoint/executors/high_throughput/messages.py", line 207, in pack
    for tid, tt in self.task_statuses.items():
RuntimeError: dictionary changed size during iteration
```
In other words, for a large enough number of tasks, it's much more likely that the `task_status_deltas` data structure is concurrently modified by the STATUS_THREAD (`_status_report_loop()`) and the main message handling loop -- but _always_ possible.

## Type of change

- Bug fix (non-breaking change that fixes an issue)