### PR TITLE
Add missing pyyaml dependency

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -36,6 +36,7 @@ REQUIRES = [
     "parsl==2023.03.27",
     "pika>=1.2.0",
     "setproctitle>=1.3.2,<1.4",
+    "pyyaml>=6.0,<7.0",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
# Description

The **PyYAML** dependency should have been added to **compute_endpoint/setup.py** via #1151 but was missed.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
