### PR TITLE
Revert "Stop sending `entry_point` when registering functions"

### DIFF
--- a/changelog.d/20230531_120415_chris_remove_entry_point.rst
+++ b/changelog.d/20230531_120415_chris_remove_entry_point.rst
@@ -1,5 +1,0 @@
-Removed
-^^^^^^^
-
-- The SDK no longer sends ``entry_point`` when registering a function. (This field was
-  unused elsewhere.)

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -654,6 +654,7 @@ class Client:
         data = FunctionRegistrationData(
             function=function,
             container_uuid=container_uuid,
+            entry_point=function_name,
             description=description,
             public=public,
             group=group,

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -34,6 +34,7 @@ class FunctionRegistrationData:
         function_name: t.Optional[str] = None,
         function_code: t.Optional[str] = None,
         container_uuid: t.Optional[ID_PARAM_T] = None,
+        entry_point: t.Optional[str] = None,
         description: t.Optional[str] = None,
         public: bool = False,
         group: t.Optional[str] = None,
@@ -54,6 +55,7 @@ class FunctionRegistrationData:
         self.container_uuid = (
             str(container_uuid) if container_uuid is not None else container_uuid
         )
+        self.entry_point = entry_point if entry_point is not None else function_name
         self.description = description
         self.public = public
         self.group = group
@@ -63,6 +65,7 @@ class FunctionRegistrationData:
             "function_name": self.function_name,
             "function_code": self.function_code,
             "container_uuid": self.container_uuid,
+            "entry_point": self.entry_point,
             "description": self.description,
             "public": self.public,
             "group": self.group,


### PR DESCRIPTION
# Description

Revert #1160 to fix smoke tests

## Type of change

- Bug fix (non-breaking change that fixes an issue)
