### PR TITLE
Rename `executor` to `engine` in YAML config

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
@@ -1,5 +1,5 @@
 display_name: None
-executor:
+engine:
   provider:
     type: LocalProvider
     init_blocks: 1

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -86,7 +86,7 @@ class ProviderModel(BaseModel):
         extra = "allow"
 
 
-class ExecutorModel(BaseModel):
+class EngineModel(BaseModel):
     type: type = Field(default=HighThroughputExecutor, const=True)
     provider: ProviderModel
     strategy: t.Optional[StrategyModel]
@@ -101,7 +101,7 @@ class ExecutorModel(BaseModel):
 
 
 class ConfigModel(BaseModel):
-    executor: ExecutorModel
+    engine: EngineModel
     display_name: t.Optional[str]
     environment: t.Optional[str]
     funcx_service_address: t.Optional[str]
@@ -116,13 +116,13 @@ class ConfigModel(BaseModel):
     stdout: t.Optional[str]
     stderr: t.Optional[str]
 
-    _validate_executor = _validate_params("executor")
+    _validate_engine = _validate_params("engine")
 
     def dict(self, *args, **kwargs):
         # Slight modification is needed here since we still
-        # store the executor in a list named executors
+        # store the engine/executor in a list named executors
         ret = super().dict(*args, **kwargs)
-        executor = ret.pop("executor")
+        executor = ret.pop("engine")
         ret["executors"] = [executor]
         return ret
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -47,7 +47,7 @@ def make_endpoint_dir(mock_command_ensure):
         ep_config.write_text(
             """
 display_name: None
-executor:
+engine:
     provider:
         type: LocalProvider
         init_blocks: 1
@@ -58,7 +58,7 @@ executor:
         ep_template.write_text(
             """
 heartbeat_period: {{ heartbeat }}
-executor:
+engine:
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -509,7 +509,7 @@ def test_render_config_user_template(fs, data):
     template.write_text(
         """
 heartbeat_period: {{ heartbeat }}
-executor:
+engine:
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -41,7 +41,7 @@ def user_conf_template(conf_dir):
     template.write_text(
         """
 heartbeat_period: {{ heartbeat }}
-executor:
+engine:
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/docs/configs/bebop.yaml
+++ b/docs/configs/bebop.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/bluewaters.yaml
+++ b/docs/configs/bluewaters.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 1
     worker_debug: False
     address: 127.0.0.1

--- a/docs/configs/cooley.yaml
+++ b/docs/configs/cooley.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/cori.yaml
+++ b/docs/configs/cori.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/frontera.yaml
+++ b/docs/configs/frontera.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/kube.yaml
+++ b/docs/configs/kube.yaml
@@ -2,7 +2,7 @@ heartbeat_period: 15
 heartbeat_threshold: 200
 log_dir: '.'
 
-executor:
+engine:
     label: Kubernetes_funcX
     max_workers_per_node: 1
 

--- a/docs/configs/midway.yaml
+++ b/docs/configs/midway.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/midway_singularity.yaml
+++ b/docs/configs/midway_singularity.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 10
 
     address:

--- a/docs/configs/perlmutter.yaml
+++ b/docs/configs/perlmutter.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     worker_debug: False
 
     address:

--- a/docs/configs/polaris.yaml
+++ b/docs/configs/polaris.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 1
 
     # Un-comment to give each worker exclusive access to a single GPU

--- a/docs/configs/theta.yaml
+++ b/docs/configs/theta.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/theta_singularity.yaml
+++ b/docs/configs/theta_singularity.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/uchicago_ai_cluster.yaml
+++ b/docs/configs/uchicago_ai_cluster.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     label: fe.cs.uchicago
     worker_debug: False
 

--- a/docs/configs/worker_pinning.yaml
+++ b/docs/configs/worker_pinning.yaml
@@ -1,4 +1,4 @@
-executor:
+engine:
     max_workers_per_node: 4
 
     # `available_accelerators` may be a natural number or a list of strings.

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -14,7 +14,7 @@ data:
     heartbeat_threshold: 200
     funcx_service_address: {{ .Values.funcXServiceAddress }}/v2
     detach_endpoint: False
-    executor:
+    engine:
         provider:
             type: KubernetesProvider
             init_blocks: { .Values.initBlocks }}

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -41,7 +41,7 @@ fi
 cat > "$conf_dir/config.yaml" <<EOF
 environment: $env
 detach_endpoint: False
-executor:
+engine:
     heartbeat_period: 10
     provider:
         type: LocalProvider


### PR DESCRIPTION
# Description

Our YAML config schema should reflect the impending change to replace executors with engines.

[sc-24805]

## Type of change

- Code maintenance/cleanup
