### PR TITLE
Add default_config.yaml to MANIFEST.in

### DIFF
--- a/compute_endpoint/MANIFEST.in
+++ b/compute_endpoint/MANIFEST.in
@@ -1,1 +1,2 @@
 include PyPI.md
+include globus_compute_endpoint/endpoint/config/default_config.yaml


### PR DESCRIPTION
# Description

The path to `default_config.yaml` must be present in our `MANIFEST.in` file for it to be included in our package.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
