### PR TITLE
Add AuthorizerLoginManager

### DIFF
--- a/changelog.d/20230902_101610_rchard_add_token_login_manager.rst
+++ b/changelog.d/20230902_101610_rchard_add_token_login_manager.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added a new ``AuthorizerLoginManager`` to create a login_manager from
+  existing tokens.  This removes the need to implement a custom login manager
+  to create a client from authorizers.

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/__init__.py
@@ -1,3 +1,4 @@
+from .authorizer_login_manager import AuthorizerLoginManager
 from .decorators import requires_login
 from .manager import ComputeScopes, LoginManager
 from .protocol import LoginManagerProtocol
@@ -7,4 +8,5 @@ __all__ = (
     "ComputeScopes",
     "LoginManagerProtocol",
     "requires_login",
+    "AuthorizerLoginManager",
 )

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/authorizer_login_manager.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+
+import globus_sdk
+from globus_compute_sdk.sdk.login_manager.manager import LoginManager
+from globus_compute_sdk.sdk.login_manager.protocol import LoginManagerProtocol
+from globus_compute_sdk.sdk.web_client import WebClient
+from globus_sdk.scopes import AuthScopes
+
+from .manager import ComputeScopeBuilder
+
+log = logging.getLogger(__name__)
+
+ComputeScopes = ComputeScopeBuilder()
+
+
+class AuthorizerLoginManager(LoginManagerProtocol):
+    """
+    Implements a LoginManager that can be instantiated with authorizers.
+    This manager can be used to create an Executor with authorizers created
+    from previously acquired tokens, rather than requiring a Native App login
+    flow or Client credentials.
+    """
+
+    def __init__(self, authorizers: dict[str, globus_sdk.RefreshTokenAuthorizer]):
+        self.authorizers = authorizers
+
+    def get_auth_client(self) -> globus_sdk.AuthClient:
+        return globus_sdk.AuthClient(authorizer=self.authorizers[AuthScopes.openid])
+
+    def get_web_client(
+        self, *, base_url: str | None = None, app_name: str | None = None
+    ) -> WebClient:
+        return WebClient(
+            base_url=base_url,
+            app_name=app_name,
+            authorizer=self.authorizers[ComputeScopes.resource_server],
+        )
+
+    def ensure_logged_in(self):
+        """Ensure authorizers for each of the required scopes are present."""
+
+        for server in LoginManager.SCOPES:
+            if server not in self.authorizers:
+                log.error(f"Required authorizer for {server} is not present.")
+                raise LookupError(
+                    f"{type(self).__name__} could not find authorizer for {server}"
+                )
+
+    def logout(self):
+        log.warning(f"Logout cannot be invoked from an {type(self).__name__}.")

--- a/compute_sdk/tests/unit/test_authorizer_login_manager.py
+++ b/compute_sdk/tests/unit/test_authorizer_login_manager.py
@@ -1,19 +1,38 @@
 from itertools import chain, combinations
 
 import pytest
-from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager
-from globus_compute_sdk.sdk.login_manager.manager import LoginManager
+from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager, LoginManager
+from globus_sdk.scopes import AuthScopes
 
 CID_KEY = "FUNCX_SDK_CLIENT_ID"
 CSC_KEY = "FUNCX_SDK_CLIENT_SECRET"
-MOCK_BASE = "globus_compute_sdk.sdk.login_manager"
+_MOCK_BASE = "globus_compute_sdk.sdk.login_manager."
 
 
 @pytest.fixture
 def logman(mocker, tmp_path):
-    home = mocker.patch(f"{MOCK_BASE}.tokenstore._home")
+    home = mocker.patch(f"{_MOCK_BASE}tokenstore._home")
     home.return_value = tmp_path
     return AuthorizerLoginManager({})
+
+
+def test_auth_client_requires_authorizer_openid_scope(mocker):
+    alm = AuthorizerLoginManager({})
+    with pytest.raises(KeyError) as pyt_exc:
+        alm.get_auth_client()
+    assert AuthScopes.openid in str(pyt_exc)
+
+
+def test_does_not_open_local_cred_storage(mocker, randomstring):
+    test_authorizer = randomstring()
+    mock_lm = mocker.patch(f"{_MOCK_BASE}authorizer_login_manager.LoginManager")
+    mock_lm.SCOPES = {test_authorizer}
+    with pytest.raises(LookupError):
+        AuthorizerLoginManager({}).ensure_logged_in()
+
+    alm = AuthorizerLoginManager({test_authorizer: "asdf"})
+    assert alm.ensure_logged_in() is None, "Test setup: verified SCOPES is checked"
+    assert not mock_lm.called, "Do not instantiate; do not create creds storage"
 
 
 @pytest.mark.parametrize(
@@ -40,8 +59,9 @@ def test_ensure_logged_in(mocker, logman, missing_keys):
         assert f"could not find authorizer for {missing_keys[0]}" in err.value.args[0]
 
 
-def test_warns_upon_logout_attempt(mocker):
-    mock_log = mocker.patch(f"{MOCK_BASE}.authorizer_login_manager.log")
-    alm = AuthorizerLoginManager(mocker.Mock())
+def test_warns_upon_logout_attempts(mocker):
+    mock_log = mocker.patch(f"{_MOCK_BASE}authorizer_login_manager.log")
+    alm = AuthorizerLoginManager({})
+    assert not mock_log.warning.called
     alm.logout()
     assert mock_log.warning.called

--- a/compute_sdk/tests/unit/test_authorizer_login_manager.py
+++ b/compute_sdk/tests/unit/test_authorizer_login_manager.py
@@ -1,0 +1,47 @@
+from itertools import chain, combinations
+
+import pytest
+from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager
+from globus_compute_sdk.sdk.login_manager.manager import LoginManager
+
+CID_KEY = "FUNCX_SDK_CLIENT_ID"
+CSC_KEY = "FUNCX_SDK_CLIENT_SECRET"
+MOCK_BASE = "globus_compute_sdk.sdk.login_manager"
+
+
+@pytest.fixture
+def logman(mocker, tmp_path):
+    home = mocker.patch(f"{MOCK_BASE}.tokenstore._home")
+    home.return_value = tmp_path
+    return AuthorizerLoginManager({})
+
+
+@pytest.mark.parametrize(
+    "missing_keys",
+    list(
+        chain(
+            combinations(LoginManager.SCOPES, 1),
+            combinations(LoginManager.SCOPES, 2),
+            [()],
+        )
+    ),
+)
+def test_ensure_logged_in(mocker, logman, missing_keys):
+    _authorizers = dict(LoginManager.SCOPES)
+    for k in missing_keys:
+        _authorizers.pop(k, None)
+
+    logman.authorizers = _authorizers
+
+    if missing_keys:
+        with pytest.raises(LookupError) as err:
+            logman.ensure_logged_in()
+
+        assert f"could not find authorizer for {missing_keys[0]}" in err.value.args[0]
+
+
+def test_warns_upon_logout_attempt(mocker):
+    mock_log = mocker.patch(f"{MOCK_BASE}.authorizer_login_manager.log")
+    alm = AuthorizerLoginManager(mocker.Mock())
+    alm.logout()
+    assert mock_log.warning.called


### PR DESCRIPTION
# Description

This PR introduces an AuthorizerLoginManager to create clients from existing tokens.

Previously, if one wanted to create a client from existing tokens they had to implement a custom login manager to serve authorizers as needed. 

## Type of change

- New feature (non-breaking change that adds functionality)
