### PR TITLE
Dlhub deployment version 0.3

### DIFF
--- a/helm/README.dlhub
+++ b/helm/README.dlhub
@@ -1,0 +1,12 @@
+Notes for redeploying DLHub endpoint:
+
+As of the release of globus-compute 2.0, the dlhub endpoint needed to be pegged
+at funcx 1.0.13, to avoid problems w/ the funcx 2.0.0 compatibility layer
+(That errored out on a "from funcx.sdk import FuncXClient")
+
+BenG fixed a problem w/ the helm chart, so the full set of commands to do this is:
+
+$ helm repo add funcx http://funcx.org/funcx-helm-charts/ && helm repo update
+$ helm install --version 0.3.4-post.1 -f dlhub_values.yaml funcx-dlhub funcx/funcx_endpoint
+
+Note: you may have to do a helm uninstall funcx-dlhub first.

--- a/helm/dlhub_values.yaml
+++ b/helm/dlhub_values.yaml
@@ -4,13 +4,14 @@
 
 replicaCount: 1
 funcXServiceAddress: https://api2.funcx.org
+useUserCredentials: true
 image:
   repository: funcx/kube-endpoint
-  tag: dlhub_deployment_version_0.3-3.7
+  tag: 1.0.13-3.7
   pullPolicy: Always
 
 workerImage: python:3.7-buster
-workerInit: pip install funcx-endpoint>=0.3.0; pip install -U home_run; export PYTHONPATH="$PYTHONPATH:/app:/home/ubuntu"; mkdir -p /home/ubuntu/
+workerInit: pip install funcx==1.0.13 funcx-endpoint==1.0.13; pip install home_run==0.5.0; export PYTHONPATH="$PYTHONPATH:/app:/home/ubuntu"; mkdir -p /home/ubuntu/
 workerNamespace: dlhub
 workingDir: /home/ubuntu
 workerImageSecret: ryan-kube-secret


### PR DESCRIPTION
# Description

The former DLHub endpoint deployment workerInit was not playing well with the funcX 2.0.x compatibility library.  This pegs it at 1.0.13.


## Type of change

This is, essentially, a documentation change, as it adds a small README and changes the dlhub_values.yaml used to deploy the DLHub funcx endpoint.
