### PR TITLE
Nicer EPStatusReport .debug() log line

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -534,7 +534,7 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
                     return
 
                 elif isinstance(msgs, EPStatusReport):
-                    log.debug(f"Received EPStatusReport {msgs}")
+                    log.debug(f"Received {msgs!r}")
                     if self.passthrough:
                         external_ep_status = convert_ep_status_report(msgs)
                         self.results_passthrough.put(

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/messages.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/messages.py
@@ -184,6 +184,11 @@ class EPStatusReport(Message):
         self.global_state = global_state
         self.task_statuses = task_statuses
 
+    def __repr__(self):
+        name = type(self).__name__
+        ep_id = uuid.UUID(bytes=self._header)
+        return f"{name}(ep:{ep_id}; task count:{len(self.task_statuses)})"
+
     @classmethod
     def unpack(cls, msg):
         endpoint_id = str(uuid.UUID(bytes=msg[:16]))


### PR DESCRIPTION
    # Before:
    [log_line_header ...] Received EPStatusReport <globus_compute_endpoint.engines.high_throughput.messages.EPStatusReport object at 0x7f2827bd77f0>

    # After:
    [log_line_header ...] Received EPStatusReport(ep:48ceb6a0-876b-3d31-6084-49dd7edb89d7; task count:0)

## Type of change

- Code maintenance/cleanup
