### PR TITLE
Fix missing channel.script_dir 

### DIFF
--- a/changelog.d/20230802_150602_yadudoc1729_fix_missing_script_dir.rst
+++ b/changelog.d/20230802_150602_yadudoc1729_fix_missing_script_dir.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+Bug Fixes
+^^^^^^^^^
+
+- Fixes a bug where the `globus_compute_endpoint.engines.GlobusComputeEngine` sets
+  the stdout and stderr capture filepaths incorrectly on the Providers, causing batch
+  jobs to fail.
+
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Changed
+.. ^^^^^^^
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -54,7 +54,14 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
         self.run_dir = os.path.join(os.getcwd(), run_dir)
         self.endpoint_id = endpoint_id
-        self.executor.provider.script_dir = os.path.join(self.run_dir, "submit_scripts")
+        script_dir = os.path.join(self.run_dir, "submit_scripts")
+        self.executor.provider.script_dir = script_dir
+        if (
+            self.executor.provider.channel
+            and not self.executor.provider.channel.script_dir
+        ):
+            self.executor.provider.channel.script_dir = script_dir
+
         os.makedirs(self.executor.provider.script_dir, exist_ok=True)
         if results_passthrough:
             # Only update the default queue in GCExecutorBase if


### PR DESCRIPTION
# Description

This PR sets the `provider.channel.script_dir` attribute at `Engine.start(...)` if that option is not supplied.
Without this option, the script paths were getting messed up when cast to str:

```
 - Before -

#SBATCH --output=None/parsl.HighThroughputExecutor.block-0.XXXXXXXX.submit.stdout

-  After -
#SBATCH --output=/home1/02551/yadunand/.globus_compute/gce_batch/submit_scripts/parsl.HighThroughputExecutor.block-0.1690574273.29589.submit.stdout
```

This fix was tested on Frontera. Ideally we'd have confirmation from Polaris (maybe @ryanchard can help), but ALCF machines are down now.

Fixes # (issue)

[sc-26051]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
