### PR TITLE
Make self-diagnostic GLOBUS_SDK_ENVIRONMENT aware 

### DIFF
--- a/changelog.d/20230830_153211_30907815+rjmello_self_diagnostic_env.rst
+++ b/changelog.d/20230830_153211_30907815+rjmello_self_diagnostic_env.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added web service version information to the output of the ``self-diagnostic`` endpoint command.

--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -8,8 +8,13 @@ import socket
 import subprocess
 import sys
 import textwrap
+from urllib.parse import urlparse
 
 import click
+from globus_compute_sdk.sdk._environments import (
+    get_amqp_service_host,
+    get_web_service_url,
+)
 
 
 def cat(path: str, wildcard: bool = False, max_bytes: int | None = None):
@@ -82,6 +87,9 @@ def _run_command(cmd: str):
 
 
 def run_self_diagnostic(log_bytes: int | None = None):
+    web_svc_host = urlparse(get_web_service_url()).netloc
+    amqp_svc_host = get_amqp_service_host()
+
     commands = [
         "uname -a",
         cat("/etc/os-release"),
@@ -89,8 +97,8 @@ def run_self_diagnostic(log_bytes: int | None = None):
         which_python,
         get_python_version,
         "pip freeze",
-        test_conn("compute.api.globus.org", 443),
-        test_conn("amqps.funcx.org", 5671),
+        test_conn(web_svc_host, 443),
+        test_conn(amqp_svc_host, 5671),
         "ip addr",
         "ifconfig",
         "ip route",

--- a/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
+++ b/compute_endpoint/globus_compute_endpoint/self_diagnostic.py
@@ -15,6 +15,7 @@ from globus_compute_sdk.sdk._environments import (
     get_amqp_service_host,
     get_web_service_url,
 )
+from globus_compute_sdk.sdk.web_client import WebClient
 
 
 def cat(path: str, wildcard: bool = False, max_bytes: int | None = None):
@@ -58,6 +59,16 @@ def test_conn(host: str, port: int, timeout: int = 5):
     return kernel
 
 
+def get_service_versions(base_url: str):
+    def kernel():
+        wc = WebClient(base_url=base_url)
+        res = wc.get_version(service="all")
+        click.echo(f"{res}\n")
+
+    kernel.display_name = f"func:get_service_versions({base_url})"  # type: ignore
+    return kernel
+
+
 def get_python_version():
     click.echo(f"Python version {sys.version}\n")
 
@@ -87,7 +98,8 @@ def _run_command(cmd: str):
 
 
 def run_self_diagnostic(log_bytes: int | None = None):
-    web_svc_host = urlparse(get_web_service_url()).netloc
+    web_svc_url = get_web_service_url()
+    web_svc_host = urlparse(web_svc_url).netloc
     amqp_svc_host = get_amqp_service_host()
 
     commands = [
@@ -99,6 +111,7 @@ def run_self_diagnostic(log_bytes: int | None = None):
         "pip freeze",
         test_conn(web_svc_host, 443),
         test_conn(amqp_svc_host, 5671),
+        get_service_versions(web_svc_url),
         "ip addr",
         "ifconfig",
         "ip route",

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -444,6 +444,29 @@ def test_self_diagnostic(
     assert log_data in stdout
 
 
+@pytest.mark.parametrize("env", ["sandbox", "integration", "staging"])
+def test_self_diagnostic_sdk_environment(
+    mocker: MockFixture,
+    mock_command_ensure,
+    mock_cli_state,
+    fs: fakefs.FakeFilesystem,
+    run_line: t.Callable,
+    monkeypatch,
+    env: str,
+):
+    mocker.patch("socket.create_connection")
+    mock_test_conn = mocker.patch(
+        "globus_compute_endpoint.self_diagnostic.test_conn",
+        return_value=lambda: "Success!",
+    )
+
+    monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", env)
+    run_line("self-diagnostic")
+
+    assert f"compute.api.{env}.globuscs.info" in mock_test_conn.call_args_list[0][0]
+    assert f"compute.amqps.{env}.globuscs.info" in mock_test_conn.call_args_list[1][0]
+
+
 def test_self_diagnostic_gzip(
     mocker: MockFixture,
     mock_cli_state,

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -17,6 +17,7 @@ from globus_compute_endpoint.cli import app, init_config_dir
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
+from globus_compute_sdk.sdk.web_client import WebClient
 from pyfakefs import fake_filesystem as fakefs
 from pytest_mock import MockFixture
 
@@ -419,6 +420,7 @@ def test_self_diagnostic(
     ep_name,
 ):
     mocker.patch("socket.create_connection")
+    mocker.patch.object(WebClient, "get_version")
 
     home_path = os.path.expanduser("~")
     ep_dir_path = f"{home_path}/.globus_compute/{ep_name}/"
@@ -438,7 +440,7 @@ def test_self_diagnostic(
     res = run_line("self-diagnostic")
     stdout = res.stdout_bytes.decode("utf-8")
 
-    assert stdout.count("== Diagnostic") >= 16
+    assert stdout.count("== Diagnostic") >= 17
     assert stdout.count("was successful!") == 2
     assert conf_data in stdout
     assert log_data in stdout
@@ -455,6 +457,7 @@ def test_self_diagnostic_sdk_environment(
     env: str,
 ):
     mocker.patch("socket.create_connection")
+    mocker.patch.object(WebClient, "get_version")
     mock_test_conn = mocker.patch(
         "globus_compute_endpoint.self_diagnostic.test_conn",
         return_value=lambda: "Success!",
@@ -475,6 +478,7 @@ def test_self_diagnostic_gzip(
     run_line: t.Callable,
 ):
     mocker.patch("socket.create_connection")
+    mocker.patch.object(WebClient, "get_version")
 
     res = run_line("self-diagnostic --gzip")
     stdout = res.stdout_bytes.decode("utf-8")
@@ -488,7 +492,7 @@ def test_self_diagnostic_gzip(
     with gzip.open(fname, "rb") as f:
         contents = f.read().decode("utf-8")
 
-    assert contents.count("== Diagnostic") >= 16
+    assert contents.count("== Diagnostic") >= 17
 
 
 @pytest.mark.parametrize("test_data", [(True, 1), (False, 0.5), (False, "")])
@@ -503,6 +507,7 @@ def test_self_diagnostic_log_size(
     should_succeed, kb = test_data
 
     mocker.patch("socket.create_connection")
+    mocker.patch.object(WebClient, "get_version")
 
     def run_cmd():
         res = run_line(f"self-diagnostic --log-kb {kb}")
@@ -510,7 +515,7 @@ def test_self_diagnostic_log_size(
 
     if should_succeed:
         stdout = run_cmd()
-        assert stdout.count("== Diagnostic") >= 16
+        assert stdout.count("== Diagnostic") >= 17
     else:
         with pytest.raises(AssertionError):
             stdout = run_cmd()
@@ -531,6 +536,7 @@ def test_self_diagnostic_log_size_limit(
     fs.create_dir(ep_dir_path)
 
     mocker.patch("socket.create_connection")
+    mocker.patch.object(WebClient, "get_version")
 
     def run_cmd():
         # Limit log file size to 1 KB

--- a/compute_sdk/globus_compute_sdk/sdk/_environments.py
+++ b/compute_sdk/globus_compute_sdk/sdk/_environments.py
@@ -12,7 +12,7 @@ def _get_envname():
     )
 
 
-def get_web_service_url(envname: str | None) -> str:
+def get_web_service_url(envname: str | None = None) -> str:
     env = envname or _get_envname()
     urls = {
         "production": "https://compute.api.globus.org",
@@ -25,6 +25,20 @@ def get_web_service_url(envname: str | None) -> str:
         urls[test_env] = f"https://compute.api.{test_env}.globuscs.info"
 
     return urls.get(env, urls["production"])
+
+
+def get_amqp_service_host(env_name: str | None = None) -> str:
+    env = env_name or _get_envname()
+    hosts = {
+        "production": "amqps.funcx.org",
+        "dev": "amqps.dev.funcx.org",
+        "preview": "compute.amqps.preview.globus.org",
+        "local": "localhost",
+    }
+    for test_env in ["sandbox", "test", "integration", "staging"]:
+        hosts[test_env] = f"compute.amqps.{test_env}.globuscs.info"
+
+    return hosts.get(env, hosts["production"])
 
 
 def remove_url_path(url: str):

--- a/compute_sdk/tests/unit/test_environment_lookups.py
+++ b/compute_sdk/tests/unit/test_environment_lookups.py
@@ -1,5 +1,8 @@
 import pytest
-from globus_compute_sdk.sdk._environments import get_web_service_url
+from globus_compute_sdk.sdk._environments import (
+    get_amqp_service_host,
+    get_web_service_url,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -26,3 +29,22 @@ def test_web_service_url(monkeypatch):
     # GLOBUS_SDK_ENVIRONMENT should override FUNCX_SDK_ENVIRONMENT
     monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", "sandbox")
     assert get_web_service_url(None) == env_url_map["sandbox"]
+
+
+def test_get_amqp_service_host(monkeypatch):
+    env_url_map = {
+        None: "amqps.funcx.org",
+        "production": "amqps.funcx.org",
+        "sandbox": "compute.amqps.sandbox.globuscs.info",
+        "invalid-env": "amqps.funcx.org",
+    }
+
+    for env, url in env_url_map.items():
+        assert get_amqp_service_host(env) == url
+
+    monkeypatch.setenv("FUNCX_SDK_ENVIRONMENT", "production")
+    assert get_amqp_service_host(None) == env_url_map["production"]
+
+    # GLOBUS_SDK_ENVIRONMENT should override FUNCX_SDK_ENVIRONMENT
+    monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", "sandbox")
+    assert get_amqp_service_host(None) == env_url_map["sandbox"]


### PR DESCRIPTION
# Description

The `self-diagnostic` endpoint command is now aware of the `GLOBUS_SDK_ENVIRONMENT` environment variable and will test connectivity to the relevant services.

I also added the `/version` API endpoint response to the `self-diagnostic` output.

[sc-26629]

## Type of change

- New feature (non-breaking change that adds functionality)
