### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/changelog.d/20231004_112352_kurtmckee_add_dependabot_for_github_actions.rst
+++ b/changelog.d/20231004_112352_kurtmckee_add_dependabot_for_github_actions.rst
@@ -1,0 +1,4 @@
+Security
+^^^^^^^^
+
+- Add a Dependabot config to keep GitHub action versions updated.


### PR DESCRIPTION
# Description

GitHub actions are currently throwing deprecation warnings due to the age of the action versions and compatibility with Node 16 ([recent example](https://github.com/funcx-faas/funcX/actions/runs/6408656739)).

Rather than update the versions with a one-off PR, this PR introduces a Dependabot configuration that will regularly submit PRs to update the action versions.

If this merges, you can expect Dependabot to immediately submit multiple PRs to update the out-of-date action versions. For example, `actions/setup-python@v1` will be updated to `actions/setup-python@v4`.

## Type of change

- Code maintenance/cleanup
