### PR TITLE
Add console message for locked/conflict messages

### DIFF
--- a/changelog.d/20230724_145257_LeiGlobus_registration_blocked_msg_sc_25245.rst
+++ b/changelog.d/20230724_145257_LeiGlobus_registration_blocked_msg_sc_25245.rst
@@ -1,0 +1,8 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+Bug Fixes
+^^^^^^^^^
+
+- Previously, starting an endpoint when it is already active or is currently locked will exit silently when ``globus-compute-endpoint start`` is run, with the only information available as a log line in endpoint.log.  Now, if start fails, a console message will display the reason on the command line.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -257,7 +257,12 @@ class Endpoint:
         # potentially running with the existing pidfile
         if pid_check["exists"]:
             if pid_check["active"]:
-                log.info("Endpoint is already active")
+                endpoint_name = endpoint_dir.name
+                if endpoint_config.display_name:
+                    endpoint_name = endpoint_config.display_name
+                active_msg = f"Endpoint '{endpoint_name}' is already active"
+                print(active_msg)
+                log.info(active_msg)
                 sys.exit(-1)
             else:
                 log.info(
@@ -322,7 +327,9 @@ class Endpoint:
             except GlobusAPIError as e:
                 if e.http_status in (409, 410, 423):
                     # CONFLICT, GONE or LOCKED
-                    log.warning(f"Endpoint registration blocked.  [{e.text}]")
+                    blocked_msg = f"Endpoint registration blocked.  [{e.text}]"
+                    print(blocked_msg)
+                    log.warning(blocked_msg)
                     exit(os.EX_UNAVAILABLE)
                 raise
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -83,7 +83,9 @@ class EndpointManager:
         except GlobusAPIError as e:
             if e.http_status == 409 or e.http_status == 423:
                 # RESOURCE_CONFLICT or RESOURCE_LOCKED
-                log.warning(f"Endpoint registration blocked.  [{e.text}]")
+                blocked_msg = f"Endpoint registration blocked.  [{e.text}]"
+                print(blocked_msg)
+                log.warning(blocked_msg)
                 exit(os.EX_UNAVAILABLE)
             raise
         except NetworkError as e:


### PR DESCRIPTION
# Description

Add console print message when trying to register an endpoint, instead of just log messages in endpoint.log.

ie. Previously running globus-compute-endpoint start will just exit silently if the endpoint is locked or already active.  Now the console message is added (and in the already active case, no log message is emitted as it's a no-op)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
