### PR TITLE
Create `Client.get_function` method

### DIFF
--- a/changelog.d/20230913_094159_30907815+rjmello.rst
+++ b/changelog.d/20230913_094159_30907815+rjmello.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added a ``Client.get_function`` method to submit a request for details about a registered
+  function, such as name, description, serialized source code, python version, etc.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -616,6 +616,24 @@ class Client:
         return r.data["function_uuid"]
 
     @requires_login
+    def get_function(self, function_id: UUID_LIKE_T):
+        """Submit a request for details about a registered function.
+
+        Parameters
+        ----------
+        function_id : UUID | str
+            UUID of the registered function
+
+        Returns
+        -------
+        dict
+            Information about the registered function, such as name, description,
+            serialized source code, python version, etc.
+        """
+        r = self.web_client.get_function(function_id)
+        return r.data
+
+    @requires_login
     def register_container(self, location, container_type, name="", description=""):
         """Register a container with the Globus Compute service.
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -228,6 +228,9 @@ class WebClient(globus_sdk.BaseClient):
         )
         return self.post("/v2/functions", data=data)
 
+    def get_function(self, function_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
+        return self.get(f"/v2/functions/{function_id}")
+
     def get_whitelist(self, endpoint_id: UUID_LIKE_T) -> globus_sdk.GlobusHTTPResponse:
         return self.get(f"/v2/endpoints/{endpoint_id}/whitelist")
 

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -318,6 +318,16 @@ def test_register_function_no_metadata():
     assert func_data.metadata is None
 
 
+def test_get_function():
+    func_uuid_str = str(uuid.uuid4())
+    gcc = gc.Client(do_version_check=False, login_manager=mock.Mock())
+    gcc.web_client = mock.MagicMock()
+
+    gcc.get_function(func_uuid_str)
+
+    assert gcc.web_client.get_function.called_with(func_uuid_str)
+
+
 def test_delete_function():
     func_uuid_str = str(uuid.uuid4())
     gcc = gc.Client(do_version_check=False, login_manager=mock.Mock())

--- a/compute_sdk/tests/unit/test_web_client.py
+++ b/compute_sdk/tests/unit/test_web_client.py
@@ -113,6 +113,20 @@ def test_multi_tenant_post(client, multi_tenant):
         assert "multi_tenant" not in req_body
 
 
+def test_get_function(client: WebClient, randomstring: t.Callable):
+    func_uuid_str = str(uuid.uuid4())
+    expected_response = randomstring()
+    responses.add(
+        responses.GET,
+        f"https://api.funcx/v2/functions/{func_uuid_str}",
+        json={"some_key": expected_response},
+    )
+
+    res = client.get_function(func_uuid_str)
+
+    assert res["some_key"] == expected_response
+
+
 def test_delete_function(client: WebClient, randomstring: t.Callable):
     func_uuid_str = str(uuid.uuid4())
     expected_response = randomstring()


### PR DESCRIPTION
# Description

Added a `Client.get_function` method to submit a request for details about a registered function, such as name, description, serialized source code, python version, etc.

[sc-25861]

## Type of change

- New feature (non-breaking change that adds functionality)
