### PR TITLE
add import as for FuncXClient and FuncXExecutor

### DIFF
--- a/compute_funcx/sdk/funcx/sdk/client.py
+++ b/compute_funcx/sdk/funcx/sdk/client.py
@@ -1,0 +1,1 @@
+from globus_compute_sdk.sdk.client import Client as FuncXClient  # noqa: F401

--- a/compute_funcx/sdk/funcx/sdk/executor.py
+++ b/compute_funcx/sdk/funcx/sdk/executor.py
@@ -1,0 +1,1 @@
+from globus_compute_sdk.sdk.executor import Executor as FuncXExecutor  # noqa: F401

--- a/docs/changelog_funcx.rst
+++ b/docs/changelog_funcx.rst
@@ -3,6 +3,18 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-2.0.2a0:
+
+funcx & funcx-endpoint v2.0.2a0
+-----------------------------
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+ - Add convenience package path import aliases for ``FuncXClient`` and ``FuncXExecutor``
+ - ``from funcx.sdk.client import FuncXClient`` and ``from funcx.sdk.executor import FuncXExecutor``
+   will both work if used in old scripts, in addition to ``from funcx import FuncXClient/FuncXExecutor``
+
 .. _changelog-2.0.1:
 
 funcx & funcx-endpoint v2.0.1


### PR DESCRIPTION
For some users who import FuncXClient and FuncXExecutor from the package paths directly instead of 'from funcx import X', we should add convenient import as shortcuts as well.

See slack thread https://funcx.slack.com/archives/C017637NZFA/p1682438637004849 for details.

``from funcx.sdk.client import FuncXClient`` and ``from funcx.sdk.executor import FuncXExecutor`` should both work using the wrappers.