### PR TITLE
Update API route to v3 submit

### DIFF
--- a/changelog.d/20230718_143645_chris_batchv3.rst
+++ b/changelog.d/20230718_143645_chris_batchv3.rst
@@ -21,10 +21,15 @@ Removed
 Changed
 ^^^^^^^
 
-- Batches of tasks can now only be associated with a single endpoint. (Previously, tasks
-  within a batch could be sent to heterogeneous endpoints.)
+- Following the updated route and schema of the ``submit`` route
+  (``v3/endpoint/ENDPOINT_UUID/submit``), tasks in a batch are now associated
+  with a single endpoint and the endpoint is selected via the route at
+  submission time.  (Previously, tasks within a batch could be sent to
+  heterogeneous endpoints.)
 
   - The signature of ``Client.create_batch`` has been adjusted to match.
+
+  - The signature of ``WebClient.submit`` has been adjusted to match
 
 - The return type of ``Client.batch_run`` has been updated to reflect the schema returned
   by the ``v3/submit`` route of the Compute API.

--- a/compute_sdk/globus_compute_sdk/sdk/batch.py
+++ b/compute_sdk/globus_compute_sdk/sdk/batch.py
@@ -14,21 +14,18 @@ class Batch:
 
     def __init__(
         self,
-        endpoint_id: UUID_LIKE_T,
         task_group_id: UUID_LIKE_T | None,
         request_queue=False,
         serializer: ComputeSerializer | None = None,
     ):
         """
         :param task_group_id: UUID of task group to which to submit the batch
-        :param endpoint_id: UUID of endpoint where tasks should be executed
         :param request_queue: Whether to request a result queue from the web service;
             typically only used by the Executor
         :param serialization_strategy: The strategy to use when serializing task
             arguments
         """
         self.task_group_id = task_group_id
-        self.endpoint_id = endpoint_id
         self.tasks: dict[str, list[str]] = defaultdict(list)
         self._serde = serializer or _default_serde
         self.request_queue = request_queue
@@ -74,7 +71,6 @@ class Batch:
         :returns: a dictionary suitable for JSONification for POSTing to the web service
         """
         data = {
-            "endpoint_id": str(self.endpoint_id),
             "create_queue": self.request_queue,
             "tasks": dict(self.tasks),
         }

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -313,15 +313,14 @@ class Client:
         task_id : str
         UUID string that identifies the task
         """
-        batch = self.create_batch(endpoint_id)
+        batch = self.create_batch()
         batch.add(function_id, args, kwargs)
-        r = self.batch_run(batch)
+        r = self.batch_run(endpoint_id, batch)
 
         return r["tasks"][function_id][0]
 
     def create_batch(
         self,
-        endpoint_id: UUID_LIKE_T,
         task_group_id: UUID_LIKE_T | None = None,
         create_websocket_queue: bool = False,
     ) -> Batch:
@@ -349,17 +348,19 @@ class Client:
         Batch instance
         """
         return Batch(
-            endpoint_id,
             task_group_id,
             create_websocket_queue,
             serializer=self.fx_serializer,
         )
 
     @requires_login
-    def batch_run(self, batch: Batch) -> dict[str, str | list[str]]:
+    def batch_run(
+        self, endpoint_id: UUID_LIKE_T, batch: Batch
+    ) -> dict[str, str | list[str]]:
         """
         Initiate a batch of tasks to Globus Compute
 
+        :param endpoint_id: The endpoint identifier to which to send the batch
         :param batch: a Batch object
 
         Returns
@@ -375,7 +376,7 @@ class Client:
             raise ValueError("No tasks specified for batch run")
 
         # Send the data to Globus Compute
-        return self.web_client.submit(batch.prepare()).data
+        return self.web_client.submit(endpoint_id, batch.prepare()).data
 
     @requires_login
     def register_endpoint(

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -709,7 +709,7 @@ class Executor(concurrent.futures.Executor):
         :param tasks: a list of tasks to submit upstream in a batch.
         """
         batch = self.funcx_client.create_batch(
-            endpoint_uuid, self.task_group_id, create_websocket_queue=True
+            self.task_group_id, create_websocket_queue=True
         )
         submitted_futs_by_fn: t.DefaultDict[str, list[ComputeFuture]] = defaultdict(
             list
@@ -721,7 +721,7 @@ class Executor(concurrent.futures.Executor):
             log.debug("Added task to Globus Compute batch: %s", task)
 
         try:
-            batch_response = self.funcx_client.batch_run(batch)
+            batch_response = self.funcx_client.batch_run(endpoint_uuid, batch)
         except Exception as e:
             log.exception(f"Error submitting {len(tasks)} tasks to Globus Compute")
             for fut_list in submitted_futs_by_fn.values():

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -144,8 +144,10 @@ class WebClient(globus_sdk.BaseClient):
             app_name += f"/{value}"
         globus_sdk.BaseClient.app_name.fset(self, app_name)
 
-    def submit(self, batch: t.Dict[str, t.Any]) -> globus_sdk.GlobusHTTPResponse:
-        return self.post("/v3/submit", data=batch)
+    def submit(
+        self, endpoint_id: UUID_LIKE_T, batch: t.Dict[str, t.Any]
+    ) -> globus_sdk.GlobusHTTPResponse:
+        return self.post(f"/v3/endpoints/{endpoint_id}/submit", data=batch)
 
     def register_endpoint(
         self,

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -535,7 +535,7 @@ def test_reload_handles_deseralization_error_gracefully(gc_executor):
 
 
 @pytest.mark.parametrize("batch_size", tuple(range(1, 11)))
-def test_task_submitter_respects_batch_size(gc_executor, batch_size: int, mocker):
+def test_task_submitter_respects_batch_size(gc_executor, batch_size: int):
     gcc, gce = gc_executor
 
     # make a new MagicMock every time create_batch is called
@@ -556,7 +556,7 @@ def test_task_submitter_respects_batch_size(gc_executor, batch_size: int, mocker
 
     assert gcc.batch_run.call_count >= num_batches
     for args, _kwargs in gcc.batch_run.call_args_list:
-        batch, *_ = args
+        *_, batch = args
         assert 0 < batch.add.call_count <= batch_size
 
 


### PR DESCRIPTION
The API route has moved to encompass the endpoint uuid in the path.  Update the SDK to match the updated endpoint, and surrounding semantics.  (For example, the Batch API.)

[sc-26022]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup
