### PR TITLE
Address race-condition w/ Executor task submission

### DIFF
--- a/changelog.d/20230731_100321_kevin_avoid_possible_tg_race_condition.rst
+++ b/changelog.d/20230731_100321_kevin_avoid_possible_tg_race_condition.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- For those who use multiple task groups, address race-condition where tasks
+  could be mis-associated.
+


### PR DESCRIPTION
Prior to this commit, tasks were not associated with a taskgroup.  In the case that a user wanted to switch task groups mid-run this created a race condition:

```python
with Executor(...) as ex:
  ex.task_group_id = "some-task-group-id"
  ex.submit(some_func_01)
  ex.task_group_id = "some-other-task-group-id"
  ex.submit(some_func_02)
```

Until this commit, `.submit()` calls did not associate tasks with a task group id, instead creating the association _with the currently assigned Executor `task_group_id`_ when the internal thread pulled the tasks for upstream submission.  Thus, from the above code, there was no guarantee that `some_func_01` would be associated with `some-task-group-id`.

Address by associating each task with the current task_group_id before returning the future to the calling code.

[sc-25897]

## Type of change

- Bug fix (non-breaking change that fixes an issue)