### PR TITLE
Add changelog for YAML config bugfix

### DIFF
--- a/changelog.d/20230622_214149_30907815+rjmello_bugfix_strategy.rst
+++ b/changelog.d/20230622_214149_30907815+rjmello_bugfix_strategy.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address bug in which adding a `strategy` stanza to a YAML config prohibits an
+  endpoint from starting.


### PR DESCRIPTION
# Description

Add missing changelog for bug in which adding a `strategy` stanza to a YAML config prohibits an endpoint from starting (see #1192).

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Documentation update
