### PR TITLE
Add allowed functions to EP registration request

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -92,6 +92,9 @@ class Config(RepresentationMixin):
         Designates the endpoint as a multi-tenant endpoint
         Default: None
 
+    allowed_functions : list[str] | None
+        List of functions that are allowed to be run on the endpoint
+
     force_mt_allow_same_user : bool
         If set, override the heuristic that determines whether the uid running the
         multi-tenant endpoint may also run user endpoints.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -360,6 +360,7 @@ class Endpoint:
                     metadata=Endpoint.get_metadata(endpoint_config),
                     multi_tenant=False,
                     display_name=endpoint_config.display_name,
+                    allowed_functions=endpoint_config.allowed_functions,
                 )
 
             except GlobusAPIError as e:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -162,14 +162,14 @@ def test_start_endpoint_allowlist_passthrough(mocker, fs, patch_compute_client):
     ep_conf = Config()
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
-    ep_conf.allowed_functions = ["a", "b"]
+    ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
 
     with pytest.raises(SystemExit):
         ep.start_endpoint(ep_dir, str(uuid.uuid4()), ep_conf, False, True, reg_info={})
 
-    config = gcc.web_client.post.call_args[1]["data"]["metadata"]["config"]
-    assert len(config["allowed_functions"]) == 2
-    assert config["allowed_functions"][1] == "b"
+    called_data = gcc.web_client.post.call_args[1]["data"]
+    assert len(called_data["allowed_functions"]) == 2
+    assert called_data["allowed_functions"][1] == ep_conf.allowed_functions[1]
 
 
 def test_endpoint_logout(monkeypatch):

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -388,19 +388,28 @@ class Client:
     def register_endpoint(
         self,
         name,
-        endpoint_id,
-        metadata=None,
-        multi_tenant=False,
-        display_name=None,
+        endpoint_id: UUID_LIKE_T,
+        metadata: dict | None = None,
+        multi_tenant: bool | None = None,
+        display_name: str | None = None,
+        allowed_functions: list[UUID_LIKE_T] | None = None,
     ):
         """Register an endpoint with the Globus Compute service.
 
         Parameters
         ----------
-        :param name str Name of the endpoint
-        :param endpoint_id str The uuid of the endpoint
-        :param metadata dict endpoint metadata
-        :param multi_tenant bool Whether the endpoint supports multiple users
+        name : str
+            Name of the endpoint
+        endpoint_id : str | UUID
+            The uuid of the endpoint
+        metadata : dict | None
+            Endpoint metadata
+        multi_tenant : bool | None
+            Whether the endpoint supports multiple users
+        display_name : str | None
+            The display name of the endpoint
+        allowed_functions: list[str | UUID] | None
+            List of functions that are allowed to be run on the endpoint
 
         Returns
         -------
@@ -417,6 +426,7 @@ class Client:
             metadata=metadata,
             multi_tenant=multi_tenant,
             display_name=display_name,
+            allowed_functions=allowed_functions,
         )
         return r.data
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -157,6 +157,7 @@ class WebClient(globus_sdk.BaseClient):
         metadata: t.Optional[dict] = None,
         multi_tenant: t.Optional[bool] = None,
         display_name: t.Optional[str] = None,
+        allowed_functions: t.Optional[t.List[UUID_LIKE_T]] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data: t.Dict[str, t.Any] = {
@@ -177,6 +178,8 @@ class WebClient(globus_sdk.BaseClient):
 
         if metadata:
             data["metadata"] = metadata
+        if allowed_functions:
+            data["allowed_functions"] = allowed_functions
         if additional_fields is not None:
             data.update(additional_fields)
         return self.post("/v2/endpoints", data=data)


### PR DESCRIPTION
# Description

The web service expects `allowed_functions` to be a top-level field in the endpoint registration API request.

[sc-25261]

## Type of change

- New feature (non-breaking change that adds functionality)
