### PR TITLE
update versions for strategy bugfix release 2.2.2

### DIFF
--- a/changelog.d/20230622_214149_30907815+rjmello_bugfix_strategy.rst
+++ b/changelog.d/20230622_214149_30907815+rjmello_bugfix_strategy.rst
@@ -1,5 +1,0 @@
-Bug Fixes
-^^^^^^^^^
-
-- Address bug in which adding a `strategy` stanza to a YAML config prohibits an
-  endpoint from starting.

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.2.0"
+__version__ = "2.2.2"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.2.0",
+    "globus-compute-sdk==2.2.2",
     "globus-compute-common==0.2.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_funcx/endpoint/funcx_endpoint/version.py
+++ b/compute_funcx/endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.2.0"
+__version__ = "2.2.2"
 
 VERSION = __version__
 

--- a/compute_funcx/endpoint/setup.py
+++ b/compute_funcx/endpoint/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-endpoint==2.2.0",
+    "globus-compute-endpoint==2.2.2",
 ]
 
 version_ns = {}

--- a/compute_funcx/sdk/funcx/version.py
+++ b/compute_funcx/sdk/funcx/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.2.0"
+__version__ = "2.2.2"
 
 DEPRECATION_FUNCX = """
 The funcX SDK has been renamed to Globus Compute SDK and the new package is

--- a/compute_funcx/sdk/setup.py
+++ b/compute_funcx/sdk/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-sdk==2.2.0",
+    "globus-compute-sdk==2.2.2",
 ]
 
 

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.2.0"
+__version__ = "2.2.2"
 
 
 def compare_versions(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,17 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-2.2.2:
+
+globus-compute-sdk & globus-compute-endpoint v2.2.2
+---------------------------------------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Address bug in which adding a `strategy` stanza to a YAML config prohibits an
+  endpoint from starting.
+
 .. _changelog-2.2.0:
 
 globus-compute-sdk & globus-compute-endpoint v2.2.0

--- a/docs/changelog_funcx.rst
+++ b/docs/changelog_funcx.rst
@@ -3,9 +3,18 @@ Changelog
 
 .. scriv-insert-here
 
+funcx & funcx-endpoint v2.2.2
+---------------------------------------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Address bug in which adding a `strategy` stanza to a YAML config prohibits an
+  endpoint from starting.
+
 .. _changelog-2.2.0:
 
-globus-compute-sdk & globus-compute-endpoint v2.2.0
+funcx & funcx-endpoint v2.2.0
 ---------------------------------------------------
 
 New Functionality
@@ -50,7 +59,7 @@ Changed
 
 .. _changelog-2.1.0:
 
-globus-compute-sdk & globus-compute-endpoint v2.1.0
+funcx & funcx-endpoint v2.1.0
 ---------------------------------------------------
 
 New Functionality


### PR DESCRIPTION
Bump versions for release.

To include the strategy changelog we need to up the version again.