### PR TITLE
Include Python and SDK versions in function reg.

### DIFF
--- a/changelog.d/20230911_113153_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20230911_113153_30907815+rjmello_HEAD.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The SDK now supports defining metadata (Python and SDK versions) when registering
+  a function. This information is automatically included when using the ``Executor``.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -15,7 +15,10 @@ from globus_compute_sdk.errors import (
 from globus_compute_sdk.sdk._environments import get_web_service_url
 from globus_compute_sdk.sdk.utils import check_version
 from globus_compute_sdk.sdk.utils.uuid_like import UUID_LIKE_T
-from globus_compute_sdk.sdk.web_client import FunctionRegistrationData
+from globus_compute_sdk.sdk.web_client import (
+    FunctionRegistrationData,
+    FunctionRegistrationMetadata,
+)
 from globus_compute_sdk.serialize import ComputeSerializer, SerializationStrategy
 from globus_compute_sdk.version import __version__, compare_versions
 
@@ -559,6 +562,7 @@ class Client:
         function_name=None,
         container_uuid=None,
         description=None,
+        metadata: dict | None = None,
         public=False,
         group=None,
         searchable=None,
@@ -575,6 +579,8 @@ class Client:
             Container UUID from registration with Globus Compute
         description : str
             Description of the file
+        metadata : dict
+            Function metadata (E.g., Python version used when serializing the function)
         public : bool
             Whether or not the function is publicly accessible. Default = False
         group : str
@@ -600,6 +606,7 @@ class Client:
             function=function,
             container_uuid=container_uuid,
             description=description,
+            metadata=FunctionRegistrationMetadata(**metadata) if metadata else None,
             public=public,
             group=group,
             serializer=self.fx_serializer,

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import json
 import logging
 import os
+import platform
 import queue
 import random
 import sys
@@ -25,6 +26,7 @@ else:
 import pika
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result
+from globus_compute_sdk import __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.client import Client
@@ -348,7 +350,14 @@ class Executor(concurrent.futures.Executor):
 
         log.debug("Function not registered. Registering: %s", fn)
         func_register_kwargs.pop("function", None)  # just to be sure
-        reg_kwargs = {"function_name": fn.__name__, "container_uuid": self.container_id}
+        reg_kwargs = {
+            "function_name": fn.__name__,
+            "container_uuid": self.container_id,
+            "metadata": {
+                "python_version": platform.python_version(),
+                "sdk_version": __version__,
+            },
+        }
         reg_kwargs.update(func_register_kwargs)
 
         try:

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -24,6 +24,18 @@ def _get_packed_code(
     return serializer.pack_buffers([serializer.serialize(func)])
 
 
+class FunctionRegistrationMetadata:
+    def __init__(self, python_version: str, sdk_version: str):
+        self.python_version = python_version
+        self.sdk_version = sdk_version
+
+    def to_dict(self):
+        return {
+            "python_version": self.python_version,
+            "sdk_version": self.sdk_version,
+        }
+
+
 class FunctionRegistrationData:
     def __init__(
         self,
@@ -33,6 +45,7 @@ class FunctionRegistrationData:
         function_code: t.Optional[str] = None,
         container_uuid: t.Optional[UUID_LIKE_T] = None,
         description: t.Optional[str] = None,
+        metadata: t.Optional[FunctionRegistrationMetadata] = None,
         public: bool = False,
         group: t.Optional[str] = None,
         serializer: t.Optional[ComputeSerializer] = None,
@@ -53,6 +66,7 @@ class FunctionRegistrationData:
             str(container_uuid) if container_uuid is not None else container_uuid
         )
         self.description = description
+        self.metadata = metadata
         self.public = public
         self.group = group
 
@@ -62,6 +76,7 @@ class FunctionRegistrationData:
             "function_code": self.function_code,
             "container_uuid": self.container_uuid,
             "description": self.description,
+            "metadata": self.metadata.to_dict(),
             "public": self.public,
             "group": self.group,
         }

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import random
 import threading
 import typing as t
@@ -10,7 +11,7 @@ import pika
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result, ResultErrorDetails
-from globus_compute_sdk import Client, Executor
+from globus_compute_sdk import Client, Executor, __version__
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.executor import _ResultWatcher, _TaskSubmissionInfo
@@ -241,6 +242,17 @@ def test_register_function_sends_container_id(gc_executor, container_id):
 
     expected_container_id = as_optional_uuid(container_id)
     assert k["container_uuid"] == expected_container_id
+
+
+def test_register_function_sends_metadata(gc_executor):
+    gcc, gce = gc_executor
+
+    gce.register_function(noop)
+
+    assert gcc.register_function.called
+    a, k = gcc.register_function.call_args
+    assert k["metadata"].get("python_version") == platform.python_version()
+    assert k["metadata"].get("sdk_version") == __version__
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

To assist with debugging and error handling related to serialization, we record the Python and SDK version that are used when serializing a function.

[sc-25861]

## Type of change

- New feature (non-breaking change that adds functionality)
