### PR TITLE
Support user-definable compute directory via env var

### DIFF
--- a/changelog.d/20230421_102543_30907815+rjmello_custom_compute_dir.rst
+++ b/changelog.d/20230421_102543_30907815+rjmello_custom_compute_dir.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Enable users to specify a custom Globus Compute directory (i.e., ``.globus_compute/``)
+  via the environment variable ``GLOBUS_COMPUTE_USER_DIR``.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -41,7 +41,7 @@ class CommandState:
 def init_config_dir() -> pathlib.Path:
     try:
         return ensure_compute_dir()
-    except FileExistsError as e:
+    except (FileExistsError, PermissionError) as e:
         raise ClickException(str(e))
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -39,19 +39,20 @@ def ensure_compute_dir() -> pathlib.Path:
     legacy_dirname = _home() / ".funcx"
     dirname = _home() / ".globus_compute"
 
+    user_dir = os.getenv("GLOBUS_COMPUTE_USER_DIR")
+    if user_dir:
+        dirname = pathlib.Path(user_dir)
+
     if dirname.is_dir():
         pass
-
     elif dirname.is_file():
         raise FileExistsError(
             f"Error creating directory {dirname}, "
             "please remove or rename the conflicting file"
         )
-
-    elif legacy_dirname.is_dir():
+    elif legacy_dirname.is_dir() and not user_dir:
         legacy_dirname.replace(dirname)
         legacy_dirname.symlink_to(dirname, target_is_directory=True)
-
     else:
         dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
 


### PR DESCRIPTION
# Description

Enable users to specify a custom Globus Compute directory (i.e., ``.globus_compute/``) via the environment variable ``GLOBUS_COMPUTE_USER_DIR``.

[sc-23683]

Fixes [#1089](https://github.com/funcx-faas/funcX/issues/1089)

## Type of change

- New feature (non-breaking change that adds functionality)
