### PR TITLE
Enforce allowed_functions locally on endpoint as redundancy to web_service checking

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -72,7 +72,7 @@ def test_invalid_task_received(mocker, endpoint_uuid):
     mocker.patch(f"{_MOCK_BASE}ResultQueuePublisher", return_value=mock_results)
     mocker.patch(f"{_MOCK_BASE}convert_to_internaltask", side_effect=Exception("BLAR"))
     task = Task(task_id=uuid.uuid4(), task_buffer="")
-    ei.pending_task_queue.put(pack(task))
+    ei.pending_task_queue.put([{}, pack(task)])
     t = threading.Thread(target=ei._main_loop, daemon=True)
     t.start()
 

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_rabbit_e2e.py
@@ -20,14 +20,14 @@ def test_simple_roundtrip(
 
     message = f"Hello test_simple_roundtrip: {randomstring()}".encode()
     task_pub.publish(message)
-    task_message = task_q.get(timeout=2)
+    _, task_message = task_q.get(timeout=2)
     assert message == task_message
 
     result_pub.publish(task_message)
-    result_message = result_q.get(timeout=2)
+    _, result_message = result_q.get(timeout=2)
 
     task_sub.quiesce_event.set()
     result_sub.kill_event.set()
 
-    expected = (result_pub.queue_info["test_routing_key"], message)
+    _, expected = (result_pub.queue_info["test_routing_key"], message)
     assert result_message == expected

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
@@ -26,7 +26,7 @@ def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
     tasks_out = multiprocessing.Queue()
     start_task_q_subscriber(queue=tasks_out)
     for i in range(count):
-        message = tasks_out.get()
+        _, message = tasks_out.get()
         assert messages[i] == message
 
 
@@ -48,7 +48,7 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
     proc = start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
     logging.warning("Proc started")
     for i in range(10):
-        message = tasks_out.get()
+        _, message = tasks_out.get()
         assert messages[i] == message
 
     # Terminate the connection
@@ -73,7 +73,7 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
     logging.warning("Replacement proc started")
     for i in range(10):
         logging.warning("getting message")
-        message = tasks_out.get()
+        _, message = tasks_out.get()
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
@@ -103,7 +103,7 @@ def test_exclusive_subscriber(start_task_q_publisher, start_task_q_subscriber):
 
     # Confirm that the first subscriber received all the messages
     for i in range(10):
-        message = tasks_out_1.get(timeout=1)
+        _, message = tasks_out_1.get(timeout=1)
         logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
@@ -123,7 +123,7 @@ def test_perf_combined_pub_sub_latency(start_task_q_publisher, start_task_q_subs
         b_message = f"Hello World! {i}".encode()
         start_t = time.time()
         task_q_pub.publish(b_message)
-        x = tasks_out.get()
+        _, x = tasks_out.get()
         delta = time.time() - start_t
         latency.append(delta)
         assert b_message == x


### PR DESCRIPTION
(Redo of previous PR for more clarity)

As per https://app.shortcut.com/funcx/story/24211/allow-list-functions-by-uuid-in-endpoint

Add checking locally on endpoint for allowed functions.  This involves adding a check for the function_id in the RMQ properties.headers which was recently added.

See [PR on service side](https://github.com/globusonline/funcx-services/pull/388).

TL;DR the config.yaml should include a section like the below with a list. 

```yaml
    display_name: ...
    allowed_functions:
         - 94c7ce20-7a5a-4eb3-ac07-6fc0aabcd50c
         - aab66753-4b02-4162-a9d3-47374dabcdc4
    executors:
   ...
```