### PR TITLE
Sync code with Globus SDK v3.20.1 and bump min. version

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -318,7 +318,7 @@ class Endpoint:
             except GlobusAPIError as e:
                 if e.http_status in (409, 410, 423):
                     # CONFLICT, GONE or LOCKED
-                    log.warning(f"Endpoint registration blocked.  [{e.message}]")
+                    log.warning(f"Endpoint registration blocked.  [{e.text}]")
                     exit(os.EX_UNAVAILABLE)
                 raise
 
@@ -531,7 +531,7 @@ class Endpoint:
         except GlobusAPIError as e:
             log.warning(
                 f"Endpoint <{ep_name}> could not be deleted from the web service"
-                f"  [{e.message}]"
+                f"  [{e.text}]"
             )
             if not force:
                 log.critical("Exiting without deleting the endpoint")

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -78,7 +78,7 @@ class EndpointManager:
         except GlobusAPIError as e:
             if e.http_status == 409 or e.http_status == 423:
                 # RESOURCE_CONFLICT or RESOURCE_LOCKED
-                log.warning(f"Endpoint registration blocked.  [{e.message}]")
+                log.warning(f"Endpoint registration blocked.  [{e.text}]")
                 exit(os.EX_UNAVAILABLE)
             raise
         except NetworkError as e:

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.20.0",
-    "globus-sdk>=3.14.0,<4",
+    "globus-sdk>=3.20.1,<4",
     "globus-compute-common==0.2.0",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",

--- a/compute_sdk/tests/integration/test_web_client_exceptions.py
+++ b/compute_sdk/tests/integration/test_web_client_exceptions.py
@@ -25,12 +25,12 @@ def client():
 
 
 @pytest.mark.parametrize("http_status", [400, 500])
-def test_reason_parsed_as_part_of_error(client, http_status):
-    reason = "you are bad and you should feel bad"
+def test_message_parsed_as_part_of_error(client, http_status):
+    message = "you are bad and you should feel bad"
     responses.add(
         responses.GET,
         "https://api.funcx/foo",
-        json={"code": 100, "reason": reason},
+        json={"code": 100, "message": message},
         match_querystring=None,
         status=http_status,
     )
@@ -39,6 +39,6 @@ def test_reason_parsed_as_part_of_error(client, http_status):
 
     err = excinfo.value
     assert err.http_status == http_status
-    assert reason in err.message
+    assert message in err.message
     # the message should be visible in the str form of the error
-    assert reason in str(err)
+    assert message in str(err)


### PR DESCRIPTION
# Description

Globus SDK v3.20.0 [modified](https://github.com/globus/globus-sdk-python/commit/23d7f1ce742e4d5231798cd56894a58a9ce0c977) the default value returned for `GlobusAPIError.message`, which we use in a few places. We will now use the `text` attribute to directly access response messages and bump the minimum required version for `globus-sdk` to v3.20.1.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
