### PR TITLE
Add Client method to delete a function

### DIFF
--- a/changelog.d/20230718_115634_30907815+rjmello_del_func.rst
+++ b/changelog.d/20230718_115634_30907815+rjmello_del_func.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added support for deleting functions via the ``Client.delete_function`` method.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -826,3 +826,19 @@ class Client:
             The response of the request
         """
         return self.web_client.delete_endpoint(endpoint_id)
+
+    @requires_login
+    def delete_function(self, function_id: str):
+        """Delete a function
+
+        Parameters
+        ----------
+        function_id : str
+            The UUID of the function
+
+        Returns
+        -------
+        json
+            The response of the request
+        """
+        return self.web_client.delete_function(function_id)

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -231,3 +231,6 @@ class WebClient(globus_sdk.BaseClient):
 
     def delete_endpoint(self, endpoint_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
         return self.delete(f"/v2/endpoints/{endpoint_id}")
+
+    def delete_function(self, function_id: ID_PARAM_T) -> globus_sdk.GlobusHTTPResponse:
+        return self.delete(f"/v2/functions/{function_id}")

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -317,3 +317,13 @@ def test_container_build_status_failure(mocker, login_manager):
         gcc.get_container_build_status("123-434")
 
     assert type(excinfo.value) == SystemError
+
+
+def test_delete_function():
+    func_uuid_str = str(uuid.uuid4())
+    gcc = gc.Client(do_version_check=False, login_manager=mock.Mock())
+    gcc.web_client = mock.MagicMock()
+
+    gcc.delete_function(func_uuid_str)
+
+    assert gcc.web_client.delete_function.called_with(func_uuid_str)

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -1,4 +1,6 @@
 import json
+import typing as t
+import uuid
 
 import pytest
 import responses
@@ -109,3 +111,17 @@ def test_multi_tenant_post(client, multi_tenant):
         assert req_body["multi_tenant"] == multi_tenant
     else:
         assert "multi_tenant" not in req_body
+
+
+def test_delete_function(client: WebClient, randomstring: t.Callable):
+    func_uuid_str = str(uuid.uuid4())
+    expected_response = randomstring()
+    responses.add(
+        responses.DELETE,
+        f"https://api.funcx/v2/functions/{func_uuid_str}",
+        json={"some_key": expected_response},
+    )
+
+    res = client.delete_function(func_uuid_str)
+
+    assert res["some_key"] == expected_response


### PR DESCRIPTION
# Description

Added support for deleting functions via the ``Client.delete_function`` method.

[sc-25810]

## Type of change

- New feature (non-breaking change that adds functionality)
