### PR TITLE
Renaming and updating existing tests

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/messages_compat.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/messages_compat.py
@@ -15,10 +15,10 @@ from globus_compute_common.messagepack.message_types import (
 )
 from globus_compute_common.messagepack.message_types import Task as OutgoingTask
 from globus_compute_common.messagepack.message_types import TaskTransition
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     EPStatusReport as InternalEPStatusReport,
 )
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     Task as InternalTask,
 )
 

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -7,14 +7,14 @@ import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 
-from funcx_common import messagepack
-from funcx_common.messagepack.message_types import (
+from globus_compute_common import messagepack
+from globus_compute_common.messagepack.message_types import (
     EPStatusReport,
     Result,
     Task,
     TaskTransition,
 )
-from funcx_common.tasks import ActorName, TaskState
+from globus_compute_common.tasks import ActorName, TaskState
 from globus_compute_endpoint.engines.helper import execute_task
 from globus_compute_endpoint.exception_handling import (
     get_error_string,

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -5,7 +5,10 @@ import typing as t
 import uuid
 from concurrent.futures import Future
 
-from funcx_common.messagepack.message_types import EPStatusReport, TaskTransition
+from globus_compute_common.messagepack.message_types import (
+    EPStatusReport,
+    TaskTransition,
+)
 from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -6,19 +6,18 @@ import uuid
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result, Task, TaskTransition
 from globus_compute_common.tasks import ActorName, TaskState
+from globus_compute_endpoint.engines.high_throughput.messages import Message
 from globus_compute_endpoint.exception_handling import (
     get_error_string,
     get_result_error_details,
 )
 from globus_compute_endpoint.exceptions import CouldNotExecuteUserTaskError
-from globus_compute_endpoint.executors.high_throughput.messages import Message
-
-from funcx.errors import MaxResultSizeExceeded
-from funcx.serialize import FuncXSerializer
+from globus_compute_sdk.errors import MaxResultSizeExceeded
+from globus_compute_sdk.serialize import ComputeSerializer
 
 log = logging.getLogger(__name__)
 
-serializer = FuncXSerializer()
+serializer = ComputeSerializer()
 
 
 def execute_task(task_body: bytes, result_size_limit: int = 10 * 1024 * 1024) -> bytes:

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -3,9 +3,9 @@ import time
 import typing as t
 import uuid
 
-from funcx_common import messagepack
-from funcx_common.messagepack.message_types import Result, Task, TaskTransition
-from funcx_common.tasks import ActorName, TaskState
+from globus_compute_common import messagepack
+from globus_compute_common.messagepack.message_types import Result, Task, TaskTransition
+from globus_compute_common.tasks import ActorName, TaskState
 from globus_compute_endpoint.exception_handling import (
     get_error_string,
     get_result_error_details,

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/__init__.py
@@ -1,3 +1,0 @@
-from globus_compute_endpoint.engines import HighThroughputEngine
-
-HighThroughputExecutor = HighThroughputEngine

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -9,7 +9,10 @@ from concurrent.futures import ProcessPoolExecutor as NativeExecutor
 from multiprocessing.queues import Queue as mpQueue
 
 import psutil
-from funcx_common.messagepack.message_types import EPStatusReport, TaskTransition
+from globus_compute_common.messagepack.message_types import (
+    EPStatusReport,
+    TaskTransition,
+)
 from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -9,7 +9,10 @@ from concurrent.futures import ThreadPoolExecutor as NativeExecutor
 from multiprocessing.queues import Queue as mpQueue
 
 import psutil
-from funcx_common.messagepack.message_types import EPStatusReport, TaskTransition
+from globus_compute_common.messagepack.message_types import (
+    EPStatusReport,
+    TaskTransition,
+)
 from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -11,7 +11,7 @@ from globus_compute_common.messagepack.message_types import EPStatusReport, Resu
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange, log
 from globus_compute_endpoint.endpoint.utils.config import Config
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     EPStatusReport as HTEPStatusReport,
 )
 from tests.utils import try_for_timeout

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_messages_compat.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_messages_compat.py
@@ -13,13 +13,13 @@ from globus_compute_endpoint.endpoint.messages_compat import (
     convert_to_internaltask,
     try_convert_to_messagepack,
 )
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     EPStatusReport as InternalEPStatusReport,
 )
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     Message as InternalMessage,
 )
