### PR TITLE
Stop sending `entry_point` when registering functions

### DIFF
--- a/changelog.d/20230531_120415_chris_remove_entry_point.rst
+++ b/changelog.d/20230531_120415_chris_remove_entry_point.rst
@@ -1,0 +1,5 @@
+Removed
+^^^^^^^
+
+- The SDK no longer sends ``entry_point`` when registering a function. (This field was
+  unused elsewhere.)

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -641,7 +641,6 @@ class Client:
         data = FunctionRegistrationData(
             function=function,
             container_uuid=container_uuid,
-            entry_point=function_name,
             description=description,
             public=public,
             group=group,

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -34,7 +34,6 @@ class FunctionRegistrationData:
         function_name: t.Optional[str] = None,
         function_code: t.Optional[str] = None,
         container_uuid: t.Optional[ID_PARAM_T] = None,
-        entry_point: t.Optional[str] = None,
         description: t.Optional[str] = None,
         public: bool = False,
         group: t.Optional[str] = None,
@@ -55,7 +54,6 @@ class FunctionRegistrationData:
         self.container_uuid = (
             str(container_uuid) if container_uuid is not None else container_uuid
         )
-        self.entry_point = entry_point if entry_point is not None else function_name
         self.description = description
         self.public = public
         self.group = group
@@ -65,7 +63,6 @@ class FunctionRegistrationData:
             "function_name": self.function_name,
             "function_code": self.function_code,
             "container_uuid": self.container_uuid,
-            "entry_point": self.entry_point,
             "description": self.description,
             "public": self.public,
             "group": self.group,


### PR DESCRIPTION
# Description

Per [this Slack conversation](https://funcx.slack.com/archives/G016JMYST9C/p1683561274668059), this is an old, unused concept.

[sc-24274]

## Type of change

- Code maintenance/cleanup
