### PR TITLE
Use `global_state` instead of `ep_status_report` when constructing `EPStatusReport` objects

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -104,7 +104,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}
         return EPStatusReport(
             endpoint_id=self.endpoint_id,
-            ep_status_report=executor_status,
+            global_state=executor_status,
             task_statuses=task_status_deltas,
         )
 

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -90,7 +90,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
 
         return EPStatusReport(
             endpoint_id=self.endpoint_id,
-            ep_status_report=executor_status,
+            global_state=executor_status,
             task_statuses=task_status_deltas,
         )
 

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -90,7 +90,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
 
         return EPStatusReport(
             endpoint_id=self.endpoint_id,
-            ep_status_report=executor_status,
+            global_state=executor_status,
             task_statuses=task_status_deltas,
         )
 


### PR DESCRIPTION
# Description

The alias `ep_status_report` only remains so that older versions of the EP/SDK can still send heartbeats without issues - new code should use the actual field name `global_state`.

Related to https://github.com/funcx-faas/funcx-common/pull/87

## Type of change

- Code maintenance/cleanup
