### PR TITLE
Support for scaling strategies in GlobusComputeEngine 

### DIFF
--- a/changelog.d/20230710_144242_yadudoc1729_strategy_for_gce.rst
+++ b/changelog.d/20230710_144242_yadudoc1729_strategy_for_gce.rst
@@ -1,0 +1,54 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+* Auto-scaling support for ``GlobusComputeEngine``
+  Here is an example configuration in python:
+
+  ```
+  engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        heartbeat_period_s=1,
+        heartbeat_threshold=1,
+        provider=LocalProvider(
+            init_blocks=0,  # Start with 0 blocks
+            min_blocks=0,   # 0 minimum blocks
+            max_blocks=4,   # scale upto 4 blocks
+        ),
+        strategy=SimpleStrategy(
+            # Shut down blocks idle for more that 30s
+            max_idletime=30.0,
+        ),
+    )
+  ```
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -13,6 +13,7 @@ from globus_compute_endpoint.engines.base import (
     GlobusComputeEngineBase,
     ReportingThread,
 )
+from globus_compute_endpoint.strategies import SimpleStrategy
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         label: str = "GlobusComputeEngine",
         address: t.Optional[str] = None,
         heartbeat_period_s: float = 30.0,
+        strategy=SimpleStrategy(),
         **kwargs,
     ):
         self.address = address
@@ -34,9 +36,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             target=self.report_status, args=[], reporting_period=heartbeat_period_s
         )
         super().__init__(*args, heartbeat_period_s=heartbeat_period_s, **kwargs)
+        self.strategy = strategy
         self.executor = HighThroughputExecutor(  # type: ignore
             *args, address=address, **kwargs
         )
