### PR TITLE
Create default templates for MT endpoints

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
@@ -1,0 +1,44 @@
+# This is the default user-template provided with newly-configured Multi-Tenant
+# endpoints.  User endpoints generate a user-endpoint-specific configuration by
+# processing this YAML file as a Jinja template against user-provided
+# variables -- please modify this template to suit your site's requirements.
+#
+# For more information, please see the `user_endpoint_config` in Globus Compute
+# SDK's Executor.
+#
+# Some common options site-administrators may want to set:
+#  - address
+#  - provider (e.g., SlurmProvider, TorqueProvider, CobaltProvider, etc.)
+#  - account
+#  - scheduler_options
+#  - walltime
+#  - worker_init
+#
+# There are a number of example configurations available in the documentation:
+#    https://globus-compute.readthedocs.io/en/stable/endpoints.html#example-configurations
+
+engine:
+  type: HighThroughputEngine
+  max_workers_per_node: 1
+
+  provider:
+    type: LocalProvider
+
+    min_blocks: 0
+    max_blocks: 1
+    init_blocks: 1
+
+    endpoint_setup: {{ endpoint_setup|default() }}
+    endpoint_init: {{ endpoint_init|default() }}
+    worker_init: {{ worker_init|default() }}
+
+# Endpoints will be restarted when a user submits new tasks to the
+# web-services, so eagerly shut down if endpoint is idle.  At 30s/hb (default
+# value), 10 heartbeats is 300s.
+idle_heartbeats_soft: 10
+
+# If endpoint is *apparently* idle (e.g., outstanding tasks, but no movement)
+# for this many heartbeats, then shutdown anyway.  At 30s/hb (default value),
+# 5,760 heartbeats == "48 hours".  (Note that this value will be ignored if
+# idle_heartbeats_soft is 0 or not set.)
+idle_heartbeats_hard: 5760

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_environment.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_environment.yaml
@@ -1,0 +1,19 @@
+# Use this YAML file to specify environment variables to inject into the user
+# endpoint processes.  Following standard process environment variables, any
+# variables specified here will be strings to the processes, and there is no
+# nesting -- this is a key-value description only.
+#
+# A couple of notes:
+#
+# - Values specified here will override any defaults (e.g., PATH)
+#
+# - Note that PATH is set to a sensible default, so typically won't need to
+#   be manually specified
+#
+# - Three variables cannot be set here: HOME, USER, and PWD.  These are set
+#   based on the user's GETENT(1) entry.
+#
+# Example:
+#
+#     PATH: /opt/bin:/other/dir/bin:/usr/bin
+#     SITE_SPECIFIC_VAR: some site specific value

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -183,12 +183,12 @@ def _sanitize_user_opts(data):
 
 
 def render_config_user_template(endpoint_dir: pathlib.Path, user_opts: dict) -> str:
-    # Only load package when called by EP manager
-    import jinja2
+    import jinja2  # Only load package when called by EP manager
+    from globus_compute_endpoint.endpoint.endpoint import Endpoint
     from jinja2.sandbox import SandboxedEnvironment
 
     user_opts = _sanitize_user_opts(user_opts)
-    user_config_path = endpoint_dir / "config_user.yaml"
+    user_config_path = Endpoint.user_config_template_path(endpoint_dir)
 
     template_str = _read_config_yaml(user_config_path)
     environment = SandboxedEnvironment(undefined=jinja2.StrictUndefined)

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 from globus_compute_endpoint.cli import app, init_config_dir
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
+from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from pyfakefs import fake_filesystem as fakefs
 from pytest_mock import MockFixture
 
@@ -47,8 +48,8 @@ def make_endpoint_dir(mock_command_ensure):
     def func(name):
         ep_dir = mock_command_ensure.endpoint_config_dir / name
         ep_dir.mkdir(parents=True, exist_ok=True)
-        ep_config = ep_dir / "config.yaml"
-        ep_template = ep_dir / "config_user.yaml"
+        ep_config = Endpoint._config_file_path(ep_dir)
+        ep_template = Endpoint.user_config_template_path(ep_dir)
         ep_config.write_text(
             """
 display_name: null

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -20,6 +20,7 @@ import responses
 import yaml
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import render_config_user_template
+from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.endpoint_manager import EndpointManager
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
 from globus_sdk import GlobusAPIError, NetworkError
@@ -42,7 +43,7 @@ def mock_conf():
 
 @pytest.fixture
 def user_conf_template(conf_dir):
-    template = conf_dir / "config_user.yaml"
+    template = Endpoint.user_config_template_path(conf_dir)
     template.write_text(
         """
 heartbeat_period: {{ heartbeat }}
@@ -949,7 +950,7 @@ def test_render_config_user_template(fs, data):
 
     ep_dir = pathlib.Path("my-ep")
     ep_dir.mkdir(parents=True, exist_ok=True)
-    template = ep_dir / "config_user.yaml"
+    template = Endpoint.user_config_template_path(ep_dir)
     template.write_text("heartbeat_period: {{ heartbeat }}")
 
     if is_valid:
@@ -965,7 +966,7 @@ def test_render_config_user_template(fs, data):
 def test_render_config_user_template_escape_strings(fs):
     ep_dir = pathlib.Path("my-ep")
     ep_dir.mkdir(parents=True, exist_ok=True)
-    template = ep_dir / "config_user.yaml"
+    template = Endpoint.user_config_template_path(ep_dir)
     template.write_text(
         """
 endpoint_setup: {{ setup }}
@@ -1017,7 +1018,7 @@ def test_render_config_user_template_option_types(fs, data):
 
     ep_dir = pathlib.Path("my-ep")
     ep_dir.mkdir(parents=True, exist_ok=True)
-    template = ep_dir / "config_user.yaml"
+    template = Endpoint.user_config_template_path(ep_dir)
     template.write_text("foo: {{ foo }}")
 
     user_opts = {"foo": val}
@@ -1043,7 +1044,7 @@ def test_render_config_user_template_sandbox(mocker: MockFixture, fs, data):
 
     ep_dir = pathlib.Path("my-ep")
     ep_dir.mkdir(parents=True, exist_ok=True)
-    template = ep_dir / "config_user.yaml"
+    template = Endpoint.user_config_template_path(ep_dir)
     template.write_text(f"foo: {jinja_op}")
 
     user_opts = {"foo": val}


### PR DESCRIPTION
# Description

For new MT configurations, ensure there's a default user_endpoint configuration template.  This provides a scaffolding for admins to modify, rather than requiring a whole-cloth creation, with some low-hanging fruit defaults (e.g., `max_blocks: 1`, `idle_heartbeats_soft`, etc.)

## Type of change

- New feature (non-breaking change that adds functionality)