### PR TITLE
Report worker info in Result messages (python, sdk, os, dill, etc)

### DIFF
--- a/changelog.d/20230822_132114_LeiGlobus_report_worker_sdk_version_sc_25606.rst
+++ b/changelog.d/20230822_132114_LeiGlobus_report_worker_sdk_version_sc_25606.rst
@@ -1,0 +1,8 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Teach the endpoint to include the Python and Dill versions, as metadata to Result objects, as well as other useful fields. If the task execution fails, the SDK will use the metadata to highlight differing versions as a possible cause.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/messages_compat.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/messages_compat.py
@@ -57,6 +57,8 @@ def try_convert_to_messagepack(message: bytes) -> bytes:
         ] = {
             "task_id": uuid.UUID(unpacked["task_id"]),
         }
+        if "details" in unpacked:
+            kwargs["details"] = unpacked["details"]
         if "task_statuses" in unpacked:
             kwargs["task_statuses"] = unpacked["task_statuses"]
         if "exception" in unpacked:

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -14,6 +14,7 @@ from globus_compute_endpoint.exception_handling import (
 )
 from globus_compute_endpoint.exceptions import CouldNotExecuteUserTaskError
 from globus_compute_sdk.errors import MaxResultSizeExceeded
+from globus_compute_sdk.sdk.utils import get_env_details
 from globus_compute_sdk.serialize import ComputeSerializer
 from parsl.app.python import timeout
 
@@ -46,6 +47,7 @@ def execute_task(
         uuid.UUID | str | tuple[str, str] | list[TaskTransition] | dict[str, str],
     ]
 
+    env_details = get_env_details()
     try:
         _task, task_buffer = _unpack_messagebody(task_body)
         log.debug("executing task task_id='%s'", task_id)
@@ -63,6 +65,8 @@ def execute_task(
             exception=get_error_string(),
             error_details=error_details,
         )
+
+    result_message["details"] = env_details
 
     exec_end = TaskTransition(
         timestamp=time.time_ns(),

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/worker.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/worker.py
@@ -20,6 +20,7 @@ from globus_compute_endpoint.exception_handling import (
     get_result_error_details,
 )
 from globus_compute_endpoint.logging_config import setup_logging
+from globus_compute_sdk.sdk.utils import get_env_details
 from globus_compute_sdk.serialize import ComputeSerializer
 
 log = logging.getLogger(__name__)
@@ -129,6 +130,7 @@ class Worker:
                 code=code,
                 user_message=user_message,
             ),
+            details=get_env_details(),
         )
         return messagepack.pack(outgoing_result)
 

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.3.2"
+__version__ = "2.3.3a0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,8 +6,8 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.20.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.3.2",
-    "globus-compute-common==0.2.0",
+    "globus-compute-sdk==2.3.3a0",
+    "globus-compute-common==0.3.0a2",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/compute_endpoint/tests/unit/test_execute_task.py
+++ b/compute_endpoint/tests/unit/test_execute_task.py
@@ -31,6 +31,9 @@ def test_execute_task():
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)
     assert result.data
+    assert "os" in result.details
+    assert "python_version" in result.details
+    assert "dill_version" in result.details
     assert serializer.deserialize(result.data) == output
 
 
@@ -58,4 +61,7 @@ def test_execute_task_with_exception():
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)
     assert result.error_details
+    assert "python_version" in result.details
+    assert "os" in result.details
+    assert result.details["dill_version"]
     assert "ZeroDivisionError" in result.data

--- a/compute_funcx/endpoint/funcx_endpoint/version.py
+++ b/compute_funcx/endpoint/funcx_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.3.2"
+__version__ = "2.3.3a0"
 
 VERSION = __version__
 

--- a/compute_funcx/endpoint/setup.py
+++ b/compute_funcx/endpoint/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-endpoint==2.3.2",
+    "globus-compute-endpoint==2.3.3a0",
 ]
 
 version_ns = {}

--- a/compute_funcx/sdk/funcx/version.py
+++ b/compute_funcx/sdk/funcx/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.3.2"
+__version__ = "2.3.3a0"
 
 DEPRECATION_FUNCX = """
 The funcX SDK has been renamed to Globus Compute SDK and the new package is

--- a/compute_funcx/sdk/setup.py
+++ b/compute_funcx/sdk/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "globus-compute-sdk==2.3.2",
+    "globus-compute-sdk==2.3.3a0",
 ]
 
 

--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -61,10 +61,16 @@ class TaskExecutionFailed(Exception):
     Error result from the remote end, wrapped as an exception object
     """
 
-    def __init__(self, remote_data: str, completion_t: str | None = None):
+    def __init__(
+        self,
+        remote_data: str,
+        completion_t: str | None = None,
+        task_details: dict | None = None,
+    ):
         self.remote_data = remote_data
+        self.task_details = task_details
         # Fill in completion time if missing
         self.completion_t = completion_t or str(time.time())
 
     def __str__(self) -> str:
-        return "\n" + textwrap.indent(self.remote_data, "    ")
+        return "\n" + textwrap.indent(self.remote_data, " ")

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -1,7 +1,63 @@
+from __future__ import annotations
+
+import sys
 import typing as t
+from datetime import datetime, timezone
 from itertools import islice
