### PR TITLE
Handle binary files gracefully in diagnostic

### DIFF
--- a/compute_endpoint/tests/unit/test_self_diagnostic.py
+++ b/compute_endpoint/tests/unit/test_self_diagnostic.py
@@ -1,0 +1,63 @@
+import contextlib
+import io
+import os
+import pathlib
+
+import pytest
+from globus_compute_endpoint.self_diagnostic import cat
+
+
+def test_cat_handles_binary_files_gracefully(fs):
+    bfile = pathlib.Path("/some/binary/file")
+    bfile.parent.mkdir(parents=True)
+    bfile.write_bytes(os.urandom(64))
+    with contextlib.redirect_stdout(io.BytesIO()) as f:
+        cat(str(bfile))()
+    assert len(f.getvalue()) > 64
+
+
+def test_cat_handles_missing_file_gracefully(fs):
+    bfile = pathlib.Path("/some/file")
+    bfile.parent.mkdir(parents=True)
+    with contextlib.redirect_stdout(io.BytesIO()) as f:
+        cat(str(bfile))()
+    fname = str(bfile).encode()
+    expected_header = b"cat " + fname
+    expected_header_hline = b"=" * len(str(bfile))
+    expected_footer_hline = b"-" * len(str(bfile))
+    assert expected_header in f.getvalue()
+    assert expected_header_hline in f.getvalue()
+    assert expected_footer_hline in f.getvalue()
+    assert b"\nNo file named " + fname in f.getvalue()
+
+
+@pytest.mark.parametrize("max_bytes", (-64, -32, -1, None, 0, 1, 32, 64))
+def test_cat_honors_max_bytes(fs, max_bytes):
+    raw_file_size = 100
+    expected_sentinel = b"abcde12345"
+    bfile = pathlib.Path("/some/binary/file")
+    bfile.parent.mkdir(parents=True)
+
+    assert raw_file_size > (max_bytes or 0), "Verify test setup"
+    fdata = expected_sentinel + os.urandom(raw_file_size)
+    fdata = fdata.replace(b"\n", b"X")  # test splits on newline
+    bfile.write_bytes(expected_sentinel + fdata)
+
+    fsize = len(bfile.read_bytes())
+    if max_bytes:
+        assert fsize > max_bytes, "Verify test setup: file size bigger than test"
+
+    with contextlib.redirect_stdout(io.BytesIO()) as f:
+        if max_bytes is None:
+            cat(str(bfile))()
+        else:
+            cat(str(bfile), max_bytes=max_bytes)()
+    payload = b"\n".join(f.getvalue().splitlines()[2:-2])  # remove header and footer
+    payload = payload[3:]  # remove line header
+
+    if max_bytes and max_bytes > 0:
+        assert len(payload) <= max_bytes
+        assert expected_sentinel not in payload
+    else:
+        assert len(payload) == fsize
+        assert expected_sentinel in payload


### PR DESCRIPTION
Rather than trying to decode the binary stream (`open(f, "rb")`), instead just work in binary-land and perform our own line indenting.

While here, add a little more window-dressing to delineate each file, and some specific unit tests:

- Add `===` horizontal line below each `cat <file>` command
- Add `---` horizontal line at end of each `cat` command
- Indent with the pipe to make each file visually standout in log (`<sp>|<sp>`)
- Unit test the `cat` diagnostic command

Prior to this commit, would fail on (errant, but "there") binary files:

    ...
      File "VENV/globus_compute_endpoint/self_diagnostic.py", line 39, in kernel
        content = f.read().decode("utf-8")
    UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 8-9: invalid continuation byte

[sc-27488]

## Type of change

- Bug fix (non-breaking change that fixes an issue)