### PR TITLE
Remove obsolete recommendation to run  endpoint stop twice

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -116,7 +116,6 @@ can be started cleanly again.
 
 .. note:: If the ENDPOINT_NAME is not specified, the default endpoint is stopped.
 
-.. warning:: Run the ``globus-compute-endpoint stop`` command **twice** to ensure that the endpoint is shutdown.
 
 Listing Endpoints
 -----------------


### PR DESCRIPTION
# Description

Our docs currently recommend running `globus-compute-endpoint stop` **twice**. This recommendation is obsolete.


Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
