### PR TITLE
Allow passing in MT creds on stdin

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -485,7 +485,7 @@ def _do_start_endpoint(
         ep_config = get_config(ep_dir)
 
     if die_with_parent:
-        # The endpoint cannot die with it's parent if it
+        # The endpoint cannot die with its parent if it
         # doesn't have one :)
         ep_config.detach_endpoint = False
         log.debug("The --die-with-parent flag has set detach_endpoint to False")
@@ -495,7 +495,7 @@ def _do_start_endpoint(
             raise ClickException(
                 "multi-tenant endpoints are not supported on this system"
             )
-        epm = EndpointManager(ep_dir, endpoint_uuid, ep_config)
+        epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
         epm.start()
     else:
         get_cli_endpoint().start_endpoint(


### PR DESCRIPTION
This is analogous to [PR #1026](https://github.com/funcx-faas/funcX/pull/1026) / dba68f32547d2655817f3f00e0a39abb17a2cfe6 (but for the MT endpoint manager), enabling a dev (the only expected user) to pass in credentials via stdin.  (i.e., `$ gce start mt < some_local_only_creds`)

## Type of change

- New (dev-specific) feature (non-breaking change that adds functionality)