### PR TITLE
Remove launch tag on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Globus Compute - Fast Function Serving
 =============================
-|licence| |build-status| |docs| |launch| |NSF-2004894| |NSF-2004932|
+|licence| |build-status| |docs| |NSF-2004894| |NSF-2004932|
 
 Globus Compute (formerly funcX) is a high-performance function-as-a-service (FaaS)
 platform that enables intuitive, flexible, efficient, scalable, and performant remote


### PR DESCRIPTION
Fix a small mistake that leaves the `launch` tag on the README.

## Type of change

- Documentation update
