### PR TITLE
Avoid creating test dir in user compute dir

### DIFF
--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -217,7 +217,10 @@ def test_restart_endpoint_does_start_and_stop(
     mock_ep.start_endpoint.assert_called_once()
 
 
-def test_configure_validates_name(run_line):
+def test_configure_validates_name(mock_command_ensure, run_line):
+    compute_dir = mock_command_ensure.endpoint_config_dir
+    compute_dir.mkdir(parents=True, exist_ok=True)
+
     run_line("configure ValidName")
     run_line("configure 'Invalid name with spaces'", assert_exit_code=1)
 


### PR DESCRIPTION
One of our tests for endpoint name validation was creating an endpoint directory in `~/.globus_compute/` and never cleaning it up. Tests should only create files/directories in a mocked filesystem or separate temp directories.
