### PR TITLE
Support engine type specification in config

### DIFF
--- a/changelog.d/20230630_110417_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20230630_110417_30907815+rjmello_HEAD.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The engine ``type`` field is now supported in ``config.yaml``. Here you can
+  specify ``GlobusComputeEngine`` or ``HighThroughputEngine``, which is designed
+  to bridge any backward compatibility issues.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import inspect
 import warnings
 
-from globus_compute_endpoint.executors import HighThroughputExecutor
+from globus_compute_endpoint.engines import HighThroughputEngine
 from parsl.utils import RepresentationMixin
 
-_DEFAULT_EXECUTORS = [HighThroughputExecutor()]
+_DEFAULT_EXECUTORS = [HighThroughputEngine()]
 
 
 class Config(RepresentationMixin):
@@ -18,7 +18,7 @@ class Config(RepresentationMixin):
     executors : list of Executors
         A list of executors which serve as the backend for function execution.
         As of 0.2.2, this list should contain only one executor.
-        Default: [HighThroughtputExecutor()]
+        Default: [HighThroughputEngine()]
 
     environment: str
         Environment the endpoint should connect to. Sets funcx_service_address and

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
@@ -1,11 +1,11 @@
 from globus_compute_endpoint.endpoint.config import Config
-from globus_compute_endpoint.executors import HighThroughputExecutor
+from globus_compute_endpoint.engines import HighThroughputEngine
 from parsl.providers import LocalProvider
 
 config = Config(
     display_name=None,  # If None, defaults to the endpoint name
     executors=[
-        HighThroughputExecutor(
+        HighThroughputEngine(
             provider=LocalProvider(
                 init_blocks=1,
                 min_blocks=0,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
@@ -1,5 +1,6 @@
 display_name: None
 engine:
+  type: HighThroughputEngine
   provider:
     type: LocalProvider
     init_blocks: 1

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -36,43 +36,36 @@ def _validate_params(field: str):
     return validator(field, allow_reuse=True)(inner)
 
 
-class AddressModel(BaseModel):
+class BaseConfigModel(BaseModel):
+    class Config:
+        extra = "allow"
+
+
+class AddressModel(BaseConfigModel):
     type: str
 
     _validate_type = _validate_import("type", parsl_addresses)
 
-    class Config:
-        extra = "allow"
 
-
-class StrategyModel(BaseModel):
+class StrategyModel(BaseConfigModel):
     type: str
 
     _validate_type = _validate_import("type", strategies)
 
-    class Config:
-        extra = "allow"
 
-
-class LauncherModel(BaseModel):
+class LauncherModel(BaseConfigModel):
     type: str
 
     _validate_type = _validate_import("type", parsl_launchers)
 
-    class Config:
-        extra = "allow"
 
-
-class ChannelModel(BaseModel):
+class ChannelModel(BaseConfigModel):
     type: str
 
     _validate_type = _validate_import("type", parsl_channels)
 
-    class Config:
-        extra = "allow"
 
-
-class ProviderModel(BaseModel):
+class ProviderModel(BaseConfigModel):
     type: str
     channel: t.Optional[ChannelModel]
     launcher: t.Optional[LauncherModel]
@@ -81,11 +74,8 @@ class ProviderModel(BaseModel):
     _validate_channel = _validate_params("channel")
     _validate_launcher = _validate_params("launcher")
 
-    class Config:
-        extra = "allow"
 
-
-class EngineModel(BaseModel):
+class EngineModel(BaseConfigModel):
     type: str
     provider: ProviderModel
     strategy: t.Optional[StrategyModel]
@@ -96,11 +86,8 @@ class EngineModel(BaseModel):
     _validate_strategy = _validate_params("strategy")
     _validate_address = _validate_params("address")
 
-    class Config:
-        extra = "allow"
 
-
-class ConfigModel(BaseModel):
+class ConfigModel(BaseConfigModel):
     engine: EngineModel
     display_name: t.Optional[str]
     environment: t.Optional[str]
@@ -127,6 +114,3 @@ class ConfigModel(BaseModel):
         executor = ret.pop("engine")
         ret["executors"] = [executor]
         return ret
-
-    class Config:
-        extra = "allow"

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import typing as t
 from types import ModuleType
 
-from globus_compute_endpoint import strategies
-from globus_compute_endpoint.executors import HighThroughputExecutor
+from globus_compute_endpoint import engines, strategies
 from parsl import addresses as parsl_addresses
 from parsl import channels as parsl_channels
 from parsl import launchers as parsl_launchers
 from parsl import providers as parsl_providers
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, validator
 
 
 def _validate_import(field: str, package: ModuleType):
@@ -87,11 +86,12 @@ class ProviderModel(BaseModel):
 
 
 class EngineModel(BaseModel):
-    type: type = Field(default=HighThroughputExecutor, const=True)
+    type: str
     provider: ProviderModel
     strategy: t.Optional[StrategyModel]
     address: t.Optional[t.Union[str, AddressModel]]
 
+    _validate_type = _validate_import("type", engines)
     _validate_provider = _validate_params("provider")
     _validate_strategy = _validate_params("strategy")
     _validate_address = _validate_params("address")

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -76,7 +76,7 @@ class ProviderModel(BaseConfigModel):
 
 
 class EngineModel(BaseConfigModel):
-    type: str
+    type: str = "HighThroughputEngine"
     provider: ProviderModel
     strategy: t.Optional[StrategyModel]
     address: t.Optional[t.Union[str, AddressModel]]
@@ -85,6 +85,9 @@ class EngineModel(BaseConfigModel):
     _validate_provider = _validate_params("provider")
     _validate_strategy = _validate_params("strategy")
     _validate_address = _validate_params("address")
+
+    class Config:
+        validate_all = True
 
 
 class ConfigModel(BaseConfigModel):

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -263,12 +263,12 @@ def test_stop_remote_endpoint(
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.executors import HighThroughputExecutor\n"
+                "from funcx_endpoint.engines import HighThroughputEngine\n"
                 "from parsl.providers import LocalProvider\n"
                 "\n"
                 "config = Config(\n"
                 "    executors=[\n"
-                "        HighThroughputExecutor(\n"
+                "        HighThroughputEngine(\n"
                 "            provider=LocalProvider(\n"
                 "                init_blocks=1,\n"
                 "                min_blocks=0,\n"
@@ -283,7 +283,7 @@ def test_stop_remote_endpoint(
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.executors import HighThroughputExecutor\n"
+                "from funcx_endpoint.engines import HighThroughputEngine\n"
                 "from parsl.providers import LocalProvider\n"
             ),
             False,
@@ -294,7 +294,7 @@ def test_stop_remote_endpoint(
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.executors import HighThroughputExecutor\n"
+                "from funcx_endpoint.engines import HighThroughputEngine\n"
                 "from parsl.providers import LocalProvider\n"
             ),
             False,
@@ -306,7 +306,7 @@ def test_stop_remote_endpoint(
             (
                 "def abc():"
                 "    from funcx_endpoint.endpoint.utils.config import Config\n"
-                "    from funcx_endpoint.executors import HighThroughputExecutor\n"
+                "    from funcx_endpoint.engines import HighThroughputEngine\n"
                 "    from parsl.providers import LocalProvider\n"
                 "    return 'hello'\n"
             ),

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -321,13 +321,13 @@ def test_start_ep_config_py_override(
     conf_py.write_text(
         """
 from globus_compute_endpoint.endpoint.config import Config
-from globus_compute_endpoint.executors import HighThroughputExecutor
+from globus_compute_endpoint.engines import HighThroughputEngine
 from parsl.providers import LocalProvider
 
 config = Config(
     display_name=None,
     executors=[
-        HighThroughputExecutor(
+        HighThroughputEngine(
             provider=LocalProvider(
                 init_blocks=1,
                 min_blocks=0,

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -48,6 +48,7 @@ def make_endpoint_dir(mock_command_ensure):
             """
 display_name: None
 engine:
+    type: HighThroughputEngine
     provider:
         type: LocalProvider
         init_blocks: 1
@@ -59,6 +60,7 @@ engine:
             """
 heartbeat_period: {{ heartbeat }}
 engine:
+    type: HighThroughputEngine
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -510,6 +510,7 @@ def test_render_config_user_template(fs, data):
         """
 heartbeat_period: {{ heartbeat }}
 engine:
+    type: HighThroughputEngine
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -42,6 +42,7 @@ def user_conf_template(conf_dir):
         """
 heartbeat_period: {{ heartbeat }}
 engine:
+    type: HighThroughputEngine
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/docs/configs/bebop.yaml
+++ b/docs/configs/bebop.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/bluewaters.yaml
+++ b/docs/configs/bluewaters.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 1
     worker_debug: False
     address: 127.0.0.1

--- a/docs/configs/bridges-2.yaml
+++ b/docs/configs/bridges-2.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/cooley.yaml
+++ b/docs/configs/cooley.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/cori.yaml
+++ b/docs/configs/cori.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/frontera.yaml
+++ b/docs/configs/frontera.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/kube.yaml
+++ b/docs/configs/kube.yaml
@@ -3,6 +3,7 @@ heartbeat_threshold: 200
 log_dir: "."
 
 engine:
+    type: HighThroughputEngine
     label: Kubernetes_funcX
     max_workers_per_node: 1
 

--- a/docs/configs/midway.yaml
+++ b/docs/configs/midway.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/midway_singularity.yaml
+++ b/docs/configs/midway_singularity.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 10
 
     address:

--- a/docs/configs/perlmutter.yaml
+++ b/docs/configs/perlmutter.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     worker_debug: False
 
     address:

--- a/docs/configs/polaris.yaml
+++ b/docs/configs/polaris.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 1
 
     # Un-comment to give each worker exclusive access to a single GPU

--- a/docs/configs/theta.yaml
+++ b/docs/configs/theta.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/theta_singularity.yaml
+++ b/docs/configs/theta_singularity.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 1
     worker_debug: False
 

--- a/docs/configs/uchicago_ai_cluster.yaml
+++ b/docs/configs/uchicago_ai_cluster.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     label: fe.cs.uchicago
     worker_debug: False
 

--- a/docs/configs/worker_pinning.yaml
+++ b/docs/configs/worker_pinning.yaml
@@ -1,4 +1,5 @@
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 4
 
     # `available_accelerators` may be a natural number or a list of strings.

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -77,7 +77,7 @@ Theta (ALCF)
 .. image:: _static/images/ALCF-Theta_111016-1000px.jpg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Theta** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Theta's Cobalt scheduler
+**Theta** supercomputer. This example uses the ``HighThroughputEngine`` and connects to Theta's Cobalt scheduler
 using the ``CobaltProvider``. This configuration assumes that the script is being executed on the login nodes of Theta.
 
 .. literalinclude:: configs/theta.yaml
@@ -95,7 +95,7 @@ Cooley (ALCF)
 .. image:: _static/images/31174D02-Cooley800.jpg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Cooley** cluster. This example uses the ``HighThroughputExecutor`` and connects to Cooley's Cobalt scheduler
+**Cooley** cluster. This example uses the ``HighThroughputEngine`` and connects to Cooley's Cobalt scheduler
 using the ``CobaltProvider``. This configuration assumes that the script is being executed on the login nodes of Cooley.
 
 .. literalinclude:: configs/cooley.yaml
@@ -108,7 +108,7 @@ Polaris (ALCF)
 .. image:: _static/images/ALCF_Polaris.jpeg
 
 The following snippet shows an example configuration for executing on Argonne Leadership Computing Facility's
-**Polaris** cluster. This example uses the ``HighThroughputExecutor`` and connects to Polaris's PBS scheduler
+**Polaris** cluster. This example uses the ``HighThroughputEngine`` and connects to Polaris's PBS scheduler
 using the ``PBSProProvider``. This configuration assumes that the script is being executed on the login node of Polaris.
 
 .. literalinclude:: configs/polaris.yaml
@@ -120,7 +120,7 @@ Cori (NERSC)
 
 .. image:: _static/images/Cori-NERSC.png
 
-The following snippet shows an example configuration for accessing NERSC's **Cori** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Cori's Slurm scheduler.
+The following snippet shows an example configuration for accessing NERSC's **Cori** supercomputer. This example uses the ``HighThroughputEngine`` and connects to Cori's Slurm scheduler.
 It is configured to request 2 nodes configured with 1 TaskBlock per node. Finally, it includes override information to request a particular node type (Haswell) and to configure a specific Python environment on the worker nodes using Anaconda.
 
 .. literalinclude:: configs/cori.yaml
@@ -132,7 +132,7 @@ Perlmutter (NERSC)
 
 .. image:: _static/images/Nersc9-image-compnew-sizer7-group-type-4-1.jpg
 
-The following snippet shows an example configuration for accessing NERSC's **Perlmutter** supercomputer. This example uses the ``HighThroughputExecutor`` and connects to Perlmutters's Slurm scheduler.
+The following snippet shows an example configuration for accessing NERSC's **Perlmutter** supercomputer. This example uses the ``HighThroughputEngine`` and connects to Perlmutters's Slurm scheduler.
 It is configured to request 2 nodes configured with 1 TaskBlock per node. Finally, it includes override information to request a particular node type (Haswell) and to configure a specific Python environment on the worker nodes using Anaconda.
 
 .. note:: Please run ``module load cgpu`` prior to executing ``globus-compute-endpoint start <endpoint_name>``
@@ -183,7 +183,7 @@ Pinning Workers to devices
 
 Many modern clusters provide multiple accelerators per compute note, yet many applications are best suited to using a
 single accelerator per task. Globus Compute supports pinning each worker to different accelerators using the ``available_accelerators``
-option of the ``HighThroughputExecutor``. Provide either the number of accelerators (Globus Compute will assume they are named
+option of the ``HighThroughputEngine``. Provide either the number of accelerators (Globus Compute will assume they are named
 in integers starting from zero) or a list of the names of the accelerators available on the node. Each Globus Compute worker
 will have the following environment variables set to the worker specific identity assigned:
 ``CUDA_VISIBLE_DEVICES``, ``ROCR_VISIBLE_DEVICES``, ``SYCL_DEVICE_FILTER``.

--- a/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
+++ b/helm/funcx_endpoint/templates/endpoint-instance-config.yaml
@@ -15,6 +15,7 @@ data:
     funcx_service_address: {{ .Values.funcXServiceAddress }}/v2
     detach_endpoint: False
     engine:
+        type: HighThroughputEngine
         provider:
             type: KubernetesProvider
             init_blocks: { .Values.initBlocks }}

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -42,6 +42,7 @@ cat > "$conf_dir/config.yaml" <<EOF
 environment: $env
 detach_endpoint: False
 engine:
+    type: HighThroughputEngine
     heartbeat_period: 10
     provider:
         type: LocalProvider


### PR DESCRIPTION
# Description

The engine `type` field is now supported in `config.yaml` and can be defined as any engine class. The default is `HighThroughputEngine` for backward compatibility.

I also replaced `HighThroughputExecutor` with `HighThroughputEngine` in `config.py` to avoid the deprecation warning when importing the former.

[sc-24805]

## Type of change

- New feature (non-breaking change that adds functionality)
