### PR TITLE
Modify serialize import to fix smoke tests

### DIFF
--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -9,7 +9,7 @@ import time
 import pytest
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.web_client import WebClient
-from globus_compute_sdk.serialize import DillCodeSource
+from globus_compute_sdk.serialize.concretes import DillCodeSource
 from globus_sdk import AccessTokenAuthorizer, AuthClient, ConfidentialAppAuthClient
 
 # the non-tutorial endpoint will be required, with the following priority order for


### PR DESCRIPTION
# Description

Our daily smoke tests are failing because the most recent deployment of `globus-compute-sdk` (v2.1.0) does not allow importing `DillCodeSource` directly from the `serialize` package.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
