### PR TITLE
Fix issue of using the string 'None' instead of None in default displ…

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
@@ -1,4 +1,4 @@
-display_name: None
+display_name: null
 engine:
   type: HighThroughputEngine
   provider:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -139,6 +139,13 @@ def load_config_yaml(config_str: str) -> Config:
     except Exception as err:
         raise ClickException(str(err)) from err
 
+    # Special case of 'display_name: None' converting to the empty
+    #   None instead of the string "None" which was the default
+    #   display_name since we started generating yaml configs from
+    #   Jun til Jul 2023.
+    # This has the side effect of disallowing the display name 'None'
+    if config.display_name == "None":
+        config.display_name = None
     return config
 
 


### PR DESCRIPTION
# Description

Fixes [#23825](https://app.shortcut.com/funcx/story/25825/default-yaml-config-should-have-null-display-name-instead-of-the-string-none) , text copied below:

If one configures a new endpoint, there is a
```
display_name: None
```
in the default `config.yaml`.  

However, no-value is represented by 'null' instead of 'None' in YAML, so all endpoints since the YAML conversion are named the string `None` instead of defaulting to the endpoint name itself (for example, in search or the webapp).  

Changing the default to

```
display_name: null
```

fixes the issue for new endpoints, but EPs created during the last few weeks would continue to be named 'None'.  This PR special cases/disallows the EP name 'None' and converts them to empty-None values.  'null' is left in the config as it highlights that the display_name can be set/changed.  

(Converting on the fly is easier than reformatting previously generated config.yaml files)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- No changelog as it was a temporarily introduced issue
