### PR TITLE
Bugfix: enable function registration without metadata

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -76,7 +76,7 @@ class FunctionRegistrationData:
             "function_code": self.function_code,
             "container_uuid": self.container_uuid,
             "description": self.description,
-            "metadata": self.metadata.to_dict(),
+            "metadata": self.metadata.to_dict() if self.metadata else None,
             "public": self.public,
             "group": self.group,
         }


### PR DESCRIPTION
# Description

Fixed a bug in which registering a function via `Client.register_function()` without a `metadata` argument raised an exception.

[sc-25861]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
