### PR TITLE
Pin click to <= 8.1.3 due to mypy issues with 8.1.4

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -21,7 +21,7 @@ REQUIRES = [
     # provides easy daemonization of the endpoint
     "python-daemon>=2,<3",
     # CLI parsing
-    "click>=8,<9",
+    "click<=8.1.3",
     # disallow use of 22.3.0; the whl package on some platforms causes ZMQ issues
     #
     # NOTE: 22.3.0 introduced a patched version of libzmq.so to the wheel packaging


### PR DESCRIPTION
# Description

This PR pins mypy to `<=8.1.3`
With mypy==8.1.4 we are seeing these errors in testing:

```
globus_compute_endpoint/cli.py:28: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
globus_compute_endpoint/cli.py:152: error: Argument 1 has incompatible type "Callable[[], Any]"; expected <nothing>  [arg-type]
globus_compute_endpoint/cli.py:244: error: Argument 1 has incompatible type "Callable[[bool], Any]"; expected <nothing>  [arg-type]
globus_compute_endpoint/cli.py:262: error: Argument 1 has incompatible type "Callable[[bool], None]"; expected <nothing>  [arg-type]
globus_compute_endpoint/cli.py:468: error: Argument 1 has incompatible type "Callable[[NamedArg(str, 'name'), NamedArg(bool, 'force')], Any]"; expected <nothing>  [arg-type]
```
Logs are here: https://github.com/funcx-faas/funcX/actions/runs/5478898485/jobs/9980000176

Refer to https://github.com/pallets/click/issues/2268 for details on typing changes

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.


- Code maintenance/cleanup
