### PR TITLE
Escape user option strings to avoid YAML injection

### DIFF
--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -12,19 +12,14 @@ from contextlib import redirect_stdout
 from types import SimpleNamespace
 from unittest import mock
 
-import jinja2
 import pytest
 import responses
-import yaml
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.default_config import (
     config as default_config,
 )
-from globus_compute_endpoint.endpoint.config.utils import (
-    render_config_user_template,
-    serialize_config,
-)
+from globus_compute_endpoint.endpoint.config.utils import serialize_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 
 _mock_base = "globus_compute_endpoint.endpoint.endpoint."
@@ -535,44 +530,6 @@ def test_serialize_config_field_types():
 
     # Others should not
     assert isinstance(result["heartbeat_threshold"], str)
-
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        (False, {}),
-        (False, {"foo": "bar"}),
-        (True, {"heartbeat": 10}),
-        (True, {"heartbeat": 10, "foo": "bar"}),
-    ],
-)
-def test_render_config_user_template(fs, data):
-    is_valid, user_opts = data
-
-    ep_dir = pathlib.Path("config_user.yaml")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-    template = ep_dir / "config_user.yaml"
-    template.write_text(
-        """
-heartbeat_period: {{ heartbeat }}
-engine:
-    type: HighThroughputEngine
-    provider:
-        type: LocalProvider
-        init_blocks: 1
-        min_blocks: 0
-        max_blocks: 1
-        """
-    )
-
-    if is_valid:
-        rendered = render_config_user_template(ep_dir, user_opts)
-        rendered_dict = yaml.safe_load(rendered)
-        assert rendered_dict["heartbeat_period"] == user_opts["heartbeat"]
-    else:
-        with pytest.raises(jinja2.exceptions.UndefinedError) as e:
-            render_config_user_template(ep_dir, user_opts)
-            assert "Missing required" in str(e)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

We avoid YAML injection attacks by applying `json.dumps()` to all string values in user config options. Note that this will enforce double-quoted YAML strings.

#### YAML injection example
```yaml
# ~/.globus_compute/mt-ep/config_user.yaml

endpoint_setup: {{ setup }}
```
```python
user_opts = {
    "setup": "my-setup\nallowed_functions:\n\t- b9703f9d-2e97-49ee-9dea-3f67ed13a0ad"
}
```

[sc-26181]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
