### PR TITLE
Fix smoke test version checks

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -38,3 +38,8 @@ def get_web_socket_url(envname: str | None) -> str:
 def urls_might_mismatch(service_url: str, socket_url: str) -> bool:
     parsed_service, parsed_socket = urlparse(service_url), urlparse(socket_url)
     return parsed_service.hostname != parsed_socket.hostname
+
+
+def remove_url_path(url: str):
+    parsed_url = urlparse(url)
+    return f"{parsed_url.scheme}://{parsed_url.netloc}"

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -8,11 +8,10 @@ It also implements data helpers for building complex payloads. Most notably,
 import json
 import typing as t
 import uuid
-from urllib.parse import urlparse
 
 import globus_sdk
 from globus_compute_common.sdk_version_sharing import user_agent_substring
-from globus_compute_sdk.sdk._environments import get_web_service_url
+from globus_compute_sdk.sdk._environments import get_web_service_url, remove_url_path
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.version import __version__
 from globus_sdk.exc.api import GlobusAPIError
@@ -92,10 +91,7 @@ class WebClient(globus_sdk.BaseClient):
     ):
         if base_url is None:
             base_url = get_web_service_url(environment)
-
-        # Remove path from base url
-        parsed_base_url = urlparse(base_url)
-        base_url = f"{parsed_base_url.scheme}://{parsed_base_url.netloc}"
+        base_url = remove_url_path(base_url)
 
         super().__init__(environment=environment, base_url=base_url, **kwargs)
 

--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -3,7 +3,6 @@ import time
 
 import globus_compute_sdk as gc
 import pytest
-import requests
 from globus_compute_sdk import Executor
 from packaging.version import Version
 
@@ -80,12 +79,11 @@ def test_wait_on_new_hello_world_func(compute_client, endpoint):
 
 def test_executor(compute_client, endpoint, tutorial_function_id):
     """Test using Executor to retrieve results."""
+    res = compute_client.web_client.get_version()
+    url = res._response.url
 
-    url = f"{compute_client.funcx_service_address}/version"
-    res = requests.get(url)
-
-    assert res.status_code == 200, f"Received {res.status_code} instead!"
-    server_version = Version(res.json())
+    assert res.http_status == 200, f"Received {res.http_status} instead!"
+    server_version = Version(res.data["api"])
     if server_version.release < (1, 0, 5):
         pytest.skip(
             "Server too old (use `tox -- -v` for details)"

--- a/smoke_tests/tests/test_version.py
+++ b/smoke_tests/tests/test_version.py
@@ -1,19 +1,16 @@
-import requests
 from packaging.version import Version
 
 
 def test_web_service(compute_client, endpoint, compute_test_config):
     """This test checks 1) web-service is online, 2) version of the web-service"""
-    service_address = compute_client.funcx_service_address
+    response = compute_client.web_client.get_version()
 
-    response = requests.get(f"{service_address}/version")
-
-    assert response.status_code == 200, (
+    assert response.http_status == 200, (
         "Request to version expected status_code=200, "
-        f"got {response.status_code} instead"
+        f"got {response.http_status} instead"
     )
 
-    service_version = response.json()
+    service_version = response.data["api"]
     api_min_version = compute_test_config.get("api_min_version")
     if api_min_version is not None:
         parsed_min = Version(api_min_version)


### PR DESCRIPTION
# Description

Our smoke tests are failing because existing SDK versions include the API version in their service address, but as of #1200, we specify the API version for each request. To support both scenarios in our smoke tests, we use the `WebClient.get_version()` method, which constructs the appropriate URL.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
