### PR TITLE
Add user-facing EP name validation

### DIFF
--- a/changelog.d/20230523_125601_kevin_no_spaces_in_ep_name.rst
+++ b/changelog.d/20230523_125601_kevin_no_spaces_in_ep_name.rst
@@ -1,0 +1,8 @@
+Bug Fixes
+^^^^^^^^^
+
+- Add validation logic to the endpoint ``configure`` subcommand to prevent
+  certain classes of endpoint names.  That is, Compute Endpoints may have
+  arbitrary _display_ names, but the name for use on the filesystem works best
+  without, for example, spaces.  Now, the ``configure`` step will exit early
+  with a (hopefully!) helpul error message explaining the problem.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -185,6 +185,10 @@ def configure_endpoint(
     Drops a config.py template into the Globus Compute configs directory.
     The template usually goes to ~/.globus_compute/<ENDPOINT_NAME>/config.py
     """
+    try:
+        Endpoint.validate_endpoint_name(name)
+    except ValueError as e:
+        raise ClickException(str(e))
     compute_dir = get_config_dir()
     ep_dir = compute_dir / name
     Endpoint.configure_endpoint(ep_dir, endpoint_config, multi_tenant, display_name)

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -217,6 +217,11 @@ def test_restart_endpoint_does_start_and_stop(
     mock_ep.start_endpoint.assert_called_once()
 
 
+def test_configure_validates_name(run_line):
+    run_line("configure ValidName")
+    run_line("configure 'Invalid name with spaces'", assert_exit_code=1)
+
+
 @pytest.mark.parametrize(
     "display_test",
     [


### PR DESCRIPTION
We recently implemented provisions for users to have alternate _display names_ (via `--display-name` to the `configure` subcommand, or to manually alter the `config.py` top-level configuration item `display_name="some name"`), but didn't go the next step and enforce that users can't do something silly (but natural!) like adding spaces to the name.  This has repercussions later on in that Parsl is not very robust with it's path handling.  So, assume the better part of valor is to die early with an explanation for the user rather than cryptically failing later on with a traceback.

[sc-24521]

## Type of change

- Bug fix (non-breaking change that fixes an issue)