### PR TITLE
Update interface used in Perlmutter example config

### DIFF
--- a/docs/configs/perlmutter.yaml
+++ b/docs/configs/perlmutter.yaml
@@ -4,7 +4,7 @@ engine:
 
     address:
         type: address_by_interface
-        ifname: nmn0
+        ifname: nmnb0
 
     provider:
         type: SlurmProvider


### PR DESCRIPTION
# Description

`nmn0` is now configured as a member of a bond interface named `nmnb0`. See [Slack thread](https://funcx.slack.com/archives/C017637NZFA/p1689884026927839?thread_ts=1689879908.266379&cid=C017637NZFA) for reference.


## Type of change

- Documentation update