### PR TITLE
Add bookend sentinels to log

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -377,14 +377,14 @@ class Endpoint:
         if die_with_parent:
             parent_pid = os.getppid()
 
-        log.info("Launching endpoint daemon process")
+        log.debug("Launching endpoint daemon process")
 
         # NOTE
         # It's important that this log is emitted before we enter the daemon context
         # because daemonization closes down everything, a log message inside the
         # context won't write the currently configured loggers
         logfile = endpoint_dir / "endpoint.log"
-        log.info(
+        log.debug(
             "Reconfiguring logging for daemonization. logfile: %s , debug: %s",
             logfile,
             self.debug,
@@ -438,6 +438,8 @@ class Endpoint:
         result_store: ResultStore,
         parent_pid: int,
     ):
+        log.info(f"\n\n========== Endpoint begins: {endpoint_uuid}")
+
         interchange = EndpointInterchange(
             config=endpoint_config,
             reg_info=reg_info,
@@ -450,7 +452,7 @@ class Endpoint:
 
         interchange.start()
 
-        log.critical("Interchange terminated.")
+        log.info(f"\n---------- Endpoint shutdown: {endpoint_uuid}\n")
 
     @staticmethod
     def stop_endpoint(

--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -203,7 +203,7 @@ class EndpointInterchange:
         self._quiesce_event.set()
 
     def cleanup(self):
-        self.executor.shutdown()
+        self.executor.shutdown(block=True)
 
     def handle_sigterm(self, sig_num, curr_stack_frame):
         log.warning("Received SIGTERM, setting termination flag.")

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/interchange.py
@@ -676,7 +676,7 @@ class Interchange:
         self._task_puller_thread.join()
         self._command_thread.join()
         self._status_report_thread.join()
-        log.info("HighThroughput Interchange stopped")
+        log.debug("HighThroughput Interchange stopped")
 
     def start(self, poll_period: int | None = None) -> None:
         """Start the Interchange


### PR DESCRIPTION
Add an aid for quickly observing the end of one run and beginning of another in the endpoint logs:

    <blank line>
    ========== Endpoint begins: 48ceb6a0-876b-3d31-6084-49dd7edb89d7
    <timestamp> [...] Initializing EndpointInterchange process with Endpoint ID: 48ceb6a0-876b-3d31-6084-49dd7edb89d7
    ... Lots of log lines
    ... Lots of log lines
    ... Lots of log lines
    ---------- Endpoint shutdown: 48ceb6a0-876b-3d31-6084-49dd7edb89d7
    <blank line>

## Type of change

- New feature (non-breaking change that adds functionality)