### PR TITLE
Revert dill version to make it compatible with 2.2.3

### DIFF
--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -14,7 +14,7 @@ REQUIRES = [
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy
-    "dill==0.3.6",
+    "dill==0.3.5.1",
     # typing_extensions, so we can use Protocol and other typing features on python3.7
     'typing_extensions>=4.0;python_version<"3.8"',
     # packaging, allowing version parsing

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -14,7 +14,8 @@ REQUIRES = [
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy
-    "dill==0.3.5.1",
+    'dill==0.3.5.1;python_version<"3.11"',
+    'dill==0.3.6;python_version>="3.11"',
     # typing_extensions, so we can use Protocol and other typing features on python3.7
     'typing_extensions>=4.0;python_version<"3.8"',
     # packaging, allowing version parsing


### PR DESCRIPTION
# Description

See discussion in :  https://funcx.slack.com/archives/C016JMYST9C/p1691005981657089

SDK using dill version 0.3.6 does not decode properly in 0.3.5.1, which was the version used in older endpoint versions.

Reverting until we figure out a long term solution.

Fixes the stack trace:
```
    Traceback (most recent call last):
      File "/home/ubuntu/.local/lib/python3.10/site-packages/globus_compute_sdk/serialize/facade.py", line 125, in unpack_and_deserialize
        deserialized = self.deserialize(current)
      File "/home/ubuntu/.local/lib/python3.10/site-packages/globus_compute_sdk/serialize/facade.py", line 82, in deserialize
        return strategy.deserialize(payload)
      File "/home/ubuntu/.local/lib/python3.10/site-packages/globus_compute_sdk/serialize/concretes.py", line 146, in deserialize
        function = dill.loads(codecs.decode(enc, "base64"))
      File "/home/ubuntu/.local/lib/python3.10/site-packages/dill/_dill.py", line 387, in loads
        return load(file, ignore, **kwds)
      File "/home/ubuntu/.local/lib/python3.10/site-packages/dill/_dill.py", line 373, in load
        return Unpickler(file, ignore=ignore, **kwds).load()
      File "/home/ubuntu/.local/lib/python3.10/site-packages/dill/_dill.py", line 646, in load
        obj = StockUnpickler.load(self)
      File "/home/ubuntu/.local/lib/python3.10/site-packages/dill/_dill.py", line 805, in _create_code
        return CodeType(args[0], 0, 0, *args[1:])
    TypeError: code expected at most 16 arguments, got 19
```
## Type of change


- Bug fix (non-breaking change that fixes an issue)
-