### PR TITLE
Show 5 slowest test durations

### DIFF
--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -10,7 +10,7 @@ extras = test
 usedevelop = true
 commands =
     coverage erase
-    coverage run -m pytest {posargs}
+    coverage run -m pytest --durations 5 {posargs}
     coverage report
 
 [testenv:mypy]

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -9,7 +9,7 @@ usedevelop = true
 extras = test
 commands =
     coverage erase
-    coverage run -m pytest {posargs}
+    coverage run -m pytest --durations 5 {posargs}
     coverage report --skip-covered
 
 [testenv:mypy]


### PR DESCRIPTION
Motivated by a (slow) progression of tests beginning to take longer, help to identify the culprits on a regular basis.

After the tests complete, we should now see output resembling:
```
========================= slowest 5 durations ==========================
0.16s call     tests/integration/test_executor_int.py::test_executor_atexit_handler_catches_all_instances
0.12s call     tests/unit/test_executor.py::test_task_submitter_stops_executor_on_upstream_error_response
0.10s call     tests/unit/test_executor.py::test_task_submitter_respects_batch_size[10]
0.10s teardown tests/unit/test_executor.py::test_user_endpoint_config_added_to_batch
0.10s call     tests/unit/test_executor.py::test_task_submitter_stops_executor_on_exception
```

## Type of change

- Code maintenance/cleanup