-from globus_compute_endpoint.executors.high_throughput.messages import (
+from globus_compute_endpoint.engines.high_throughput.messages import (
     Task as InternalTask,
 )
 

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_manager.py
@@ -4,8 +4,8 @@ import queue
 import shutil
 
 import pytest
-from globus_compute_endpoint.executors.high_throughput.manager import Manager
-from globus_compute_endpoint.executors.high_throughput.messages import Task
+from globus_compute_endpoint.engines.high_throughput.manager import Manager
+from globus_compute_endpoint.engines.high_throughput.messages import Task
 
 
 class TestManager:
@@ -18,7 +18,7 @@ class TestManager:
     def test_remove_worker_init(self, mocker):
         # zmq is being mocked here because it was making tests hang
         mocker.patch(
-            "globus_compute_endpoint.executors.high_throughput.manager.zmq.Context"  # noqa: E501
+            "globus_compute_endpoint.engines.high_throughput.manager.zmq.Context"  # noqa: E501
         )
 
         manager = Manager(logdir="./", uid="mock_uid")
@@ -34,11 +34,11 @@ class TestManager:
     def test_poll_funcx_task_socket(self, mocker):
         # zmq is being mocked here because it was making tests hang
         mocker.patch(
-            "globus_compute_endpoint.executors.high_throughput.manager.zmq.Context"  # noqa: E501
+            "globus_compute_endpoint.engines.high_throughput.manager.zmq.Context"  # noqa: E501
         )
 
         mock_worker_map = mocker.patch(
-            "globus_compute_endpoint.executors.high_throughput.manager.WorkerMap"
+            "globus_compute_endpoint.engines.high_throughput.manager.WorkerMap"
         )
 
         manager = Manager(logdir="./", uid="mock_uid")

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_worker_map.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_worker_map.py
@@ -1,13 +1,13 @@
 import logging
 import os
 
-from globus_compute_endpoint.executors.high_throughput.worker_map import WorkerMap
+from globus_compute_endpoint.engines.high_throughput.worker_map import WorkerMap
 
 
 class TestWorkerMap:
     def test_add_worker(self, mocker):
         mock_popen = mocker.patch(
-            "globus_compute_endpoint.executors.high_throughput.worker_map.subprocess.Popen"  # noqa: E501
+            "globus_compute_endpoint.engines.high_throughput.worker_map.subprocess.Popen"  # noqa: E501
         )
         mock_popen.return_value = "proc"
 

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -6,7 +6,7 @@ import uuid
 
 import dill
 from globus_compute_common.messagepack.message_types import Result, Task
-from globus_compute_endpoint.executors.high_throughput.messages import Message
+from globus_compute_endpoint.engines.high_throughput.messages import Message
 from globus_compute_sdk import Client
 
 

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -337,7 +337,7 @@ def test_endpoint_get_metadata(mocker):
     config = meta["config"]
     assert "funcx_service_address" in config
     assert len(config["executors"]) == 1
-    assert config["executors"][0]["_type"] == "HighThroughputExecutor"
+    assert config["executors"][0]["_type"] == "HighThroughputEngine"
     assert config["executors"][0]["provider"]["_type"] == "LocalProvider"
 
 

--- a/compute_endpoint/tests/unit/test_highthroughputinterchange.py
+++ b/compute_endpoint/tests/unit/test_highthroughputinterchange.py
@@ -4,14 +4,14 @@ from unittest import mock
 
 import pytest
 from globus_compute_common.tasks import TaskState
-from globus_compute_endpoint.executors.high_throughput.interchange import (
+from globus_compute_endpoint.engines.high_throughput.interchange import (
     Interchange,
     starter,
 )
-from globus_compute_endpoint.executors.high_throughput.messages import Task
+from globus_compute_endpoint.engines.high_throughput.messages import Task
 
 # Work with linter's 88 char limit, and be uniform in this file how we do it
-mod_dot_path = "globus_compute_endpoint.executors.high_throughput.interchange"
+mod_dot_path = "globus_compute_endpoint.engines.high_throughput.interchange"
 
 
 @mock.patch(f"{mod_dot_path}.zmq")

--- a/compute_endpoint/tests/unit/test_manager_unit.py
+++ b/compute_endpoint/tests/unit/test_manager_unit.py
@@ -3,11 +3,11 @@ import uuid
 from unittest import mock
 
 from globus_compute_common.tasks import TaskState
-from globus_compute_endpoint.executors.high_throughput.manager import Manager
-from globus_compute_endpoint.executors.high_throughput.messages import Task
+from globus_compute_endpoint.engines.high_throughput.manager import Manager
+from globus_compute_endpoint.engines.high_throughput.messages import Task
 
 
-@mock.patch("globus_compute_endpoint.executors.high_throughput.manager.zmq")
+@mock.patch("globus_compute_endpoint.engines.high_throughput.manager.zmq")
 class TestManager:
     def test_task_to_worker_status_change(self, randomstring):
         task_type = randomstring()

--- a/compute_endpoint/tests/unit/test_worker.py
+++ b/compute_endpoint/tests/unit/test_worker.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pytest
 from globus_compute_common import messagepack
-from globus_compute_endpoint.executors.high_throughput.messages import Task
-from globus_compute_endpoint.executors.high_throughput.worker import Worker
+from globus_compute_endpoint.engines.high_throughput.messages import Task
+from globus_compute_endpoint.engines.high_throughput.worker import Worker
 from parsl.app.errors import AppTimeout
 
 
@@ -36,7 +36,7 @@ def reset_signals_auto(reset_signals):
 @pytest.fixture
 def test_worker():
     with mock.patch(
-        "globus_compute_endpoint.executors.high_throughput.worker.zmq.Context"
+        "globus_compute_endpoint.engines.high_throughput.worker.zmq.Context"
     ) as mock_context:
         # the worker will receive tasks and send messages on this mock socket
         mock_socket = mock.Mock()


### PR DESCRIPTION
# Description

This PR updates all the existing tests with renaming `funcx_common` -> `globus_compute_common` and `executors`->`engines`. This PR is 90% renaming.


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
