### PR TITLE
Migrate to v3 version route

### DIFF
--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -85,9 +85,13 @@ class FakeLoginManager:
 def get_standard_compute_client():
     responses.add(
         method=responses.GET,
-        url="https://compute.api.globus.org/v2/version",
+        url="https://compute.api.globus.org/v3/version",
         headers={"Content-Type": "application/json"},
-        json={"api": "0.4.0", "min_ep_version": "0.0.0", "min_sdk_version": "0.0.0"},
+        json={
+            "api": "0.4.0",
+            "min_endpoint_version": "0.0.0",
+            "min_sdk_version": "0.0.0",
+        },
     )
 
     def func():

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -54,8 +54,12 @@ def test_start_endpoint_blocked(
     reason_msg = randomstring()
     responses.add(
         responses.GET,
-        svc_addy + "/v2/version",
-        json={"api": "1.0.5", "min_ep_version": "1.0.5", "min_sdk_version": "0.0.2a0"},
+        svc_addy + "/v3/version",
+        json={
+            "api": "1.0.5",
+            "min_endpoint_version": "1.0.5",
+            "min_sdk_version": "0.0.2a0",
+        },
         status=200,
     )
     responses.add(
@@ -105,8 +109,12 @@ def test_start_endpoint_display_name(mocker, fs, patch_compute_client, display_n
 
     responses.add(
         responses.GET,
-        svc_addy + "/v2/version",
-        json={"api": "1.0.5", "min_ep_version": "1.0.5", "min_sdk_version": "0.0.2a0"},
+        svc_addy + "/v3/version",
+        json={
+            "api": "1.0.5",
+            "min_endpoint_version": "1.0.5",
+            "min_sdk_version": "0.0.2a0",
+        },
         status=200,
     )
     responses.add(
@@ -147,8 +155,12 @@ def test_start_endpoint_allowlist_passthrough(mocker, fs, patch_compute_client):
 
     responses.add(
         responses.GET,
-        gcc_addy + "/v2/version",
-        json={"api": "1.0.5", "min_ep_version": "1.0.5", "min_sdk_version": "0.0.2a0"},
+        gcc_addy + "/v3/version",
+        json={
+            "api": "1.0.5",
+            "min_endpoint_version": "1.0.5",
+            "min_sdk_version": "0.0.2a0",
+        },
         status=200,
     )
     responses.add(

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -151,7 +151,7 @@ class Client:
         """
         data = self.web_client.get_version()
 
-        min_ep_version = data["min_ep_version"]
+        min_ep_version = data["min_endpoint_version"]
         min_sdk_version = data["min_sdk_version"]
 
         compare_versions(__version__, min_sdk_version)

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -97,7 +97,7 @@ class WebClient(globus_sdk.BaseClient):
         self.user_app_name = app_name
 
     def get_version(self, *, service: str = "all") -> globus_sdk.GlobusHTTPResponse:
-        return self.get("/v2/version", query_params={"service": service})
+        return self.get("/v3/version", query_params={"service": service})
 
     def get_taskgroup_tasks(
         self, task_group_id: UUID_LIKE_T

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -46,7 +46,7 @@ def test_get_version_service_param(client, service_param):
     # to match on querystring and URL
     responses.add(
         responses.GET,
-        "https://api.funcx/v2/version",
+        "https://api.funcx/v3/version",
         json={"version": 100},
         match=[responses.matchers.query_param_matcher({"service": expect_param})],
     )

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -24,7 +24,7 @@ This should return the Python version, for example: ``Python 3.8.10``.
 
 To check if your endpoint/client has network access and can connect to the Globus Compute service, run::
 
-  >>> curl https://compute.api.globus.org/v2/version
+  >>> curl https://compute.api.globus.org/v3/version
 
 This should return a version string, for example: ``"1.0.5"``
 


### PR DESCRIPTION
# Description

Start using the new `/v3/version` API route to get version information.

[sc-26607]

## Type of change

- Code maintenance/cleanup
