### PR TITLE
Pass GC_TASK_TIMEOUT to instantianted pod

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/providers/kubernetes/kube.py
+++ b/compute_endpoint/globus_compute_endpoint/providers/kubernetes/kube.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import queue
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -288,7 +289,10 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
             )
 
         # Create the enviornment variables and command to initiate IPP
-        environment_vars = client.V1EnvVar(name="TEST", value="SOME DATA")
+        env = []
+        for var_name in ("GC_TASK_TIMEOUT",):
+            if var_name in os.environ:
+                env.append(client.V1EnvVar(name=var_name, value=os.getenv(var_name)))
 
         launch_args = ["-c", f"{cmd_string}"]
 
@@ -311,7 +315,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
             volume_mounts=volume_mounts,
             command=["/bin/bash"],
             args=launch_args,
-            env=[environment_vars],
+            env=env,
             security_context=security_context,
         )
 


### PR DESCRIPTION
The helm chart faithfully exports the `GC_TASK_TIMEOUT` variable to the endpoint's environment, but the workers weren't receiving that variable.

The implemented fix is a hard-coded list of environment variables (okay, a list of length 1) to check.  If passing information from the parent pod (the endpoint) to the child pods (the workers) becomes an issue in the future, the intended approach is to "deal with it then" in a more complete way.  For now, then, though not ideal, this commit is "good enough."

[sc-23725]

## Type of change

- Bug fix (non-breaking change that fixes an issue)