### PR TITLE
Use Python to get path of binary for interpreter

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -57,6 +57,10 @@ def get_python_version():
     click.echo(f"Python version {sys.version}\n")
 
 
+def which_python():
+    click.echo(f"{sys.executable}\n")
+
+
 def _run_command(cmd: str):
     cmd_list = shlex.split(cmd)
     arg0 = cmd_list[0]
@@ -82,7 +86,7 @@ def run_self_diagnostic(log_bytes: int | None = None):
         "uname -a",
         cat("/etc/os-release"),
         "whoami",
-        "which python",
+        which_python,
         get_python_version,
         "pip freeze",
         test_conn("compute.api.globus.org", 443),


### PR DESCRIPTION
# Description

Using the `which` command in bash is less robust because of terminal differences, custom binary names, etc.

## Type of change

- Code maintenance/cleanup
