### PR TITLE
Show precise import error if debugging

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -27,8 +27,12 @@ from globus_compute_sdk.sdk.login_manager.whoami import print_whoami_info
 
 try:
     from globus_compute_endpoint.endpoint.endpoint_manager import EndpointManager
-except ImportError:
+except ImportError as _e:
     _has_multi_tenant = False
+    if "--debug" in sys.argv and sys.stderr.isatty():
+        # We haven't set up logging yet so manually print for now
+        print(f"(DEBUG) Failed to import from file: {__file__}", file=sys.stderr)
+        print(f"(DEBUG) [{type(_e).__name__}] {_e}", file=sys.stderr)
 else:
     _has_multi_tenant = True
 


### PR DESCRIPTION
Save a couple of minutes of the next dev's head scratching when a known-working module mysteriously "doesn't exist."

## Type of change

- Code maintenance/cleanup