### PR TITLE
Remove unpack() in endpoint/interchange

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -200,7 +200,8 @@ def test_soft_idle_honored(mocker, endpoint_uuid, mock_spt):
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
     )
     result = Result(task_id=uuid.uuid1(), data=b"TASK RESULT")
-    ei.results_passthrough.put(pack(result))
+    msg = {"task_id": str(result.task_id), "message": pack(result)}
+    ei.results_passthrough.put(msg)
 
     ei._main_loop()
 
@@ -276,7 +277,8 @@ def test_unidle_updates_proc_title(mocker, endpoint_uuid, mock_spt):
 
     def insert_msg():
         result = Result(task_id=uuid.uuid1(), data=b"TASK RESULT")
-        ei.results_passthrough.put(pack(result))
+        msg = {"task_id": str(result.task_id), "message": pack(result)}
+        ei.results_passthrough.put(msg)
         while True:
             yield
 
@@ -337,7 +339,7 @@ def test_faithfully_handles_status_report_messages(mocker, endpoint_uuid, random
         endpoint_id=endpoint_uuid, global_state={"sentinel": "foo"}, task_statuses=[]
     )
 
-    ei.results_passthrough.put(pack(status_report))
+    ei.results_passthrough.put({"message": pack(status_report)})
     t = threading.Thread(target=ei._main_loop, daemon=True)
     t.start()
 

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_htex_regression.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_htex_regression.py
@@ -35,7 +35,7 @@ def test_engine_submit(engine):
             task_id=task_id, container_id=uuid.uuid1(), task_buffer=task_body
         )
     )
-    future = engine.submit(task_id, task_message)
+    future = engine.submit(str(task_id), task_message)
     packed_result = future.result()
 
     # Confirm that the future got the right answer
@@ -46,11 +46,10 @@ def test_engine_submit(engine):
 
     # Confirm that the same result got back though the queue
     for _i in range(10):
-        packed_result_q = q.get(timeout=0.1)
-        assert isinstance(
-            packed_result_q, bytes
-        ), "Expected bytes from the passthrough_q"
+        q_msg = q.get(timeout=5)
+        assert isinstance(q_msg, dict)
 
+        packed_result_q = q_msg["message"]
         result = messagepack.unpack(packed_result_q)
         # Handle a sneaky EPStatusReport that popped in ahead of the result
         if isinstance(result, messagepack.message_types.EPStatusReport):

--- a/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/mock_executors.py
@@ -31,4 +31,5 @@ class MockExecutor(unittest.mock.Mock):
         task: Task = messagepack.unpack(packed_task)
         res = Result(task_id=task_id, data=task.task_buffer)
         packed_result = messagepack.pack(res)
-        self.results_passthrough.put(packed_result)
+        msg = {"task_id": str(task_id), "message": packed_result}
+        self.results_passthrough.put(msg)

--- a/compute_endpoint/tests/unit/test_status_reporting.py
+++ b/compute_endpoint/tests/unit/test_status_reporting.py
@@ -36,8 +36,9 @@ def test_status_reporting(
 
     # Confirm heartbeats in regular intervals
     for _i in range(3):
-        message = results_q.get(timeout=0.2)
-        assert isinstance(message, bytes)
+        q_msg = results_q.get(timeout=1)
+        assert isinstance(q_msg, dict)
 
+        message = q_msg["message"]
         report = messagepack.unpack(message)
         assert isinstance(report, EPStatusReport)


### PR DESCRIPTION
One of the main goals of the recent Engine work and the addition of the task identifying information to the AMQP messages was to remove the need to deserialize in the main endpoint interchange.  More recently,[1] we removed the `unpack()` call from the Task forwarding thread loop.  Follow-through and remove the same from the Result forwarding thread loop as well.

[1] 1ee3fd54906895393a78a6916f19edef70a31c76 "check rmq message header for allowlist and add header to queue (#1241)"

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
