### PR TITLE
Add support for multi-tenant config templates

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -421,10 +421,11 @@ def _do_start_endpoint(
     else:
         ep_config = get_config(ep_dir)
 
-    if die_with_parent and ep_config.detach_endpoint:
+    if die_with_parent:
         # The endpoint cannot die with it's parent if it
         # doesn't have one :)
         ep_config.detach_endpoint = False
+        log.debug("The --die-with-parent flag has set detach_endpoint to False")
 
     if ep_config.multi_tenant:
         epm = EndpointManager(ep_dir, endpoint_uuid, ep_config)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -17,7 +17,7 @@ from .model import ConfigModel
 log = logging.getLogger(__name__)
 
 
-def _read_config_py(endpoint_dir: pathlib.Path) -> Config | None:
+def _load_config_py(endpoint_dir: pathlib.Path) -> Config | None:
     conf_path = endpoint_dir / "config.py"
 
     if not conf_path.exists():
@@ -94,7 +94,7 @@ def _read_config_py(endpoint_dir: pathlib.Path) -> Config | None:
         raise
 
 
-def _read_config_yaml(endpoint_dir: pathlib.Path) -> Config:
+def _load_config_yaml(endpoint_dir: pathlib.Path) -> Config:
     config_path = endpoint_dir / "config.yaml"
     endpoint_name = endpoint_dir.name
 
@@ -140,14 +140,14 @@ def _read_config_yaml(endpoint_dir: pathlib.Path) -> Config:
 
 
 def get_config(endpoint_dir: pathlib.Path) -> Config:
-    config = _read_config_py(endpoint_dir)
+    config = _load_config_py(endpoint_dir)
     if config:
         # Use config.py if present
         # Note that if config.py exists but is invalid,
         # an exception will be raised
         return config
 
-    return _read_config_yaml(endpoint_dir)
+    return _load_config_yaml(endpoint_dir)
 
 
 def serialize_config(config: Config) -> dict:

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -37,6 +37,7 @@ REQUIRES = [
     "pika>=1.2.0",
     "setproctitle>=1.3.2,<1.4",
     "pyyaml>=6.0,<7.0",
+    "jinja2>=3.1.2,<3.2",
 ]
 
 TEST_REQUIRES = [

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -279,7 +279,7 @@ def test_start_ep_incorrect_config_py(run_line, mock_cli_state, make_endpoint_di
     assert "modified incorrectly?" in res.stderr
 
 
-@mock.patch("globus_compute_endpoint.endpoint.config.utils._read_config_py")
+@mock.patch("globus_compute_endpoint.endpoint.config.utils._load_config_py")
 def test_start_ep_config_py_override(
     read_config, run_line, mock_cli_state, make_endpoint_dir
 ):
@@ -311,7 +311,7 @@ config = Config(
     read_config.assert_called_once()
 
 
-@mock.patch("globus_compute_endpoint.endpoint.config.utils._read_config_py")
+@mock.patch("globus_compute_endpoint.endpoint.config.utils._load_config_py")
 def test_delete_endpoint(read_config, run_line, mock_cli_state):
     run_line("delete foo --yes")
     mock_ep, _ = mock_cli_state

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -346,3 +346,19 @@ def test_delete_endpoint(read_config, run_line, mock_cli_state):
     run_line("delete foo --yes")
     mock_ep, _ = mock_cli_state
     mock_ep.delete_endpoint.assert_called_once()
+
+
+@pytest.mark.parametrize("die_with_parent", [True, False])
+@mock.patch("globus_compute_endpoint.cli.get_config")
+def test_die_with_parent_detached(
+    mock_get_config, run_line, mock_cli_state, die_with_parent
+):
+    config = Config()
+    mock_get_config.return_value = config
+
+    if die_with_parent:
+        run_line("start foo --die-with-parent")
+        assert not config.detach_endpoint
+    else:
+        run_line("start foo")
+        assert config.detach_endpoint


### PR DESCRIPTION
# Description

This PR adds support for multi-tenant user configuration templates with Jinja syntax. As currently implemented, each multi-tenant endpoint must have one user config template named `config_user.yaml` in its endpoint directory.

#### General Workflow

1. Pass user options in a command payload to the `EndpointManager`
2. Call `fork`
3. Render the user config template (`config_user.yaml`) with the user options
4. Write the user config to `stdin`
5. Call `exec`
6. Read the user config from `stdin`
7. Generate a `Config` object for the user endpoint

I also included a small but relevant modification to ensure that an endpoint is not detached when started with the `--die-with-parent` flag.

[sc-21024]

## Type of change

- New feature (non-breaking change that adds functionality)
