### PR TITLE
Skip test until published SDK catches up

### DIFF
--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -34,7 +34,7 @@ def ohai():
     return "ohai"
 
 
-@pytest.mark.skipif(sdk_version.release < (1, 0, 5), reason="batch.add iface updated")
+@pytest.mark.skipif(sdk_version.release < (2, 2, 4), reason="batch.add iface updated")
 def test_batch(compute_client, endpoint):
     """Test batch submission and get_batch_result"""
 


### PR DESCRIPTION
# Description

Address currently broken hourly smoke tests.  The borked test is because we just updated the `.add()` method of the Batch class.  Tests pass locally with the yet-unpublished SDK -- will be fixed once we publish.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
