### PR TITLE
Prevent same-user child-processes

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -92,6 +92,18 @@ class Config(RepresentationMixin):
         Designates the endpoint as a multi-tenant endpoint
         Default: None
 
+    force_mt_allow_same_user : bool
+        If set, override the heuristic that determines whether the uid running the
+        multi-tenant endpoint may also run user endpoints.
+
+        Normally, the multi-tenant endpoint disallows starting user endpoints with
+        the same UID as the parent process unless the UID has no privileges.  That
+        means that the UID is not 0 (root), or that the UID does *not* have (among
+        many others) the capability to change the user (otherwise known as "drop
+        privileges").
+
+        Default: False
+
     display_name : str | None
         The display name for the endpoint.  If None, defaults to name
         Default: None
@@ -120,6 +132,7 @@ class Config(RepresentationMixin):
         detach_endpoint=True,
         endpoint_setup: str | None = None,
         endpoint_teardown: str | None = None,
+        force_mt_allow_same_user: bool = False,
         # Misc info
         display_name: str | None = None,
         # Logging info
@@ -157,6 +170,7 @@ class Config(RepresentationMixin):
         self.funcx_service_address = funcx_service_address
 
         self.multi_tenant = multi_tenant is True
+        self.force_mt_allow_same_user = force_mt_allow_same_user is True
         self.allowed_functions = allowed_functions
 
         # Tuning info

--- a/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/utils/__init__.py
@@ -1,11 +1,56 @@
+import os as _os
+import pwd as _pwd
 import re as _re
 import typing as t
+
+import pyprctl as _pyprctl
 
 _url_user_pass_pattern = r"://([^:]+):[^@]+@"
 _url_user_pass_re = _re.compile(_url_user_pass_pattern)
 _urlb_user_pass_re = _re.compile(_url_user_pass_pattern.encode())
 
 _T = t.TypeVar("_T", str, bytes)
+
+# List of Linux capabilities that would suggest the running process is
+# privileged, even if os.getuid() != 0.
+_MULTI_USER_CAPS = {
+    _pyprctl.Cap.AUDIT_CONTROL,
+    _pyprctl.Cap.AUDIT_READ,
+    _pyprctl.Cap.BPF,
+    _pyprctl.Cap.CHECKPOINT_RESTORE,
+    _pyprctl.Cap.CHOWN,
+    _pyprctl.Cap.DAC_OVERRIDE,
+    _pyprctl.Cap.DAC_READ_SEARCH,
+    _pyprctl.Cap.FOWNER,
+    _pyprctl.Cap.FSETID,
+    _pyprctl.Cap.IPC_OWNER,
+    _pyprctl.Cap.KILL,
+    _pyprctl.Cap.LINUX_IMMUTABLE,
+    _pyprctl.Cap.MAC_ADMIN,
+    _pyprctl.Cap.MAC_OVERRIDE,
+    _pyprctl.Cap.MKNOD,
+    _pyprctl.Cap.NET_ADMIN,
+    _pyprctl.Cap.NET_BIND_SERVICE,
+    _pyprctl.Cap.NET_RAW,
+    _pyprctl.Cap.PERFMON,
+    _pyprctl.Cap.SETGID,
+    _pyprctl.Cap.SETFCAP,
+    _pyprctl.Cap.SETPCAP,
+    _pyprctl.Cap.SETUID,
+    _pyprctl.Cap.SYS_ADMIN,
+    _pyprctl.Cap.SYS_BOOT,
+    _pyprctl.Cap.SYS_CHROOT,
+    _pyprctl.Cap.SYS_MODULE,
+    _pyprctl.Cap.SYS_NICE,
+    _pyprctl.Cap.SYS_PACCT,
+    _pyprctl.Cap.SYS_PTRACE,
+    _pyprctl.Cap.SYS_RAWIO,
+    _pyprctl.Cap.SYS_RESOURCE,
+    _pyprctl.Cap.SYS_TIME,
+    _pyprctl.Cap.SYS_TTY_CONFIG,
+    _pyprctl.Cap.SYSLOG,
+    _pyprctl.Cap.WAKE_ALARM,
+}
 
 
 def _redact_url_creds(raw: _T, redact_user=True, repl="***", count=0) -> _T:
@@ -27,3 +72,14 @@ def _redact_url_creds(raw: _T, redact_user=True, repl="***", count=0) -> _T:
     if isinstance(raw, str):
         return _url_user_pass_re.sub(repl=repl, string=raw, count=count)
     return _urlb_user_pass_re.sub(repl=repl.encode(), string=raw, count=count)
+
+
+def is_privileged(posix_user=None):
+    if not posix_user:
+        posix_user = _pwd.getpwuid(_os.getuid())
+
+    proc_caps = _pyprctl.CapState.get_current()
+    has_privileges = posix_user.pw_uid == 0
+    has_privileges |= posix_user.pw_name == "root"
+    has_privileges |= any(c in proc_caps.effective for c in _MULTI_USER_CAPS)
+    return has_privileges

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,6 +35,7 @@ REQUIRES = [
     # pin exact versions because it does not use semver
     "parsl==2023.7.3",
     "pika>=1.2.0",
+    "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.2,<3.2",

--- a/compute_endpoint/tests/unit/test_utils.py
+++ b/compute_endpoint/tests/unit/test_utils.py
@@ -1,4 +1,10 @@
-from globus_compute_endpoint.endpoint.utils import _redact_url_creds
+from collections import namedtuple
+
+import pyprctl
+import pytest
+from globus_compute_endpoint.endpoint.utils import _redact_url_creds, is_privileged
+
+_MOCK_BASE = "globus_compute_endpoint.endpoint.utils."
 
 
 def test_url_redaction(randomstring):
@@ -21,3 +27,29 @@ def test_url_redaction(randomstring):
             else:
                 expected = f"{scheme}://{uname}:{repl}@{fqdn}/{somepath}"
             assert _redact_url_creds(some_url, **kwargs) == expected
+
+
+@pytest.mark.parametrize("uid", (0, 1000))
+def test_is_privileged_tests_against_uid(mocker, uid):
+    user = namedtuple("posix_user", "pw_uid,pw_name")(uid, "asdf")
+    mock_prctl = mocker.patch(f"{_MOCK_BASE}_pyprctl")
+    mock_prctl.CapState.get_current.return_value.effective = {}
+
+    assert is_privileged(user) is bool(0 == uid)
+
+
+@pytest.mark.parametrize("uname", ("root", "not_root_uname"))
+def test_is_privileged_tests_for_root_username(mocker, uname):
+    user = namedtuple("posix_user", "pw_uid,pw_name")(987, uname)
+    mock_prctl = mocker.patch(f"{_MOCK_BASE}_pyprctl")
+    mock_prctl.CapState.get_current.return_value.effective = {}
+
+    assert is_privileged(user) is bool("root" == uname)
+
+
+@pytest.mark.parametrize("cap", ({pyprctl.Cap.SYS_ADMIN}, {}))
+def test_is_privileged_checks_for_privileges(mocker, cap):
+    user = namedtuple("posix_user", "pw_uid,pw_name")(987, "asdf")
+    mock_prctl = mocker.patch(f"{_MOCK_BASE}_pyprctl")
+    mock_prctl.CapState.get_current.return_value.effective = cap
+    assert is_privileged(user) is bool(cap)


### PR DESCRIPTION
For administrators running a multi-tenant endpoint, the parent process&nbsp;&mdash;&nbsp;the endpoint manager&nbsp;&mdash;&nbsp;is expected to lookup local user ids (UID) and then drop privileges to that UID before `exec()`ing.  On the other hand, for non-power users (e.g., not `root`) running the multi-tenant endpoint, the process won't have the privileges to change users anyway.  Consequently, implement a check that only allows the parent endpoint process to create child endpoint processes ("user endpoints") with the same process UID if the UID is not otherwise privileged.
    
This is implemented with 2 checks:
    
- Is the parent process owned by UID 0?
- Does the parent process have any admin-like capabilities (via `pyprctl`)
    
If either are true, then set a flag to prevent any attempts to create a child process with the same UID.
    
If neither are true&nbsp;&mdash;&nbsp;so, when a "regular user" is running the multitenant endpoint manager&nbsp;&mdash;&nbsp;then only proceed if the MT UID and the local user UID _do_, in fact, match&nbsp;&mdash;&nbsp;don't even try to execute the `os.set*id()` syscalls.

[sc-26381]

## Type of change

- New feature (non-breaking change that adds functionality)