### PR TITLE
Fix duplicate validator name

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -94,7 +94,7 @@ class EngineModel(BaseModel):
 
     _validate_provider = _validate_params("provider")
     _validate_strategy = _validate_params("strategy")
-    _validate_strategy = _validate_params("address")
+    _validate_address = _validate_params("address")
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
# Description

A small typo in a validator name made the `strategy` config stanza unusable.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
