### PR TITLE
Validate user config options against JSON schema

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_schema.json
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "endpoint_setup": { "type": "string" },
+    "endpoint_init": { "type": "string" },
+    "worker_init": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
@@ -3,6 +3,10 @@
 # processing this YAML file as a Jinja template against user-provided
 # variables -- please modify this template to suit your site's requirements.
 #
+# Optionally, you can define a JSON schema for the user-provided variables in a
+# file named `user_config_schema.json` within the same directory. The variables
+# will be validated against the schema before rendering this template.
+#
 # For more information, please see the `user_endpoint_config` in Globus Compute
 # SDK's Executor.
 #

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -165,12 +165,12 @@ def get_config(endpoint_dir: pathlib.Path) -> Config:
     return config
 
 
-def load_user_config_schema(endpoint_dir: pathlib.Path):
+def load_user_config_schema(endpoint_dir: pathlib.Path) -> dict | None:
     from globus_compute_endpoint.endpoint.endpoint import Endpoint
 
     user_config_schema_path = Endpoint.user_config_schema_path(endpoint_dir)
     if not user_config_schema_path.exists():
-        return
+        return None
 
     try:
         return json.loads(user_config_schema_path.read_text())

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -58,6 +58,10 @@ class Endpoint:
         return endpoint_dir / "user_config_template.yaml"
 
     @staticmethod
+    def user_config_schema_path(endpoint_dir: pathlib.Path) -> pathlib.Path:
+        return endpoint_dir / "user_config_schema.json"
+
+    @staticmethod
     def _user_environment_path(endpoint_dir: pathlib.Path) -> pathlib.Path:
         return endpoint_dir / "user_environment.yaml"
 
@@ -126,14 +130,18 @@ class Endpoint:
                 endpoint_dir.chmod(world_executable)
 
                 src_user_tmpl_path = package_dir / "config/user_config_template.yaml"
+                src_user_schem_path = package_dir / "config/user_config_schema.json"
                 src_user_env_path = package_dir / "config/user_environment.yaml"
                 dst_user_tmpl_path = Endpoint.user_config_template_path(endpoint_dir)
+                dst_user_schem_path = Endpoint.user_config_schema_path(endpoint_dir)
                 dst_user_env_path = Endpoint._user_environment_path(endpoint_dir)
 
                 shutil.copy(src_user_tmpl_path, dst_user_tmpl_path)
+                shutil.copy(src_user_schem_path, dst_user_schem_path)
                 shutil.copy(src_user_env_path, dst_user_env_path)
 
                 dst_user_tmpl_path.chmod(world_readable)
+                dst_user_schem_path.chmod(world_readable)
                 dst_user_env_path.chmod(world_readable)
 
         finally:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -24,6 +24,7 @@ import yaml
 from globus_compute_endpoint import __version__
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import (
+    load_user_config_schema,
     render_config_user_template,
     serialize_config,
 )
@@ -83,7 +84,7 @@ class EndpointManager:
             reg_info = gcc.register_endpoint(
                 conf_dir.name,
                 endpoint_uuid,
-                metadata=EndpointManager.get_metadata(config),
+                metadata=EndpointManager.get_metadata(config, conf_dir),
                 multi_tenant=True,
             )
         except GlobusAPIError as e:
@@ -160,7 +161,7 @@ class EndpointManager:
         )
 
     @staticmethod
-    def get_metadata(config: Config) -> dict:
+    def get_metadata(config: Config, conf_dir: pathlib.Path) -> dict:
         # Piecemeal Config settings because for MT, most of the ST items are
         # unrelated -- the MT (aka EndpointManager) does not execute tasks
         return {
@@ -168,6 +169,7 @@ class EndpointManager:
             "hostname": socket.getfqdn(),
             "local_user": pwd.getpwuid(os.getuid()).pw_name,
             "config": serialize_config(config),
+            "user_config_schema": load_user_config_schema(conf_dir),
         }
 
     def request_shutdown(self, sig_num, curr_stack_frame):

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -39,6 +39,7 @@ REQUIRES = [
     "setproctitle>=1.3.2,<1.4",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.2,<3.2",
+    "jsonschema>=4.19.0,<4.20",
 ]
 
 TEST_REQUIRES = [

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -39,6 +39,7 @@ class TestStart:
         # pyfakefs will take care of newly created files, not existing config
         fs.add_real_file(DEF_CONFIG_DIR / "default_config.yaml")
         fs.add_real_file(DEF_CONFIG_DIR / "user_config_template.yaml")
+        fs.add_real_file(DEF_CONFIG_DIR / "user_config_schema.json")
         fs.add_real_file(DEF_CONFIG_DIR / "user_environment.yaml")
 
         yield


### PR DESCRIPTION
# Description

The `EndpointManager` now validates user config options against the JSON schema defined in `~/.globus_compute/<ep_name>/user_config_schema.json`. Validation will occur before the user config template is rendered. If no schema is defined, we skip validation.

We also provide a permissive default that matches the default user config template. This schema can be modified or removed as needed.

[sc-26049]

## Type of change

- New feature (non-breaking change that adds functionality)
