### PR TITLE
Make the provider config field optional

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -77,7 +77,7 @@ class ProviderModel(BaseConfigModel):
 
 class EngineModel(BaseConfigModel):
     type: str = "HighThroughputEngine"
-    provider: ProviderModel
+    provider: t.Optional[ProviderModel]
     strategy: t.Optional[StrategyModel]
     address: t.Optional[t.Union[str, AddressModel]]
 


### PR DESCRIPTION
# Description

The `ThreadPoolEngine` does not accept a provider argument, so the related config field must be made optional.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
