### PR TITLE
Create decorator to handle Auth API errors

### DIFF
--- a/changelog.d/20230906_131715_30907815+rjmello_auth_errors.rst
+++ b/changelog.d/20230906_131715_30907815+rjmello_auth_errors.rst
@@ -1,0 +1,4 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- A helpful message will be printed to the terminal in the event of an auth API error.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -17,6 +17,7 @@ import click
 from click import ClickException
 from globus_compute_endpoint.endpoint.config.utils import get_config, load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
+from globus_compute_endpoint.exception_handling import handle_auth_errors
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_endpoint.self_diagnostic import run_self_diagnostic
 from globus_compute_endpoint.version import DEPRECATION_FUNCX_ENDPOINT
@@ -249,6 +250,7 @@ def configure_endpoint(
 @name_or_uuid_arg
 @start_options
 @common_options
+@handle_auth_errors
 def start_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
     """Start an endpoint
 
@@ -504,6 +506,7 @@ def _do_start_endpoint(
     help="send stop signal to all endpoints with this UUID, local or elsewhere",
 )
 @common_options
+@handle_auth_errors
 def stop_endpoint(*, ep_dir: pathlib.Path, remote: bool):
     """Stops an endpoint using the pidfile"""
     _do_stop_endpoint(ep_dir=ep_dir, remote=remote)
@@ -565,6 +568,7 @@ def list_endpoints():
     "--yes", default=False, is_flag=True, help="Do not ask for confirmation to delete."
 )
 @common_options
+@handle_auth_errors
 def delete_endpoint(*, ep_dir: pathlib.Path, force: bool, yes: bool):
     """Deletes an endpoint and its config."""
     if not yes:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -28,7 +28,7 @@ from globus_compute_endpoint.endpoint.result_store import ResultStore
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_sdk.sdk.client import Client
-from globus_sdk import GlobusAPIError, NetworkError
+from globus_sdk import AuthAPIError, GlobusAPIError, NetworkError
 
 log = logging.getLogger(__name__)
 
@@ -604,6 +604,9 @@ class Endpoint:
             fx_client = Endpoint.get_funcx_client(endpoint_config)
             fx_client.delete_endpoint(endpoint_id)
             log.info(f"Endpoint <{ep_name}> has been deleted from the web service")
+        except AuthAPIError:
+            # Send to the exception handler
+            raise
         except GlobusAPIError as e:
             log.warning(
                 f"Endpoint <{ep_name}> could not be deleted from the web service"


### PR DESCRIPTION
# Description

Created a decorator that will capture any `globus_sdk.AuthAPIError` exceptions then print a helpful message to the terminal. I've applied the decorator to all commands that use an SDK method in which auth is required.

[sc-25677]

## Type of change

- New feature (non-breaking change that adds functionality)
