### PR TITLE
change language for endpoint name errors and disallow UUID

### DIFF
--- a/changelog.d/20230518_130845_LeiGlobus_endpoint_uuid_argument_sc_24353.rst
+++ b/changelog.d/20230518_130845_LeiGlobus_endpoint_uuid_argument_sc_24353.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- To avoid confusion, UUIDs will no longer be allowed as the name of an Endpoint.
+

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -505,7 +505,7 @@ def delete_endpoint(*, name: str, force: bool, yes: bool):
         )
 
     ep_dir = get_config_dir() / name
-    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), create_info=False, force)
+    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), create_info=False, force=force)
 
 
 def cli_run():

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -505,7 +505,7 @@ def delete_endpoint(*, name: str, force: bool, yes: bool):
         )
 
     ep_dir = get_config_dir() / name
-    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), create_info=False, force=force)
+    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), force=force)
 
 
 def cli_run():

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -121,7 +121,23 @@ def start_options(f):
     return f
 
 
+def verify_not_uuid(ctx, param, value):
+    try:
+        uuid.UUID(value)
+        raise click.BadParameter(
+            "Specifying an UUID for endpoint commands is not currently supported"
+        )
+    except ValueError:
+        return value
+
+
 def name_arg(f):
+    return click.argument(
+        "name", required=False, callback=verify_not_uuid, default="default"
+    )(f)
+
+
+def name_arg_allow_uuid(f):
     return click.argument("name", required=False, default="default")(f)
 
 
@@ -470,7 +486,7 @@ def list_endpoints():
 
 
 @app.command("delete")
-@name_arg
+@name_arg_allow_uuid
 @click.option(
     "--force",
     default=False,
@@ -485,11 +501,11 @@ def delete_endpoint(*, name: str, force: bool, yes: bool):
     """Deletes an endpoint and its config."""
     if not yes:
         click.confirm(
-            f"Are you sure you want to delete the endpoint <{name}>?", abort=True
+            f"Are you sure you want to delete the endpoint named <{name}>?", abort=True
         )
 
     ep_dir = get_config_dir() / name
-    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), force)
+    Endpoint.delete_endpoint(ep_dir, get_config(ep_dir), create_info=False, force)
 
 
 def cli_run():

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -517,7 +517,7 @@ class Endpoint:
         endpoint_id = Endpoint.get_endpoint_id(endpoint_dir)
         if endpoint_id is None:
             log.warning(
-                f"Endpoint named <{ep_name}>'s configuration not found, it "
+                f"Configuration for endpoint <{ep_name}> could not be found, it "
                 "might not have been initialized locally"
             )
             if not force:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -130,13 +130,13 @@ class Endpoint:
         )
         config_path = Endpoint._config_file_path(conf_dir)
         if multi_tenant:
-            print(f"Created multi-tenant profile for <{ep_name}>")
+            print(f"Created multi-tenant profile for endpoint named <{ep_name}>")
         else:
-            print(f"Created profile for <{ep_name}>")
+            print(f"Created profile for endpoint named <{ep_name}>")
         print(
-            f"\n    Configuration file: {config_path}\n"
+            f"\n\tConfiguration file: {config_path}\n"
             "\nUse the `start` subcommand to run it:\n"
-            f"\n    $ globus-compute-endpoint start {ep_name}"
+            f"\n\t$ globus-compute-endpoint start {ep_name}"
         )
 
     @staticmethod
@@ -516,7 +516,10 @@ class Endpoint:
 
         endpoint_id = Endpoint.get_endpoint_id(endpoint_dir)
         if endpoint_id is None:
-            log.warning(f"Endpoint <{ep_name}> could not be located")
+            log.warning(
+                f"Endpoint named <{ep_name}>'s configuration not found, it "
+                "might not have been initialized locally"
+            )
             if not force:
                 exit(-1)
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import shlex
+import uuid
 from unittest import mock
 
 import pytest
@@ -141,6 +142,13 @@ def test_start_endpoint_existing_ep(run_line, mock_cli_state, make_endpoint_dir)
     run_line("start foo")
     mock_ep, _ = mock_cli_state
     mock_ep.start_endpoint.assert_called_once()
+
+
+@pytest.mark.parametrize("cli_cmd", ["start", "configure", "stop"])
+def test_endpoint_uuid_name_not_supported(run_line, cli_cmd):
+    ep_uuid_name = uuid.uuid4()
+    res = run_line(f"{cli_cmd} {ep_uuid_name}", assert_exit_code=2)
+    assert "UUID" in res.stderr and "not currently supported" in res.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Before we support specifying the UUID in CLI commands, we should more explicitly prevent users from using an UUID as the endpoint name (which would generate a different actual UUID), as this is very confusing.

This PR changes the language on the configure command to emphasize that we are looking for a name, and also detects and prevents an UUID from being used as the endpoint name.

Linked story is a precursor to possible future feature allowing UUID or name (or display_name) to be used in commands.

Additionally, fix an issue when deleting endpoints that have been configured but not yet initialized, and skip going to the web-service when it isn't necessary.

Example sample output:

```
$ globus-compute-endpoint configure 9483834a-1633-4447-9ce6-f345fbb1ce7d
Usage: globus-compute-endpoint configure [OPTIONS] [NAME]

Error: Invalid value for '[NAME]': Specifying an UUID for endpoint commands is not currently supported

$ globus-compute-endpoint start 9483834a-1633-4447-9ce6-f345fbb1ce7d
Usage: globus-compute-endpoint start [OPTIONS] [NAME]

Error: Invalid value for '[NAME]': Specifying an UUID for endpoint commands is not currently supported

$ globus-compute-endpoint start non-existant-ep-name
Error: [Errno 2] No such file or directory: '/Users/lei/.globus_compute/non-existant-ep-name/config.py'

Endpoint 'non-existant-ep-name' is not configured! If you wish to create an endpoint with this name, follow these steps:

1. Create a configuration template with:
	globus-compute-endpoint configure non-existant-ep-name
2. Update the configuration file at:
	/Users/lei/.globus_compute/non-existant-ep-name/config.py
3. Start the endpoint with:
	globus-compute-endpoint start non-existant-ep-name
```