### PR TITLE
Standardize and disambiguate serialization class names

### DIFF
--- a/changelog.d/20230522_134306_chris_user_selectable_serialization.rst
+++ b/changelog.d/20230522_134306_chris_user_selectable_serialization.rst
@@ -5,18 +5,18 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
-- The methods used to serialize functions and arguments are now selectable at the
-  ``Client`` level via constructor arguments (``code_serializer_method`` and
-  ``data_serializer_method``)
+- The strategies used to serialize functions and arguments are now selectable at the
+  ``Client`` level via constructor arguments (``code_serialization_strategy`` and
+  ``data_serialization_strategy``)
   - For example, to use ``DillCodeSource`` when serializing functions:
-    ``client = Client(code_serializer_method=DillCodeSource())``
+    ``client = Client(code_serialization_strategy=DillCodeSource())``
   - This functionality is available to ``Executor``s by passing a custom client. Using
     the client above: ``executor = Executor(funcx_client=client)``
 
 Changed
 ^^^^^^^
 
-- Simplified the logic used to select a serialization method when one isn't specified -
-  rather than try every serializer in order, Globus Compute now simply defaults to
+- Simplified the logic used to select a serialization strategy when one isn't specified -
+  rather than try every strategy in order, Globus Compute now simply defaults to
   ``DillCode`` and ``DillDataBase64`` for code and data respectively
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -21,7 +21,7 @@ from globus_compute_sdk.sdk._environments import (
 from globus_compute_sdk.sdk.asynchronous.compute_task import ComputeTask
 from globus_compute_sdk.sdk.asynchronous.ws_polling_task import WebSocketPollingTask
 from globus_compute_sdk.sdk.web_client import FunctionRegistrationData
-from globus_compute_sdk.serialize import ComputeSerializer, SerializeBase
+from globus_compute_sdk.serialize import ComputeSerializer, SerializationStrategy
 from globus_compute_sdk.version import __version__, compare_versions
 
 from .batch import Batch
@@ -62,8 +62,8 @@ class Client:
         search_authorizer: t.Any = None,
         fx_authorizer: t.Any = None,
         *,
-        code_serializer_method: SerializeBase | None = None,
-        data_serializer_method: SerializeBase | None = None,
+        code_serialization_strategy: SerializationStrategy | None = None,
+        data_serialization_strategy: SerializationStrategy | None = None,
         login_manager: LoginManagerProtocol | None = None,
         **kwargs,
     ):
@@ -123,13 +123,13 @@ class Client:
             session or to reestablish Executor futures.
             Default: None (will be auto generated)
 
-        code_serializer_method: SerializeBase
-            Serializer method to use when serializing function code. If None,
-            globus_compute_sdk.serialize.DEFAULT_METHOD_CODE will be used.
+        code_serialization_strategy: SerializationStrategy
+            Strategy to use when serializing function code. If None,
+            globus_compute_sdk.serialize.DEFAULT_STRATEGY_CODE will be used.
 
-        data_serializer_method: SerializeBase
-            Serializer method to use when serializing function arguments. If None,
-            globus_compute_sdk.serialize.DEFAULT_METHOD_DATA will be used.
+        data_serialization_strategy: SerializationStrategy
+            Strategy to use when serializing function arguments. If None,
+            globus_compute_sdk.serialize.DEFAULT_STRATEGY_DATA will be used.
 
         Keyword arguments are the same as for BaseClient.
 
@@ -173,8 +173,8 @@ class Client:
             base_url=funcx_service_address
         )
         self.fx_serializer = ComputeSerializer(
-            method_code=code_serializer_method,
-            method_data=data_serializer_method,
+            strategy_code=code_serialization_strategy,
+            strategy_data=data_serialization_strategy,
         )
 
         self.funcx_service_address = funcx_service_address

