### PR TITLE
Add bashrc to Docker image

### DIFF
--- a/Dockerfile-endpoint
+++ b/Dockerfile-endpoint
@@ -14,18 +14,16 @@ RUN apt-get update && apt-get upgrade -y
 
 RUN if [ -n "$pip_conf" ]; then echo "$pip_conf" > "/etc/pip.conf"; fi
 
-RUN mkdir /opt/compute
 RUN python -m pip install -U pip
 RUN python -m pip install kubernetes
 RUN python -m pip install --no-binary :all: --force-reinstall pyzmq
 
+RUN mkdir /opt/compute
 COPY compute_sdk /opt/compute/compute_sdk/
-WORKDIR /opt/compute/compute_sdk
-RUN python -m pip install .
-
-COPY compute_endpoint /opt/compute/compute_endpoint
-WORKDIR /opt/compute/compute_endpoint
-RUN python -m pip install .
+COPY compute_endpoint /opt/compute/compute_endpoint/
+WORKDIR /opt/compute/
+RUN python -m pip install compute_endpoint/ compute_sdk/
+RUN rm -rf /opt/compute/
 
 # Undo local-dev ministrations
 RUN if [ -n "$pip_conf" ]; then rm -f "/etc/pip.conf"; fi
@@ -36,4 +34,5 @@ RUN mkdir -p /home/compute/.kube
 USER compute
 WORKDIR /home/compute
 COPY helm/boot.sh .
+COPY helm/bashrc ./.bashrc
 ENV HOME /home/compute

--- a/helm/bashrc
+++ b/helm/bashrc
@@ -1,0 +1,66 @@
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+shopt -s checkwinsize
+shopt -s globstar
+
+shopt -s histappend
+HISTCONTROL=ignoreboth
+HISTSIZE=1000
+HISTFILESIZE=20000
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+if [[ -x /usr/bin/tput ]] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+fi
+
+if [[ $color_prompt = yes ]]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [[ -x /usr/bin/dircolors ]]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -lh'
+alias la='ls -A'
+alias l='ls -CF'
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi


### PR DESCRIPTION
Main motivation: muscle memory with `ll`, but also enable color prompt&nbsp;&mdash;&nbsp;a minor editing of the default skeleton bashrc file.

While here, also slightly streamline the Dockerfile and cleanup after the install.

## Type of change

- Developer nicety