### PR TITLE
Remove noisy log during test

### DIFF
--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -96,10 +96,12 @@ def cli_runner():
 
 @pytest.fixture
 def run_line(cli_runner):
-    def func(argline, *, assert_exit_code: int | None = 0):
+    def func(argline, *, assert_exit_code: int | None = 0, stdin=None):
         args = shlex.split(argline) if isinstance(argline, str) else argline
 
-        result = cli_runner.invoke(app, args)
+        if stdin is None:
+            stdin = "{}"  # silence some logs; incurred by invoke's sys.stdin choice
+        result = cli_runner.invoke(app, args, input=stdin)
         if assert_exit_code is not None:
             assert result.exit_code == assert_exit_code, (result.stdout, result.stderr)
         return result


### PR DESCRIPTION
Due to `click.CliRunner`'s implementation for testing sys.stdin, and our use of sys.stdin for credentials, we're hitting the early `log.debug()` call and getting:

    ... Invalid info on stdin -- (JSONDecodeError) Expecting value: line 1 column 1 (char 0)

when showing the verbose debugging output.  This is noise that is unrelated to the tests, so opt instead to give a default value that avoids that log call.

## Type of change

- Code maintenance/cleanup
