### PR TITLE
Reimplement ProcessPoolEngine

### DIFF
--- a/changelog.d/20230716_122638_30907815+rjmello_process_pool_engine.rst
+++ b/changelog.d/20230716_122638_30907815+rjmello_process_pool_engine.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Reimplemented ``ProcessPoolEngine``, which wraps ``concurrent.futures.ProcessPoolExecutor``,
+  for concurrent local execution. We temporarily removed the former implementation because of a
+  critical bug.

--- a/compute_endpoint/globus_compute_endpoint/engines/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/__init__.py
@@ -1,9 +1,11 @@
 from .globus_compute import GlobusComputeEngine
 from .high_throughput.engine import HighThroughputEngine
+from .process_pool import ProcessPoolEngine
 from .thread_pool import ThreadPoolEngine
 
 __all__ = (
     "GlobusComputeEngine",
+    "ProcessPoolEngine",
     "ThreadPoolEngine",
     "HighThroughputEngine",
 )

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import queue
+import typing as t
+import uuid
+from concurrent.futures import Future
+from concurrent.futures import ProcessPoolExecutor as NativeExecutor
+
+import psutil
+from globus_compute_common.messagepack.message_types import (
+    EPStatusReport,
+    TaskTransition,
+)
+from globus_compute_endpoint.engines.base import (
+    GlobusComputeEngineBase,
+    ReportingThread,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessPoolEngine(GlobusComputeEngineBase):
+    def __init__(
+        self,
+        *args,
+        label: str = "ProcessPoolEngine",
+        heartbeat_period_s: float = 30.0,
+        **kwargs,
+    ):
+        self.label = label
+        self.executor: t.Optional[NativeExecutor] = None
+        self._executor_args = args
+        self._executor_kwargs = kwargs
+        self._status_report_thread = ReportingThread(
+            target=self.report_status, args=[], reporting_period=heartbeat_period_s
+        )
+        super().__init__(*args, heartbeat_period_s=heartbeat_period_s, **kwargs)
+
+    def start(
+        self,
+        *args,
+        endpoint_id: t.Optional[uuid.UUID] = None,
+        results_passthrough: t.Optional[queue.Queue] = None,
+        **kwargs,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        endpoint_id: Endpoint UUID
+        results_passthrough: Queue to which packed results will be posted
+        Returns
+        -------
+        """
+        if self.executor is None:
+            # We are instantiating the executor here, rather than in the constructor,
+            # to ensure the executor starts within the daemon context. Doing so avoids
+            # having the daemon close existing pipe file descriptors required for
+            # inter-process communication.
+            self.executor = NativeExecutor(
+                *self._executor_args, **self._executor_kwargs
+            )
+
+        assert endpoint_id, "ProcessPoolExecutor requires kwarg:endpoint_id at start"
+        self.endpoint_id = endpoint_id
+        if results_passthrough:
+            self.results_passthrough = results_passthrough
+        assert self.results_passthrough
+
+        self._status_report_thread.start()
+
+    def get_status_report(self) -> EPStatusReport:
+        assert self.executor, "The engine has not been started"
+        executor_status: t.Dict[str, t.Any] = {
+            "task_id": -2,
+            "info": {
+                "total_cores": multiprocessing.cpu_count(),
+                "total_mem": round(psutil.virtual_memory().available / (2**30), 1),
+                "total_core_hrs": 0,
+                "total_workers": self.executor._max_workers,  # type: ignore
+                "pending_tasks": 0,
+                "outstanding_tasks": 0,
+                "scaling_enabled": False,
+                "max_blocks": 1,
+                "min_blocks": 1,
+                "max_workers_per_node": self.executor._max_workers,  # type: ignore
+                "nodes_per_block": 1,
+                "heartbeat_period": self._heartbeat_period_s,
+            },
+        }
+        task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}
+
+        return EPStatusReport(
+            endpoint_id=self.endpoint_id,
+            global_state=executor_status,
+            task_statuses=task_status_deltas,
+        )
+
+    def _submit(
+        self,
+        func: t.Callable,
+        *args: t.Any,
+        **kwargs: t.Any,
+    ) -> Future:
+        """We pass all params except the function to executor.submit()"""
+        assert self.executor, "The engine has not been started"
+        logger.warning("Got task")
+        return self.executor.submit(func, *args, **kwargs)
+
+    def status_polling_interval(self) -> int:
+        return 30
+
+    def shutdown(self):
+        self._status_report_thread.stop()
+        if self.executor:
+            self.executor.shutdown()

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -1,10 +1,8 @@
 import concurrent.futures
 import logging
-import multiprocessing
 import random
 import time
 import uuid
-from queue import Queue
 
 import pytest
 from globus_compute_common import messagepack
@@ -20,42 +18,6 @@ from parsl.executors.high_throughput.interchange import ManagerLost
 from tests.utils import double, ez_pack_function, slow_double
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def proc_pool_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = ProcessPoolEngine(heartbeat_period_s=1, max_workers=2)
-    queue = multiprocessing.Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
-
-
-@pytest.fixture
-def thread_pool_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = ThreadPoolEngine(heartbeat_period_s=1, max_workers=2)
-
-    queue = Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
-
-
-@pytest.fixture
-def gc_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = GlobusComputeEngine(
-        address="127.0.0.1", heartbeat_period_s=1, heartbeat_threshold=1
-    )
-    queue = multiprocessing.Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
 
 
 def test_result_message_packing():

--- a/compute_endpoint/tests/unit/test_status_reporting.py
+++ b/compute_endpoint/tests/unit/test_status_reporting.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import uuid
+from queue import Queue
 
 import pytest
 from globus_compute_common import messagepack
@@ -10,6 +11,33 @@ from globus_compute_endpoint import engines
 logger = logging.getLogger(__name__)
 
 HEARTBEAT_PERIOD = 0.1
+
+
+@pytest.fixture
+def proc_pool_engine(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = engines.ProcessPoolEngine(
+        max_workers=2, heartbeat_period_s=HEARTBEAT_PERIOD
+    )
+    queue = multiprocessing.Queue()
+    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
+
+    yield engine
+    engine.shutdown()
+
+
+@pytest.fixture
+def thread_pool_engine(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = engines.ThreadPoolEngine(
+        max_workers=2, heartbeat_period_s=HEARTBEAT_PERIOD
+    )
+
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
+
+    yield engine
+    engine.shutdown()
 
 
 @pytest.fixture
@@ -27,8 +55,19 @@ def gc_engine(tmp_path):
     engine.shutdown()
 
 
-def test_status_reporting(gc_engine):
-    engine = gc_engine
+@pytest.mark.parametrize("engine_type", ["proc_pool", "thread_pool", "gc"])
+def test_status_reporting(
+    proc_pool_engine: engines.ProcessPoolEngine,
+    thread_pool_engine: engines.ThreadPoolEngine,
+    gc_engine: engines.GlobusComputeEngine,
+    engine_type: str,
+):
+    if engine_type == "proc_pool":
+        engine = proc_pool_engine
+    elif engine_type == "thread_pool":
+        engine = thread_pool_engine
+    else:
+        engine = gc_engine
 
     report = engine.get_status_report()
     assert isinstance(report, EPStatusReport)

--- a/compute_endpoint/tests/unit/test_status_reporting.py
+++ b/compute_endpoint/tests/unit/test_status_reporting.py
@@ -1,7 +1,4 @@
 import logging
-import multiprocessing
-import uuid
-from queue import Queue
 
 import pytest
 from globus_compute_common import messagepack
@@ -10,56 +7,13 @@ from globus_compute_endpoint import engines
 
 logger = logging.getLogger(__name__)
 
-HEARTBEAT_PERIOD = 0.1
-
-
-@pytest.fixture
-def proc_pool_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = engines.ProcessPoolEngine(
-        max_workers=2, heartbeat_period_s=HEARTBEAT_PERIOD
-    )
-    queue = multiprocessing.Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
-
-
-@pytest.fixture
-def thread_pool_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = engines.ThreadPoolEngine(
-        max_workers=2, heartbeat_period_s=HEARTBEAT_PERIOD
-    )
-
-    queue = Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
-
-
-@pytest.fixture
-def gc_engine(tmp_path):
-    ep_id = uuid.uuid4()
-    engine = engines.GlobusComputeEngine(
-        address="127.0.0.1",
-        heartbeat_period_s=HEARTBEAT_PERIOD,
-        heartbeat_threshold=1,
-    )
-    queue = multiprocessing.Queue()
-    engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
-
-    yield engine
-    engine.shutdown()
-
 
 @pytest.mark.parametrize("engine_type", ["proc_pool", "thread_pool", "gc"])
 def test_status_reporting(
     proc_pool_engine: engines.ProcessPoolEngine,
     thread_pool_engine: engines.ThreadPoolEngine,
     gc_engine: engines.GlobusComputeEngine,
+    engine_heartbeat: float,
     engine_type: str,
 ):
     if engine_type == "proc_pool":
@@ -74,7 +28,7 @@ def test_status_reporting(
 
     results_q = engine.results_passthrough
 
-    assert engine._status_report_thread.reporting_period == HEARTBEAT_PERIOD
+    assert engine._status_report_thread.reporting_period == engine_heartbeat
 
     # Flush queue to start
     while not results_q.empty():


### PR DESCRIPTION
# Description

Reimplemented ``ProcessPoolEngine`` for concurrent local execution.

The root issue with the former implementation was that we called the `concurrent.futures.ProcessPoolExecutor` constructor, which creates pipes for inter-process communication, in the `ProcessPoolEngine` constructor, which we call before we enter the daemon context. By default, the daemon process will close all existing file descriptors and break the existing pipes.

To fix this, we can either specify file descriptors for the daemon process to preserve or, more simply, ensure that we call the `ProcessPoolExecutor` constructor within the daemon context. I've implemented the latter by instantiating the `ProcessPoolExecutor` object in the `ProcessPoolEngine.start()` method.

[sc-25115]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