--- a/compute_sdk/globus_compute_sdk/serialize/__init__.py
+++ b/compute_sdk/globus_compute_sdk/serialize/__init__.py
@@ -1,7 +1,7 @@
-from globus_compute_sdk.serialize.base import SerializeBase
+from globus_compute_sdk.serialize.base import SerializationStrategy
 from globus_compute_sdk.serialize.concretes import (
-    DEFAULT_METHOD_CODE,
-    DEFAULT_METHOD_DATA,
+    DEFAULT_STRATEGY_CODE,
+    DEFAULT_STRATEGY_DATA,
     CombinedCode,
     DillCode,
     DillCodeSource,
@@ -12,10 +12,10 @@ from globus_compute_sdk.serialize.facade import ComputeSerializer
 
 __all__ = [
     "ComputeSerializer",
-    "SerializeBase",
-    "DEFAULT_METHOD_CODE",
-    "DEFAULT_METHOD_DATA",
-    # Selectable serializers:
+    "SerializationStrategy",
+    "DEFAULT_STRATEGY_CODE",
+    "DEFAULT_STRATEGY_DATA",
+    # Selectable strategies:
     "CombinedCode",
     "DillCode",
     "DillCodeSource",

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -1,8 +1,10 @@
 from abc import ABCMeta, abstractmethod
 
 
-class SerializeBase(metaclass=ABCMeta):
-    """Shared functionality for all serializer implementations"""
+class SerializationStrategy(metaclass=ABCMeta):
+    """A SerializationStrategy is in charge of converting function source code or
+    arguments into string data and back again.
+    """
 
     @property
     @abstractmethod

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -35,7 +35,7 @@ class SerializationStrategy(metaclass=ABCMeta):
         raise NotImplementedError("Concrete class did not implement deserialize")
 
 
-class SerializerError(Exception):
+class SerializationError(Exception):
     def __init__(self, reason):
         self.reason = reason
 

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from globus_compute_sdk.serialize.base import SerializationStrategy, SerializerError
+from globus_compute_sdk.serialize.base import SerializationError, SerializationStrategy
 from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_CODE,
     DEFAULT_STRATEGY_DATA,
@@ -25,7 +25,7 @@ class ComputeSerializer:
 
         def validate(strategy: SerializationStrategy) -> SerializationStrategy:
             if type(strategy) not in SELECTABLE_STRATEGIES:
-                raise SerializerError(
+                raise SerializationError(
                     f"{strategy} is not a known serialization strategy "
                     f"(must be one of {SELECTABLE_STRATEGIES})"
                 )
@@ -58,7 +58,7 @@ class ComputeSerializer:
             return strategy.serialize(data)
         except Exception as e:
             err_msg = f"{stype} Serialization strategy {strategy} failed"
-            raise SerializerError(err_msg) from e
+            raise SerializationError(err_msg) from e
 
     def deserialize(self, payload):
         """
@@ -72,7 +72,7 @@ class ComputeSerializer:
         strategy = self.strategies.get(header)
 
         if not strategy:
-            raise SerializerError(f"Invalid header: {header} in data payload")
+            raise SerializationError(f"Invalid header: {header} in data payload")
 
         return strategy.deserialize(payload)
 

--- a/compute_sdk/tests/integration/test_serialization.py
+++ b/compute_sdk/tests/integration/test_serialization.py
@@ -3,7 +3,7 @@ import sys
 
 import globus_compute_sdk.serialize.concretes as concretes
 import pytest
-from globus_compute_sdk.serialize.base import SerializationStrategy, SerializerError
+from globus_compute_sdk.serialize.base import SerializationError, SerializationStrategy
 from globus_compute_sdk.serialize.facade import ComputeSerializer
 
 # length of serializer identifier
@@ -312,8 +312,8 @@ def test_serializer_errors_on_unknown_strategy():
 
     strategy = NewStrategy()
 
-    with pytest.raises(SerializerError):
+    with pytest.raises(SerializationError):
         ComputeSerializer(strategy_code=strategy)
 
-    with pytest.raises(SerializerError):
+    with pytest.raises(SerializationError):
         ComputeSerializer(strategy_data=strategy)

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -174,7 +174,7 @@ def compute_test_config(pytestconfig, compute_test_config_name):
     if api_client_id and api_client_secret:
         _add_args_for_client_creds_login(api_client_id, api_client_secret, client_args)
 
-    client_args["code_serializer_method"] = DillCodeSource()
+    client_args["code_serialization_strategy"] = DillCodeSource()
 
     return config
 


### PR DESCRIPTION
# Description

In anticipation of writing documentation for the new selectable serializer feature, it occurred to me that because of the way we use `ComputeSerializer` to wrap instances of `SerializeBase` - but not subclass it - there is some potential for confusion. I also don't love the usage of `method` to refer to the `SerializeBase` subclasses which are used to serialize/deserialize data within `ComputeSerializer`, since `method` is such an overloaded term in programming.

Instead, I propose the following:

* Rename `SerializeBase` to `SerializationStrategy`
* Refer to instances of `SerializationStrategy` as `strategies` (previously called `method`s)

This PR also renames `SerializerError` to `SerializationError`, which is more precise and mirrors the name of `DeserializationError`.

[sc-23912]

## Type of change

- Code maintenance/cleanup
