### PR TITLE
Remove binder badge and replace quickstart reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,6 @@ function execution on existing infrastructure including clouds, clusters, and su
 .. |docs| image:: https://readthedocs.org/projects/funcx/badge/?version=latest
    :target: https://funcx.readthedocs.io/en/latest/
    :alt: Documentation Status
-.. |launch| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb
-   :alt: Launch in Binder
 .. |NSF-2004894| image:: https://img.shields.io/badge/NSF-2004894-blue.svg
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=2004894
    :alt: NSF award info

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 
 **Globus Compute** client and endpoint software releases are available on `PyPI <https://pypi.org/project/funcx/>`_.
 
-You can try Globus Compute on a hosted Jupyter notebook with `Binder <https://mybinder.org/v2/gh/funcx-faas/examples/HEAD?filepath=notebooks%2FIntroduction.ipynb>`_
+You can try Globus Compute on a hosted `Jupyter notebook <https://jupyter.demo.globus.org/hub/user-redirect/lab/tree/globus-jupyter-notebooks/Compute_Introduction.ipynb>`_
 
 
 Installation


### PR DESCRIPTION
# Description

Documentation update to reflect our move to Globus' jupyter hub. This removes the Binder badge from the README and updates the quickstart reference to binder.

Fixes # [sc-24212]

## Type of change

- Documentation update
