### PR TITLE
Add Engine .shutdown() expected interface

### DIFF
--- a/changelog.d/20230918_120556_kevin_address_gc_engine_shutdown_bug.rst
+++ b/changelog.d/20230918_120556_kevin_address_gc_engine_shutdown_bug.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fix an innocuous bug during cleanup after having successfully shutdown an
+  Endpoint using the ``GlobusComputeEngine``.
+

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -185,3 +185,7 @@ class GlobusComputeEngineBase(ABC):
         future = self._submit(execute_task, task_id, packed_task)
         self._setup_future_done_callback(task_id, future)
         return future
+
+    @abstractmethod
+    def shutdown(self, /, **kwargs) -> None:
+        raise NotImplementedError()

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -174,8 +174,8 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             task_statuses=task_status_deltas,
         )
 
-    def shutdown(self):
+    def shutdown(self, /, **kwargs) -> None:
         self._status_report_thread.stop()
         if self.strategy:
             self.strategy.close()
-        return self.executor.shutdown()
+        self.executor.shutdown()

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -817,7 +817,7 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
 
         return status
 
-    def shutdown(self, hub=True, targets="all", block=False):
+    def shutdown(self, /, hub=True, targets="all", block=False, **kwargs) -> None:
         """Shutdown the Engine, including all workers and controllers.
 
         This is not implemented.
@@ -844,7 +844,6 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
                 if self.queue_proc.exitcode is None:
                     self.queue_proc.kill()
             log.info("Finished HighThroughputEngine shutdown attempt")
-        return True
 
     def cancel_task(self, task_id: uuid.UUID | str) -> bool:
         """

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -111,7 +111,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
     def status_polling_interval(self) -> int:
         return 30
 
-    def shutdown(self):
+    def shutdown(self, /, block=False, **kwargs) -> None:
         self._status_report_thread.stop()
         if self.executor:
-            self.executor.shutdown()
+            self.executor.shutdown(wait=block)

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -118,6 +118,6 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
     def status(self) -> dict:
         return {}
 
-    def shutdown(self):
+    def shutdown(self, /, block=False, **kwargs) -> None:
         self._status_report_thread.stop()
-        self.executor.shutdown()
+        self.executor.shutdown(wait=block)

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -138,7 +138,7 @@ def engine_runner(tmp_path, engine_heartbeat) -> t.Callable:
 
     yield _runner
     for ngin in engines_to_shutdown:
-        ngin.shutdown()
+        ngin.shutdown(block=True)
 
 
 ###


### PR DESCRIPTION
Commit 8effb2a1b56397ae4e6873aa1f67ce51ccf9adaf assumed an interface for `EngineBase.shutdown()` that accepted `block` as an argument.  Unfortunately, not all engines implement this keyword; those using the `GlobusComputeEngine` would receive a traceback after shutdown (during cleanup) like:

```python
Traceback (most recent call last):
  File "VENVBIN/bin/globus-compute-endpoint", line 33, in <module>
    sys.exit(load_entry_point('globus-compute-endpoint', 'console_scripts', 'globus-compute-endpoint')())
  ...
  File "VENV/globus_compute_endpoint/endpoint/interchange.py", line 302, in start
    self.cleanup()
  File "VENV/globus_compute_endpoint/endpoint/interchange.py", line 206, in cleanup
    self.executor.shutdown(block=True)
TypeError: GlobusComputeEngine.shutdown() got an unexpected keyword argument 'block'
```

Address that by teaching the `GlobusComputeEngineBase` what is an acceptable interface for the `.shutdown()` method, and then honoring that interface in the subclasses.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