+from pathlib import Path
+from platform import platform
+
+import dill
+import globus_compute_sdk.version as sdk_version
 
 
 def chunk_by(iterable: t.Iterable, size) -> t.Iterable[tuple]:
     to_chunk_iter = iter(iterable)
     return iter(lambda: tuple(islice(to_chunk_iter, size)), ())
+
+
+def log_tmp_file(item, filename: Path | None = None) -> None:
+    """
+    Convenience method for logging to a tmp file for debugging, getting
+    around most thread or logging setup complexities.
+    Usage of this should be removed after dev testing is done
+
+    :param item: The info to log to file
+    :param filename: An optional path to the log file.   If None,
+                      use a file in the current user's home directory
+    """
+    if filename is None:
+        filename = Path.home() / "compute_debug.log"
+    with open(filename, "a") as f:
+        ts = datetime.now(timezone.utc).astimezone().isoformat()
+        f.write(f"{ts} {item}\n")
+
+
+def get_env_details() -> t.Dict[str, t.Any]:
+    return {
+        "os": platform(),
+        "dill_version": dill.__version__,
+        "python_version": ".".join(map(str, sys.version_info[:3])),
+        "globus_compute_sdk_version": sdk_version.__version__,
+    }
+
+
+def check_version(task_details: dict | None) -> str | None:
+    """
+    This method adds an optional string to some Exceptions below to
+    warn of differing environments as a possible cause.  It is pre-pended
+
+    """
+    if task_details:
+        worker_py = task_details.get("python_version", "UnknownPy")
+        worker_dill = task_details.get("dill_version", "UnknownDill")
+        worker_os = task_details.get("os", "UnknownOS")
+        client_details = get_env_details()
+        sdk_py = client_details["python_version"]
+        sdk_dill = client_details["dill_version"]
+        if (sdk_py, sdk_dill) != (worker_py, worker_dill):
+            return (
+                f"Warning:  Client SDK uses Python {sdk_py}/Dill {sdk_dill} "
+                f"but worker used {worker_py}/{worker_dill} (OS: {worker_os})"
+            )
+    return None

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -16,11 +16,13 @@ def chunk_by(iterable: t.Iterable, size) -> t.Iterable[tuple]:
     return iter(lambda: tuple(islice(to_chunk_iter, size)), ())
 
 
-def log_tmp_file(item, filename: Path | None = None) -> None:
+def _log_tmp_file(item, filename: Path | None = None) -> None:
     """
     Convenience method for logging to a tmp file for debugging, getting
     around most thread or logging setup complexities.
     Usage of this should be removed after dev testing is done
+
+    Not intended for non-development debugging usage
 
     :param item: The info to log to file
     :param filename: An optional path to the log file.   If None,
@@ -30,7 +32,8 @@ def log_tmp_file(item, filename: Path | None = None) -> None:
         filename = Path.home() / "compute_debug.log"
     with open(filename, "a") as f:
         ts = datetime.now(timezone.utc).astimezone().isoformat()
-        f.write(f"{ts} {item}\n")
+        # Console as well as write to file
+        print(ts, item, file=f)
 
 
 def get_env_details() -> t.Dict[str, t.Any]:

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.3.2"
+__version__ = "2.3.3a0"
 
 
 def compare_versions(

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     # request sending and authorization tools
     "requests>=2.20.0",
     "globus-sdk>=3.20.1,<4",
-    "globus-compute-common==0.2.0",
+    "globus-compute-common==0.3.0a2",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types

--- a/compute_sdk/tests/unit/conftest.py
+++ b/compute_sdk/tests/unit/conftest.py
@@ -1,7 +1,11 @@
+import json
 import random
 import string
+from unittest import mock
 
 import pytest
+import requests
+from globus_sdk import GlobusHTTPResponse
 
 
 @pytest.fixture
@@ -10,3 +14,15 @@ def randomstring():
         return "".join(random.choice(alphabet) for _ in range(length))
 
     return func
+
+
+@pytest.fixture
+def mock_response():
+    def response(resp_code, resp_json) -> GlobusHTTPResponse:
+        resp = requests.Response()
+        resp.status_code = resp_code
+        resp.code = f"Mock {resp_code}"
+        resp._content = json.dumps(resp_json).encode("utf-8")
+        return GlobusHTTPResponse(resp, client=mock.Mock())
+
+    yield response


### PR DESCRIPTION

# Description

This is the largest of the 3 PR necessary to report differing python versions between the client and worker if task execution fails.  It involves adding metadata in the 'details' field of all results.  

Now SerializationError and TaskExecutionError will add such info to the stack trace.  

See story https://app.shortcut.com/funcx/story/25606/report-warning-error-message-if-sdk-and-worker-python-version-mismatch

An import requirement is that the web-service and associated storage classes handle older endpoints that supplies results without the new field.

Currently, the info is stored in RedisTask (AsyncRedisTask).  This is ephemeral, so a followup PR will add a column to the task in psql to keep a more permanent record.

2.3.1a1 SDK and EP have already been pushed to PyPI for testing purposes.  (Albeit a slightly earlier code branch but with the same logic).  The web-service is currently deployed to sandbox, but will be available on dev shortly.

## Type of change

- New feature (non-breaking change that adds functionality)