### PR TITLE
Fix smoke tests and `Executor.reload_tasks`

### DIFF
--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -41,12 +41,12 @@ def test_batch(compute_client, endpoint):
     double_fn_id = compute_client.register_function(double)
 
     inputs = list(range(10))
-    batch = compute_client.create_batch(endpoint)
+    batch = compute_client.create_batch()
 
     for x in inputs:
         batch.add(double_fn_id, args=(x,))
 
-    batch_res = compute_client.batch_run(batch)
+    batch_res = compute_client.batch_run(endpoint, batch)
     tasks = [t for tl in batch_res["tasks"].values() for t in tl]
 
     total = 0


### PR DESCRIPTION
# Description

* Updated the arguments for `Client.create_batch` and `Client.batch_run` in our smoke tests to match recent changes.
* Modified `Executor.reload_tasks` to ensure that we use the matching types (`str`) when comparing the task group UUID associated with the `Executor` with what is sent back from the web service.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
