### PR TITLE
Globuscs environments

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.1.0"
+__version__ = "2.2.0a0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.1.0",
+    "globus-compute-sdk==2.2.0a0",
     "globus-compute-common==0.2.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_funcx/endpoint/funcx_endpoint/version.py
+++ b/compute_funcx/endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.1.0"
+__version__ = "2.2.0a0"
 
 VERSION = __version__
 

--- a/compute_funcx/endpoint/setup.py
+++ b/compute_funcx/endpoint/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-endpoint==2.1.0",
+    "globus-compute-endpoint==2.2.0a0",
 ]
 
 version_ns = {}

--- a/compute_funcx/sdk/funcx/version.py
+++ b/compute_funcx/sdk/funcx/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.1.0"
+__version__ = "2.2.0a0"
 
 DEPRECATION_FUNCX = """
 The funcX SDK has been renamed to Globus Compute SDK and the new package is

--- a/compute_funcx/sdk/setup.py
+++ b/compute_funcx/sdk/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-sdk==2.1.0",
+    "globus-compute-sdk==2.2.0a0",
 ]
 
 

--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -5,7 +5,11 @@ from urllib.parse import urlparse
 
 
 def _get_envname():
-    return os.getenv("FUNCX_SDK_ENVIRONMENT", "production")
+    return os.getenv(
+        "GLOBUS_SDK_ENVIRONMENT",
+        # Fallback to the old ENV var if GLOBUS_SDK_ENVIRONMENT is not set
+        os.getenv("FUNCX_SDK_ENVIRONMENT", "production"),
+    )
 
 
 def get_web_service_url(envname: str | None) -> str:
@@ -15,6 +19,9 @@ def get_web_service_url(envname: str | None) -> str:
         "dev": "https://api.dev.funcx.org/v2",
         "local": "http://localhost:5000/v2",
     }
+    for test_env in ["sandbox", "test", "integration", "staging", "preview"]:
+        urls[test_env] = f"https://compute.api.{test_env}.globuscs.info/v2"
+
     return urls.get(env, urls["production"])
 
 

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.1.0"
+__version__ = "2.2.0a0"
 
 
 def compare_versions(

--- a/compute_sdk/tests/unit/test_environment_lookups.py
+++ b/compute_sdk/tests/unit/test_environment_lookups.py
@@ -12,15 +12,24 @@ def _clear_sdk_env(monkeypatch):
 
 
 def test_web_service_url(monkeypatch):
-    assert get_web_service_url(None) == "https://compute.api.globus.org/v2"
-    assert get_web_service_url("production") == "https://compute.api.globus.org/v2"
-    assert (
-        get_web_service_url("no-such-env-name-known")
-        == "https://compute.api.globus.org/v2"
-    )
-    assert get_web_service_url("dev") == "https://api.dev.funcx.org/v2"
+    env_url_map = {
+        None: "https://compute.api.globus.org/v2",
+        "production": "https://compute.api.globus.org/v2",
+        "bad-env-name": "https://compute.api.globus.org/v2",
+        "sandbox": "https://compute.api.sandbox.globuscs.info/v2",
+        "test": "https://compute.api.test.globuscs.info/v2",
+        "preview": "https://compute.api.preview.globuscs.info/v2",
+    }
+
+    for env, url in env_url_map.items():
+        assert get_web_service_url(env) == url
+
     monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", "dev")
     assert get_web_service_url(None) == "https://api.dev.funcx.org/v2"
+
+    # GLOBUS_SDK_ENVIRONMENT should override FUNCX_SDK_ENVIRONMENT
+    monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", "sandbox")
+    assert get_web_service_url(None) == env_url_map["sandbox"]
 
 
 def test_web_socket_url(monkeypatch):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,9 +3,9 @@ Changelog
 
 .. scriv-insert-here
 
-.. _changelog-2.1.0:
+.. _changelog-2.2.0a0:
 
-globus-compute-sdk & globus-compute-endpoint v2.1.0
+globus-compute-sdk & globus-compute-endpoint v2.2.0a0
 ---------------------------------------------------
 
 New Functionality

--- a/docs/changelog_funcx.rst
+++ b/docs/changelog_funcx.rst
@@ -3,9 +3,9 @@ Changelog
 
 .. scriv-insert-here
 
-.. _changelog-2.1.0:
+.. _changelog-2.2.0a0:
 
-funcx & funcx-endpoint v2.1.0
+funcx & funcx-endpoint v2.2.0a0
 ---------------------------------------------------
 
 Bug Fixes


### PR DESCRIPTION
This adds the various internal test environments to the allowed env list (staging, test, integration, preview, sandbox).

Getting the env now also uses GLOBUS_SDK_ENVIRONMENT (but falls back to FUNC_SDK_ENVIRONMENT if the former is not present).  

Also, includes alpha release version bump for the release earlier today.

Intentionally left the changelog unmodified