### PR TITLE
Explicitly define engine type in example configs

### DIFF
--- a/docs/configs/delta.yaml
+++ b/docs/configs/delta.yaml
@@ -1,5 +1,6 @@
 display_name: NCSA Delta 2 CPU
 engine:
+    type: HighThroughputEngine
     max_workers_per_node: 2
     worker_debug: False
 

--- a/docs/configs/stampede2.yaml
+++ b/docs/configs/stampede2.yaml
@@ -1,6 +1,7 @@
 display_name: Stampede2.TACC.batch
 
 engine:
+  type: HighThroughputEngine
   address:
     type: address_by_interface
     ifname: em3


### PR DESCRIPTION
# Description

A couple example configs do not explicitly define an engine type, thus are using the default `HighThroughputEngine` type. In order to match our other example configs and increase clarity, I've added the explicit definition.

## Type of change

- Documentation update
