### PR TITLE
Convert certain config fields to tuples

### DIFF
--- a/changelog.d/20230928_123020_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20230928_123020_30907815+rjmello_HEAD.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Defining ``worker_ports``, ``worker_port_range``, or ``interchange_port_range``
+  in an endpoint's YAML config no longer raises an error.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -80,6 +80,9 @@ class EngineModel(BaseConfigModel):
     provider: t.Optional[ProviderModel]
     strategy: t.Optional[StrategyModel]
     address: t.Optional[t.Union[str, AddressModel]]
+    worker_ports: t.Optional[t.Tuple[int, int]]
+    worker_port_range: t.Optional[t.Tuple[int, int]]
+    interchange_port_range: t.Optional[t.Tuple[int, int]]
 
     _validate_type = _validate_import("type", engines)
     _validate_provider = _validate_params("provider")

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -1,0 +1,33 @@
+import typing as t
+
+import pytest
+from globus_compute_endpoint.endpoint.config.model import ConfigModel
+
+
+@pytest.fixture
+def config_dict():
+    return {"engine": {"type": "HighThroughputEngine"}}
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ("worker_ports", (50000, 55000)),
+        ("worker_port_range", (50000, 55000)),
+        ("interchange_port_range", (50000, 55000)),
+    ],
+)
+def test_config_model_tuple_conversions(config_dict: dict, data: t.Tuple[str, t.Tuple]):
+    field, expected_val = data
+
+    config_dict["engine"][field] = expected_val
+    model = ConfigModel(**config_dict)
+    assert getattr(model.engine, field) == expected_val
+
+    config_dict["engine"][field] = list(expected_val)
+    model = ConfigModel(**config_dict)
+    assert getattr(model.engine, field) == expected_val
+
+    config_dict["engine"][field] = 50000
+    with pytest.raises(ValueError):
+        ConfigModel(**config_dict)


### PR DESCRIPTION
# Description

The `yaml.safe_load()` method only supports simple Python objects like integers and lists, but Parsl's `HighThroughputEngine` requires tuples for certain fields. To address this, we leverage Pydantic to convert the relevant field values.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
