### PR TITLE
Remove unused metadata entries

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -781,18 +781,12 @@ class Endpoint:
 
     @staticmethod
     def get_metadata(config: Config) -> dict:
-        metadata: dict = {}
-
-        metadata["endpoint_version"] = __version__
-        metadata["hostname"] = socket.getfqdn()
-
-        # should be more accurate than `getpass.getuser()` in non-login situations
-        metadata["local_user"] = pwd.getpwuid(os.getuid()).pw_name
-
-        # the following are read from the HTTP request by the web service, but can be
-        # overridden here if desired:
-        metadata["ip_address"] = None
-        metadata["sdk_version"] = None
+        metadata: dict = {
+            "endpoint_version": __version__,
+            "hostname": socket.getfqdn(),
+            # should be more accurate than `getpass.getuser()` in non-login situations
+            "local_user": pwd.getpwuid(os.getuid()).pw_name,
+        }
 
         try:
             metadata["config"] = serialize_config(config)

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -457,9 +457,6 @@ def test_endpoint_get_metadata(mocker):
     for k, v in mock_data.items():
         assert meta[k] == v
 
-    assert meta["ip_address"] is None
-    assert meta["sdk_version"] is None
-
     config = meta["config"]
     assert "funcx_service_address" in config
     assert len(config["executors"]) == 1


### PR DESCRIPTION
These two entries currently allow a motivated personality (perhaps a dev?) to override what the API automatically discerns regarding the SDK version.  This has so far not been utilized and has no backing customer need.  So, under YAGNI, removing until a more-specific need arises.

Meanwhile, refactor the dict creation to placate the IDE warning ...

## Type of change

- Code maintenance/cleanup
