### PR TITLE
Add whitelisted functions to config parsing

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -695,6 +695,7 @@ def _serialize_config(config: Config) -> dict:
     """
 
     expand_list = ["strategy", "provider", "launcher"]
+    pass_through_list = ["allowed_functions"]
 
     def to_dict(o):
         mems = {"_type": type(o).__name__}
@@ -705,10 +706,10 @@ def _serialize_config(config: Config) -> dict:
 
             if k in expand_list:
                 mems[k] = to_dict(v)
-            elif not isinstance(v, str):
-                mems[k] = repr(v)
-            else:
+            elif isinstance(v, str) or k in pass_through_list:
                 mems[k] = v
+            else:
+                mems[k] = repr(v)
 
         return mems
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/config.py
@@ -105,6 +105,7 @@ class Config(RepresentationMixin):
         environment: str | None = None,
         funcx_service_address=None,
         multi_tenant: bool | None = None,
+        allowed_functions: list[str] | None = None,
         # Tuning info
         heartbeat_period=30,
         heartbeat_threshold=120,
@@ -148,6 +149,7 @@ class Config(RepresentationMixin):
         self.funcx_service_address = funcx_service_address
 
         self.multi_tenant = multi_tenant is True
+        self.allowed_functions = allowed_functions
 
         # Tuning info
         self.heartbeat_period = heartbeat_period


### PR DESCRIPTION
As per https://app.shortcut.com/funcx/story/24200/allow-list-functions-by-uuid-in-webservice

Add ability to take in a list of function UUIDs in metadata.config.allowed_functions in POST /endpoint and add it to the whitelist, as previously possible only via POST /endpoints//whitelist/<func_uuid>.

The logic is simple - just let it go through in the web_client, and add it to the Config object definition.

This is already in alpha version 2.0.2a1.  I intentionally avoided documenting it until the web-service side is deployed and becomes functional, and pending discussion on whether we should advertise this feature.  Note that allowed_functions will simply be ignored by the web-service before PR 388.

See [PR on service side](https://github.com/globusonline/funcx-services/pull/388).

TL;DR the config.py should include a section like the below with a list. If allowed_functions is not present, nothing is modified relating to restricted functions:

...
    display_name= "whatever",  # If None, defaults to the endpoint name
    allowed_functions = [
         "94c7ce20-7a5a-4eb3-ac07-6fc0aabcd50c",
         "aab66753-4b02-4162-a9d3-47374dabcdc4",
    ],
    executors=[
...