### PR TITLE
User selectable serialization

### DIFF
--- a/changelog.d/20230522_134306_chris_user_selectable_serialization.rst
+++ b/changelog.d/20230522_134306_chris_user_selectable_serialization.rst
@@ -1,0 +1,22 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The methods used to serialize functions and arguments are now selectable at the
+  ``Client`` level via constructor arguments (``code_serializer_method`` and
+  ``data_serializer_method``)
+  - For example, to use ``DillCodeSource`` when serializing functions:
+    ``client = Client(code_serializer_method=DillCodeSource())``
+  - This functionality is available to ``Executor``s by passing a custom client. Using
+    the client above: ``executor = Executor(funcx_client=client)``
+
+Changed
+^^^^^^^
+
+- Simplified the logic used to select a serialization method when one isn't specified -
+  rather than try every serializer in order, Globus Compute now simply defaults to
+  ``DillCode`` and ``DillDataBase64`` for code and data respectively
+

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -21,7 +21,7 @@ from globus_compute_sdk.sdk._environments import (
 from globus_compute_sdk.sdk.asynchronous.compute_task import ComputeTask
 from globus_compute_sdk.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
 from globus_compute_sdk.sdk.web_client import FunctionRegistrationData
-from globus_compute_sdk.serialize import ComputeSerializer
+from globus_compute_sdk.serialize import ComputeSerializer, SerializeBase
 from globus_compute_sdk.version import __version__, compare_versions
 
 from .batch import Batch
@@ -62,6 +62,8 @@ class Client:
         search_authorizer: t.Any = None,
         fx_authorizer: t.Any = None,
         *,
+        code_serializer_method: SerializeBase | None = None,
+        data_serializer_method: SerializeBase | None = None,
         login_manager: LoginManagerProtocol | None = None,
         **kwargs,
     ):
@@ -121,6 +123,14 @@ class Client:
             session or to reestablish Executor futures.
             Default: None (will be auto generated)
 
+        code_serializer_method: SerializeBase
+            Serializer method to use when serializing function code. If None,
+            globus_compute_sdk.serialize.DEFAULT_METHOD_CODE will be used.
+
+        data_serializer_method: SerializeBase
+            Serializer method to use when serializing function arguments. If None,
+            globus_compute_sdk.serialize.DEFAULT_METHOD_DATA will be used.
+
         Keyword arguments are the same as for BaseClient.
 
         """
@@ -162,7 +172,10 @@ class Client:
         self.web_client = self.login_manager.get_web_client(
             base_url=funcx_service_address
         )
-        self.fx_serializer = ComputeSerializer()
+        self.fx_serializer = ComputeSerializer(
+            method_code=code_serializer_method,
+            method_data=data_serializer_method,
+        )
 
         self.funcx_service_address = funcx_service_address
 

--- a/compute_sdk/globus_compute_sdk/serialize/__init__.py
+++ b/compute_sdk/globus_compute_sdk/serialize/__init__.py
@@ -1,3 +1,24 @@
+from globus_compute_sdk.serialize.base import SerializeBase
+from globus_compute_sdk.serialize.concretes import (
+    DEFAULT_METHOD_CODE,
+    DEFAULT_METHOD_DATA,
+    CombinedCode,
+    DillCode,
+    DillCodeSource,
+    DillCodeTextInspect,
+    DillDataBase64,
+)
 from globus_compute_sdk.serialize.facade import ComputeSerializer
 
-__all__ = ("ComputeSerializer",)
+__all__ = [
+    "ComputeSerializer",
+    "SerializeBase",
+    "DEFAULT_METHOD_CODE",
+    "DEFAULT_METHOD_DATA",
+    # Selectable serializers:
+    "CombinedCode",
+    "DillCode",
+    "DillCodeSource",
+    "DillCodeTextInspect",
+    "DillDataBase64",
+]

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -33,7 +33,7 @@ class SerializeBase(metaclass=ABCMeta):
         raise NotImplementedError("Concrete class did not implement deserialize")
 
 
-class SerializerError:
+class SerializerError(Exception):
     def __init__(self, reason):
         self.reason = reason
 

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -4,6 +4,7 @@ import codecs
 import inspect
 import logging
 import pickle
+import typing as t
 from collections import OrderedDict
 
 import dill
@@ -124,6 +125,7 @@ class DillCode(SerializeBase):
     """
 
     identifier = "01\n"
+    _for_code = True
 
     def __init__(self):
         super().__init__()
@@ -149,6 +151,7 @@ class CombinedCode(SerializeBase):
     """
 
     identifier = "10\n"
+    _for_code = True
 
     # Functions are serialized using the following methods and the resulting encoded
     # versions are stored as chunks.  Allows redundancy if one of the methods fails on
@@ -216,7 +219,7 @@ class CombinedCode(SerializeBase):
         raise DeserializationError(f"Deserialization failed after {count} tries")
 
 
-METHODS_MAP = {
+METHODS_MAP: dict[str, t.Type[SerializeBase]] = {
     DillDataBase64.identifier: DillDataBase64,
     DillCodeSource.identifier: DillCodeSource,
     DillCode.identifier: DillCode,
@@ -225,5 +228,13 @@ METHODS_MAP = {
     CombinedCode.identifier: CombinedCode,
 }
 
-DEFAULT_METHOD_CODE = DillCode
-DEFAULT_METHOD_DATA = DillDataBase64
+SELECTABLE_SERIALIZERS = [
+    DillDataBase64,
+    DillCodeSource,
+    DillCode,
+    DillCodeTextInspect,
+    CombinedCode,
+]
+
+DEFAULT_METHOD_CODE = DillCode()
+DEFAULT_METHOD_DATA = DillDataBase64()

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -9,6 +9,7 @@ import time
 import pytest
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.web_client import WebClient
+from globus_compute_sdk.serialize import DillCodeSource
 from globus_sdk import AccessTokenAuthorizer, AuthClient, ConfidentialAppAuthClient
 
 # the non-tutorial endpoint will be required, with the following priority order for
@@ -172,6 +173,8 @@ def compute_test_config(pytestconfig, compute_test_config_name):
 
     if api_client_id and api_client_secret:
         _add_args_for_client_creds_login(api_client_id, api_client_secret, client_args)
+
+    client_args["code_serializer_method"] = DillCodeSource()
 
     return config
 


### PR DESCRIPTION
# Description

Allow users to specify what serializer to use when constructing a client, and, by extension, an executor.

[sc-23912]

Note for reviewers - the meat of the changes are in two commits, c3d45e3e4ea2513824f0ff015bb0256073d1a44f and 7c9a8e11534d85984b2209c3147dd90a1515ea54. Suggest reviewing those individually, and then the PR as a whole.

## Type of change

- New feature (non-breaking change that adds functionality)
