### PR TITLE
Expand handling of blocked EP registration

### DIFF
--- a/changelog.d/20231023_121708_30907815+rjmello_ep_reg_errors.rst
+++ b/changelog.d/20231023_121708_30907815+rjmello_ep_reg_errors.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Expand cases in which we return a meaningful exit code and message after endpoint
+  registration failures when calling ``globus-compute-endpoint start``.

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -9,6 +9,7 @@ import random
 import uuid
 from collections import namedtuple
 from contextlib import redirect_stdout
+from http import HTTPStatus
 from types import SimpleNamespace
 from unittest import mock
 
@@ -24,7 +25,7 @@ from globus_compute_endpoint.endpoint.config.utils import (
     serialize_config,
 )
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
-from globus_sdk import NetworkError
+from globus_sdk import GlobusAPIError, NetworkError
 from pytest_mock import MockFixture
 
 _mock_base = "globus_compute_endpoint.endpoint.endpoint."
@@ -263,39 +264,63 @@ def test_register_endpoint_invalid_response(
     assert other_endpoint_id in mock_log.error.call_args[0][0]
 
 
-@pytest.mark.parametrize("ret_value", [[409, "Conflict"], [423, "Locked"]])
+@pytest.mark.parametrize(
+    "exit_code,status_code",
+    (
+        (os.EX_UNAVAILABLE, HTTPStatus.CONFLICT),
+        (os.EX_UNAVAILABLE, HTTPStatus.LOCKED),
+        (os.EX_UNAVAILABLE, HTTPStatus.NOT_FOUND),
+        (os.EX_DATAERR, HTTPStatus.BAD_REQUEST),
+        (os.EX_DATAERR, HTTPStatus.UNPROCESSABLE_ENTITY),
+        ("Error", 418),  # IM_A_TEAPOT
+    ),
+)
 @responses.activate
-def test_register_endpoint_locked_conflict_print(
+def test_register_endpoint_blocked(
     mocker,
     fs,
     register_endpoint_failure_response,
     get_standard_compute_client,
     mock_ep_data,
-    ret_value,
+    randomstring,
+    exit_code,
+    status_code,
 ):
     """
     Check to ensure endpoint registration escalates up with API error
     """
-    ret_code, ret_text = ret_value
+    mock_log = mocker.patch(f"{_mock_base}log")
     mock_gcc = get_standard_compute_client()
     mocker.patch(f"{_mock_base}Endpoint.get_funcx_client").return_value = mock_gcc
     f = io.StringIO()
 
     ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
     ep_id = str(uuid.uuid4())
+    some_err = randomstring()
     register_endpoint_failure_response(
         endpoint_id=ep_id,
-        status_code=ret_code,
-        msg=ret_text,
+        status_code=status_code,
+        msg=some_err,
     )
+
     with redirect_stdout(f):
-        with pytest.raises(SystemExit) as pytest_exc:
+        with pytest.raises((GlobusAPIError, SystemExit)) as pytexc:
             ep.start_endpoint(
                 ep_dir, ep_id, ep_conf, log_to_console, no_color, reg_info={}
             )
-        err_msg = f.getvalue()
-        assert "Endpoint registration blocked" in err_msg and ret_text in err_msg
-        assert pytest_exc.value.code == os.EX_UNAVAILABLE
+        stdout_msg = f.getvalue()
+
+    assert mock_log.warning.called
+    a, *_ = mock_log.warning.call_args
+    assert some_err in str(a), "Expected upstream response still shared"
+
+    assert some_err in stdout_msg, f"Expecting error message in stdout ({stdout_msg})"
+    assert pytexc.value.code == exit_code, "Expecting meaningful exit code"
+
+    if exit_code == "Error":
+        # The other route tests SystemExit; nominally this route is an unhandled
+        # traceback -- good.  We should _not_ blanket hide all exceptions.
+        assert pytexc.value.http_status == status_code
 
 
 def test_register_endpoint_already_active(


### PR DESCRIPTION
# Description

Expand cases in which we return a meaningful exit code and message after endpoint registration failures when calling ``globus-compute-endpoint start``.

Formerly, we only did this for `LOCKED` and `CONFLICT` HTTP responses.

[sc-27805]

## Type of change

- New feature (non-breaking change that adds functionality)
