### PR TITLE
Update preview domain from globuscs.info to globus.org

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -16,10 +16,12 @@ def get_web_service_url(envname: str | None) -> str:
     env = envname or _get_envname()
     urls = {
         "production": "https://compute.api.globus.org",
+        # Special case for preview unlike the other globuscs.info envs
+        "preview": "https://compute.api.preview.globus.org",
         "dev": "https://api.dev.funcx.org",
         "local": "http://localhost:5000",
     }
-    for test_env in ["sandbox", "test", "integration", "staging", "preview"]:
+    for test_env in ["sandbox", "test", "integration", "staging"]:
         urls[test_env] = f"https://compute.api.{test_env}.globuscs.info"
 
     return urls.get(env, urls["production"])

--- a/compute_sdk/tests/unit/test_environment_lookups.py
+++ b/compute_sdk/tests/unit/test_environment_lookups.py
@@ -18,7 +18,7 @@ def test_web_service_url(monkeypatch):
         "bad-env-name": "https://compute.api.globus.org",
         "sandbox": "https://compute.api.sandbox.globuscs.info",
         "test": "https://compute.api.test.globuscs.info",
-        "preview": "https://compute.api.preview.globuscs.info",
+        "preview": "https://compute.api.preview.globus.org",
     }
 
     for env, url in env_url_map.items():


### PR DESCRIPTION
# Description

Preview environment domain is actually on globus.org ie. [app.preview.globus.org](https://app.preview.globus.org/compute), not globuscs.info like sandbox, integration etc.  Make correction and update test.

## Type of change

- Bug fix (non-breaking change that fixes an issue)