### PR TITLE
Refactor engine test fixtures

### DIFF
--- a/compute_endpoint/tests/unit/test_status_reporting.py
+++ b/compute_endpoint/tests/unit/test_status_reporting.py
@@ -8,20 +8,12 @@ from globus_compute_endpoint import engines
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("engine_type", ["proc_pool", "thread_pool", "gc"])
-def test_status_reporting(
-    proc_pool_engine: engines.ProcessPoolEngine,
-    thread_pool_engine: engines.ThreadPoolEngine,
-    gc_engine: engines.GlobusComputeEngine,
-    engine_heartbeat: float,
-    engine_type: str,
-):
-    if engine_type == "proc_pool":
-        engine = proc_pool_engine
-    elif engine_type == "thread_pool":
-        engine = thread_pool_engine
-    else:
-        engine = gc_engine
+@pytest.mark.parametrize(
+    "engine_type",
+    (engines.ProcessPoolEngine, engines.ThreadPoolEngine, engines.GlobusComputeEngine),
+)
+def test_status_reporting(engine_type, engine_runner, engine_heartbeat: float):
+    engine = engine_runner(engine_type)
 
     report = engine.get_status_report()
     assert isinstance(report, EPStatusReport)


### PR DESCRIPTION
Motivated by an upcoming change, remove instantiation of unused engines for parameterized tests.  Instead, only instantiate each class under test for its specific test parameter.  As a bonus win, there's now only a single fixture ("single path") for engine starting and stopping.

For the reviewer: the change of consequence is removing from `tests/conftest.py` the three fixtures:

- `proc_pool_engine`
- `thread_pool_engine`
- `gc_engine`

and replacing them with `engine_runner`.  The rest of the changes are "just" flushing that change to all uses.

## Type of change

- Code maintenance/cleanup
