### PR TITLE
Change `heartbeat_period` type from float to int

### DIFF
--- a/changelog.d/20231024_175842_30907815+rjmello_engine_heartbeat_period_int.rst
+++ b/changelog.d/20231024_175842_30907815+rjmello_engine_heartbeat_period_int.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- Changed ``heartbeat_period`` type from float to int for ``GlobusComputeEngine``,
+  ``ProcessPoolEngine``, and ``ThreadPoolEngine`` to maintain parity with the
+  ``HighThroughputEngine`` and Parsl's ``HighThroughputExecutor``.

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -75,7 +75,7 @@ class GlobusComputeEngineBase(ABC):
     def __init__(
         self,
         *args: object,
-        heartbeat_period: float = 30.0,
+        heartbeat_period: int = 30,
         endpoint_id: t.Optional[uuid.UUID] = None,
         **kwargs: object,
     ):

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -25,7 +25,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         *args,
         label: str = "GlobusComputeEngine",
         address: t.Optional[str] = None,
-        heartbeat_period: float = 30.0,
+        heartbeat_period: int = 30,
         strategy: t.Optional[SimpleStrategy] = SimpleStrategy(),
         executor: t.Optional[HighThroughputExecutor] = None,
         **kwargs,

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -26,7 +26,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         label: str = "ProcessPoolEngine",
-        heartbeat_period: float = 30.0,
+        heartbeat_period: int = 30,
         **kwargs,
     ):
         self.label = label

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -26,7 +26,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         label: str = "ThreadPoolEngine",
-        heartbeat_period: float = 30.0,
+        heartbeat_period: int = 30,
         **kwargs,
     ):
         self.label = label

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -168,7 +168,7 @@ def test_no_idle_if_not_configured(mocker, endpoint_uuid, mock_spt):
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.01,
+        heartbeat_period=1,
         idle_heartbeats_soft=0,
     )
     ei = EndpointInterchange(
@@ -191,7 +191,7 @@ def test_soft_idle_honored(mocker, endpoint_uuid, mock_spt):
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.1,
+        heartbeat_period=1,
         idle_heartbeats_soft=3,
     )
     ei = EndpointInterchange(
@@ -229,7 +229,7 @@ def test_hard_idle_honored(mocker, endpoint_uuid, mock_spt):
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.1,
+        heartbeat_period=1,
         idle_heartbeats_soft=1,
         idle_heartbeats_hard=3,
     )
@@ -265,7 +265,7 @@ def test_unidle_updates_proc_title(mocker, endpoint_uuid, mock_spt):
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.1,
+        heartbeat_period=1,
         idle_heartbeats_soft=1,
         idle_heartbeats_hard=3,
     )
@@ -302,7 +302,7 @@ def test_sends_final_status_message_on_shutdown(mocker, endpoint_uuid):
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.01,
+        heartbeat_period=1,
         idle_heartbeats_soft=1,
         idle_heartbeats_hard=2,
     )
@@ -327,7 +327,7 @@ def test_faithfully_handles_status_report_messages(mocker, endpoint_uuid, random
 
     conf = Config(
         executors=[mocker.Mock(endpoint_id=endpoint_uuid)],
-        heartbeat_period=0.01,
+        heartbeat_period=1,
     )
     ei = EndpointInterchange(
         endpoint_id=endpoint_uuid,


### PR DESCRIPTION
# Description

Changed `heartbeat_period` type from float to int for `GlobusComputeEngine`, `ProcessPoolEngine`, and `ThreadPoolEngine` to maintain parity with the `HighThroughputEngine` and Parsl's `HighThroughputExecutor`.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
