### PR TITLE
Support Globus auth policies on endpoints

### DIFF
--- a/changelog.d/20231002_152607_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20231002_152607_30907815+rjmello_HEAD.rst
@@ -1,0 +1,11 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Endpoint admins can now define a Globus authentication policy directly in an
+  endpoint's configuration or by using the ``--auth-policy`` flag when running
+  the ``globus-compute-endpoint configure`` command.
+
+  Users are evaluated against the policy when submitting tasks, retrieving endpoint
+  information, etc. For more information regarding Globus authentication policies,
+  visit https://docs.globus.org/api/auth/developer-guide/#authentication-policies.
+  Please note that we do not currently support HA policies.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -234,6 +234,14 @@ def version_command():
     "--display-name",
     help="A human readable display name for the endpoint, if desired",
 )
+@click.option(
+    "--auth-policy",
+    help=(
+        "Endpoint users are evaluated against this Globus authentication policy. "
+        "For more information on Globus authentication policies, visit "
+        "https://docs.globus.org/api/auth/developer-guide/#authentication-policies."
+    ),
+)
 @name_arg
 @common_options
 def configure_endpoint(
@@ -242,6 +250,7 @@ def configure_endpoint(
     endpoint_config: str | None,
     multi_user: bool,
     display_name: str | None,
+    auth_policy: str | None,
 ):
     """Configure an endpoint
 
@@ -258,7 +267,9 @@ def configure_endpoint(
 
     compute_dir = get_config_dir()
     ep_dir = compute_dir / name
-    Endpoint.configure_endpoint(ep_dir, endpoint_config, multi_user, display_name)
+    Endpoint.configure_endpoint(
+        ep_dir, endpoint_config, multi_user, display_name, auth_policy
+    )
 
 
 @app.command(name="start", help="Start an endpoint")

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -95,6 +95,9 @@ class Config(RepresentationMixin):
     allowed_functions : list[str] | None
         List of functions that are allowed to be run on the endpoint
 
+    authentication_policy : str | None
+        Endpoint users are evaluated against this Globus authentication policy
+
     force_mu_allow_same_user : bool
         If set, override the heuristic that determines whether the uid running the
         multi-user endpoint may also run single-user endpoints.
@@ -127,6 +130,7 @@ class Config(RepresentationMixin):
         funcx_service_address=None,
         multi_user: bool | None = None,
         allowed_functions: list[str] | None = None,
+        authentication_policy: str | None = None,
         # Tuning info
         heartbeat_period=30,
         heartbeat_threshold=120,
@@ -175,6 +179,7 @@ class Config(RepresentationMixin):
         self.multi_user = multi_user is True
         self.force_mu_allow_same_user = force_mu_allow_same_user is True
         self.allowed_functions = allowed_functions
+        self.authentication_policy = authentication_policy
 
         # Tuning info
         self.heartbeat_period = heartbeat_period

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -71,12 +71,16 @@ class Endpoint:
         target_path: pathlib.Path,
         multi_user: bool,
         display_name: str | None,
+        auth_policy: str | None,
     ):
         config_text = original_path.read_text()
         config_dict = yaml.safe_load(config_text)
 
         if display_name:
             config_dict["display_name"] = display_name
+
+        if auth_policy:
+            config_dict["authentication_policy"] = auth_policy
 
         if multi_user:
             config_dict["multi_user"] = multi_user
@@ -90,6 +94,7 @@ class Endpoint:
         endpoint_config: pathlib.Path | None = None,
         multi_user=False,
         display_name: str | None = None,
+        auth_policy: str | None = None,
     ):
         """Initialize a clean endpoint dir
 
@@ -98,6 +103,7 @@ class Endpoint:
             the Globus Compute default config file
         :param multi_user: Whether the endpoint is a multi-user endpoint
         :param display_name: A display name to use, if desired
+        :param auth_policy: Globus authentication policy
         """
         log.debug(f"Creating endpoint dir {endpoint_dir}")
         user_umask = os.umask(0o0077)
@@ -120,6 +126,7 @@ class Endpoint:
                 config_target_path,
                 multi_user,
                 display_name,
+                auth_policy,
             )
 
             if multi_user:
@@ -153,6 +160,7 @@ class Endpoint:
         endpoint_config: str | None,
         multi_user: bool = False,
         display_name: str | None = None,
+        auth_policy: str | None = None,
     ):
         ep_name = conf_dir.name
         if conf_dir.exists():
@@ -161,7 +169,9 @@ class Endpoint:
             raise Exception("ConfigExists")
 
         templ_conf_path = pathlib.Path(endpoint_config) if endpoint_config else None
-        Endpoint.init_endpoint_dir(conf_dir, templ_conf_path, multi_user, display_name)
+        Endpoint.init_endpoint_dir(
+            conf_dir, templ_conf_path, multi_user, display_name, auth_policy
+        )
         config_path = Endpoint._config_file_path(conf_dir)
         if multi_user:
             user_conf_tmpl_path = Endpoint.user_config_template_path(conf_dir)
@@ -376,6 +386,7 @@ class Endpoint:
                     multi_user=False,
                     display_name=endpoint_config.display_name,
                     allowed_functions=endpoint_config.allowed_functions,
+                    auth_policy=endpoint_config.authentication_policy,
                 )
 
             except GlobusAPIError as e:

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -299,6 +299,21 @@ def test_start_ep_display_name_in_config(
     assert conf_dict["display_name"] == display_name
 
 
+def test_configure_ep_auth_policy_in_config(
+    run_line, mock_command_ensure, make_endpoint_dir
+):
+    ep_name = "my-ep"
+    auth_policy = str(uuid.uuid4())
+    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+
+    run_line(f"configure {ep_name} --auth-policy {auth_policy}")
+
+    with open(conf) as f:
+        conf_dict = yaml.safe_load(f)
+
+    assert conf_dict["authentication_policy"] == auth_policy
+
+
 @pytest.mark.parametrize("display_name", [None, "None"])
 def test_config_yaml_display_none(
     run_line, mock_command_ensure, make_endpoint_dir, display_name

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -421,6 +421,7 @@ class Client:
         multi_user: bool | None = None,
         display_name: str | None = None,
         allowed_functions: list[UUID_LIKE_T] | None = None,
+        auth_policy: UUID_LIKE_T | None = None,
     ):
         """Register an endpoint with the Globus Compute service.
 
@@ -438,6 +439,8 @@ class Client:
             The display name of the endpoint
         allowed_functions: list[str | UUID] | None
             List of functions that are allowed to be run on the endpoint
+        auth_policy: str | UUID | None
+            Endpoint users are evaluated against this Globus authentication policy
 
         Returns
         -------
@@ -455,6 +458,7 @@ class Client:
             multi_user=multi_user,
             display_name=display_name,
             allowed_functions=allowed_functions,
+            auth_policy=auth_policy,
         )
         return r.data
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -173,6 +173,7 @@ class WebClient(globus_sdk.BaseClient):
         multi_user: t.Optional[bool] = None,
         display_name: t.Optional[str] = None,
         allowed_functions: t.Optional[t.List[UUID_LIKE_T]] = None,
+        auth_policy: t.Optional[UUID_LIKE_T] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data: t.Dict[str, t.Any] = {
@@ -195,6 +196,8 @@ class WebClient(globus_sdk.BaseClient):
             data["metadata"] = metadata
         if allowed_functions:
             data["allowed_functions"] = allowed_functions
+        if auth_policy:
+            data["authentication_policy"] = auth_policy
         if additional_fields is not None:
             data.update(additional_fields)
         return self.post("/v2/endpoints", data=data)


### PR DESCRIPTION
# Description

Endpoint admins can now define a Globus authentication policy directly in an endpoint's configuration or by using the `--auth-policy` flag when running the `globus-compute-endpoint configure` command.

Users are evaluated against the policy when submitting tasks, retrieving endpoint information, etc. The Globus Compute web service handles both evaluation and enforcement (see https://github.com/globusonline/funcx-services/pull/501).

[sc-26335]

## Type of change

- New feature (non-breaking change that adds functionality)