+        self.max_workers_per_node = 1
 
     def start(
         self,
@@ -57,6 +61,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             # a queue is passed in
             self.results_passthrough = results_passthrough
         self.executor.start()
+        self.strategy.start(self)
         self._status_report_thread.start()
 
     def _submit(
@@ -66,6 +71,59 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         **kwargs: t.Any,
     ) -> Future:
         return self.executor.submit(func, {}, *args, **kwargs)
+
+    @property
+    def provider(self):
+        return self.executor.provider
+
+    def get_outstanding_breakdown(self) -> t.List[t.Tuple[str, int, bool]]:
+        """
+
+        Returns
+        -------
+        List of tuples of the form (component, # of tasks on component, active?)
+        """
+        total_task_count = self.executor.outstanding
+        manager_info: t.List[t.Dict[str, t.Any]] = self.executor.connected_managers()
+        breakdown = [(m["manager"], m["tasks"], m["active"]) for m in manager_info]
+        total_count_managers = sum([m["tasks"] for m in manager_info])
+        task_count_interchange = total_task_count - total_count_managers
+        breakdown = [("interchange", task_count_interchange, True)] + breakdown
+        return breakdown
+
+    def get_total_tasks_outstanding(self):
+        """
+
+        Returns
+        -------
+        Returns a dict of type {str_task_type: count_tasks}
+
+        """
+        outstanding = self.get_outstanding_breakdown()
+        total = sum([component[1] for component in outstanding])
+        return {"RAW": total}
+
+    def provider_status(self):
+        status = []
+        if self.provider:
+            # ex.locks is a dict of block_id:job_id mappings
+            job_ids = self.executor.blocks.values()
+            status = self.provider.status(job_ids=job_ids)
+        return status
+
+    def get_total_live_workers(self) -> int:
+        manager_info = self.executor.connected_managers
+        worker_count = [mgr["worker_count"] for mgr in manager_info]
+        return worker_count
+
+    def scale_out(self, blocks: int):
+        logger.info(f"Scaling out {blocks} blocks")
+        return self.executor.scale_out(blocks=blocks)
+
+    def scale_in(self, blocks: int):
+        logger.info(f"Scaling in {blocks} blocks")
+        to_kill = list(self.executor.blocks.values())[:blocks]
+        return self.provider.cancel(to_kill)
 
     def get_status_report(self) -> EPStatusReport:
         """

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -113,7 +113,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         return status
 
     def get_total_live_workers(self) -> int:
-        manager_info = self.executor.connected_managers
+        manager_info: t.List[dict[str, t.Any]] = self.executor.connected_managers()
         worker_count = sum([mgr["worker_count"] for mgr in manager_info])
         return worker_count
 

--- a/compute_endpoint/globus_compute_endpoint/strategies/base.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/base.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import time
+import typing as t
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class BaseStrategy:
         self.callback = self.strategize
         self._handle = None
         self._event_count = 0
-        self._event_buffer = []
+        self._event_buffer: t.List[t.Any] = []
         self._wake_up_time = time.time() + 1
         self._kill_event = threading.Event()
         self._thread = threading.Thread(
@@ -113,7 +114,7 @@ class BaseStrategy:
             else:
                 print("Sleeping a bit more")
 
-    def notify(self, event_id):
+    def notify(self, event_id: t.Any):
         """Let the FlowControl system know that there is an event.
 
         This method is to be called from the Interchange to notify the flowcontrol

--- a/compute_endpoint/globus_compute_endpoint/strategies/base.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/base.py
@@ -71,6 +71,9 @@ class BaseStrategy:
          globus_compute_endpoint.executors.high_throughput.interchange.Interchange
             Interchange to bind the strategy to
         """
+        # This thread is created here to ensure a new thread is created whenever start
+        # is called. This is to avoid errors from tests reusing strategy objects which
+        # would attempt to restart stopped threads.
         self._thread = threading.Thread(
             target=self._wake_up_timer, args=(self._kill_event,), name="Base-Strategy"
         )

--- a/compute_endpoint/globus_compute_endpoint/strategies/base.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/base.py
@@ -39,7 +39,7 @@ class BaseStrategy:
     from a duplicate logger being added by the thread.
     """
 
-    def __init__(self, *args, threshold=20, interval=5):
+    def __init__(self, *args, threshold: int = 20, interval: float = 5.0):
         """Initialize the flowcontrol object.
 
         We start the timer thread here

--- a/compute_endpoint/globus_compute_endpoint/strategies/simple.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/simple.py
@@ -13,7 +13,13 @@ log = logging.getLogger(__name__)
 class SimpleStrategy(BaseStrategy):
     """Implements the simple strategy"""
 
-    def __init__(self, *args, threshold=20, interval=1, max_idletime=60):
+    def __init__(
+        self,
+        *args,
+        threshold: int = 20,
+        interval: float = 1.0,
+        max_idletime: float = 60.0,
+    ):
         """Initialize the flowcontrol object.
 
         We start the timer thread here
@@ -23,10 +29,10 @@ class SimpleStrategy(BaseStrategy):
         threshold:(int)
           Tasks after which the callback is triggered
 
-        interval (int)
+        interval (float)
           seconds after which timer expires
 
-        max_idletime: (int)
+        max_idletime: (float)
           maximum idle time(seconds) allowed for resources after which strategy will
           try to kill them.
           default: 60s

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -1,0 +1,66 @@
+import concurrent.futures
+import logging
+import multiprocessing
+import random
+import uuid
+
+import pytest
+from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_endpoint.strategies import SimpleStrategy
+from parsl.providers import LocalProvider
+from tests.utils import double
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def gc_engine_scaling(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        heartbeat_period_s=1,
+        heartbeat_threshold=1,
+        provider=LocalProvider(
+            init_blocks=0,
+            min_blocks=0,
+            max_blocks=1,
+        ),
+        strategy=SimpleStrategy(interval=0.1, max_idletime=0),
+    )
+    queue = multiprocessing.Queue()
+    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
+
+    yield engine
+    engine.shutdown()
+
+
+def test_engine_submit_init_0(gc_engine_scaling):
+    """Test engine.submit with multiple engines"""
+    engine = gc_engine_scaling
+    max_idletime = engine.strategy.max_idletime
+
+    # At the start there should be 0 managers
+    outstanding = gc_engine_scaling.get_outstanding_breakdown()
+    assert len(outstanding) == 1, "Expected only interchange"
+
+    # Run a function to trigger scale_out and confirm via breakdown
+    param = random.randint(1, 100)
+    future = engine._submit(double, param)
+    assert isinstance(future, concurrent.futures.Future)
+    assert future.result() == param * 2
+
+    outstanding = gc_engine_scaling.get_outstanding_breakdown()
+    assert len(outstanding) == 2, "Expected 1 manager + interchange"
+
+    # With 0 tasks and excess workers we should expect scale_down
+    # While scale_down might be triggered it appears to take 1s
+    # lowest heartbeat period to detect a manager going down
+    while True:
+        import time
+
+        managers = gc_engine_scaling.executor.connected_managers
+        if len(managers) == 0:
+            break
+        idle_time = managers[0]["idle_duration"]
+        assert idle_time <= max_idletime + 1, "Manager exceeded idletime"
+        time.sleep(0.1)

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -79,7 +79,7 @@ def test_engine_submit_init_0(gc_engine_scaling):
     while True:
         import time
 
-        managers = engine.executor.connected_managers
+        managers = engine.executor.connected_managers()
         if len(managers) == 0:
             break
         idle_time = managers[0]["idle_duration"]

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -69,7 +69,7 @@ def test_engine_submit(
     param = random.randint(1, 100)
     future = engine._submit(double, param)
     assert isinstance(future, concurrent.futures.Future)
-    assert future.result() == param * 2
+    assert future.result(timeout=1) == param * 2
 
 
 @pytest.mark.parametrize("engine_type", ["proc_pool", "thread_pool", "gc"])


### PR DESCRIPTION
# Description

This PR adds support for auto-scaling in `GlobusComputeEngine`.

* Each `GlobusComputeEngine` now starts with a strategy.
* `GlobusComputeEngine` now has these methods to determine task pressure and available capacity:
    * get_total_tasks_outstanding
    * get_outstanding_breakdown
    * provider_status
    * get_total_live_workers
* `GlobusComputeEngine` now has these methods to provision and drop resources: 
    * scale_out
    * scale_in  
    
Fixes # (issue)

[sc-23907]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
