### PR TITLE
Print message to stdout when network error occurs

### DIFF
--- a/changelog.d/20230824_124226_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20230824_124226_30907815+rjmello_HEAD.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- An informative error message will print to stdout when attempting to start or delete an
+  endpoint while the Globus Compute web service is unreachable.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -378,13 +378,14 @@ class Endpoint:
                 log.exception(
                     f"Caught exception while attempting endpoint registration: {e}"
                 )
-                log.critical(
+                msg = (
                     "globus-compute-endpoint is unable to reach the Globus Compute "
-                    "service due to a NetworkError \n"
-                    "Please make sure that the Globus Compute service address you "
-                    "provided is reachable \n"
-                    "and then attempt restarting the endpoint"
+                    "service due to a network error.\n"
+                    "Please ensure the Globus Compute service address is reachable, "
+                    "then attempt restarting the endpoint."
                 )
+                print(msg)
+                log.critical(msg)
                 exit(os.EX_TEMPFAIL)
 
             ret_ep_uuid = reg_info.get("endpoint_id")
@@ -600,13 +601,14 @@ class Endpoint:
                 f"  [{e}]"
             )
             if not force:
-                log.critical(
+                msg = (
                     "globus-compute-endpoint is unable to reach the Globus Compute "
-                    "service due to a NetworkError \n"
-                    "Please make sure that the Globus Compute service address you "
-                    "provided is reachable \n"
-                    "and then attempt to delete the endpoint again"
+                    "service due to a network error.\n"
+                    "Please ensure the Globus Compute service address is reachable, "
+                    "then attempt to delete the endpoint again."
                 )
+                print(msg)
+                log.critical(msg)
                 exit(os.EX_TEMPFAIL)
 
         # Stop endpoint to handle process cleanup


### PR DESCRIPTION
# Description

An informative error message will print to stdout when attempting to start or delete an endpoint while the Globus Compute web service is unreachable.

[sc-26628]

## Type of change

- New feature (non-breaking change that adds functionality)
