### PR TITLE
Support for automatic task retries on the endpoint

### DIFF
--- a/changelog.d/20231031_230517_yadudoc1729_task_retries_1.rst
+++ b/changelog.d/20231031_230517_yadudoc1729_task_retries_1.rst
@@ -1,0 +1,14 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- ``GlobusComputeEngine`` can now be configured to automatically retry task failures when
+  node failures (e.g nodes are lost due to batch job reaching walltime) occur. This option
+  is set to 0 by default to avoid unintentional resource wastage from retrying tasks.
+  Traceback history from all prior attempts is supplied if the last retry attempt fails.
+  Here's a snippet from config.yaml:
+
+.. code-block:: yaml
+
+   engine:
+      type: GlobusComputeEngine
+      max_retries_on_system_failure: 2

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -84,6 +84,7 @@ class EngineModel(BaseConfigModel):
     worker_ports: t.Optional[t.Tuple[int, int]]
     worker_port_range: t.Optional[t.Tuple[int, int]]
     interchange_port_range: t.Optional[t.Tuple[int, int]]
+    max_retries_on_system_failure: t.Optional[int]
 
     _validate_type = _validate_import("type", engines)
     _validate_provider = _validate_params("provider")

--- a/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_gcengine_retries.py
@@ -1,0 +1,139 @@
+import uuid
+from queue import Queue
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_endpoint.strategies import SimpleStrategy
+from globus_compute_sdk.serialize import ComputeSerializer
+from parsl.executors.high_throughput.interchange import ManagerLost
+from parsl.providers import LocalProvider
+from tests.utils import ez_pack_function, kill_manager, succeed_after_n_runs
+
+
+@pytest.fixture
+def gc_engine_with_retries(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        heartbeat_period=1,
+        heartbeat_threshold=1,
+        max_retries_on_system_failure=0,
+        provider=LocalProvider(
+            init_blocks=0,
+            min_blocks=0,
+            max_blocks=1,
+        ),
+        strategy=SimpleStrategy(interval=0.1, max_idletime=0),
+    )
+    engine._status_report_thread.reporting_period = 1
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
+    yield engine
+    engine.shutdown()
+
+
+def test_gce_kill_manager(gc_engine_with_retries):
+    engine = gc_engine_with_retries
+    engine.max_retries_on_system_failure = 0
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+
+    # Confirm error message for ManagerLost
+    task_body = ez_pack_function(serializer, kill_manager, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+
+    future = engine.submit(task_id, task_message)
+
+    with pytest.raises(ManagerLost):
+        future.result()
+
+    flag = False
+    for _i in range(4):
+        q_msg = queue.get(timeout=2)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            if result.error_details and "ManagerLost" in result.data:
+                flag = True
+                break
+
+    assert flag, "Result message missing"
+
+
+def test_success_after_1_fail(gc_engine_with_retries, tmp_path):
+    engine = gc_engine_with_retries
+    engine.max_retries_on_system_failure = 2
+    fail_count = 1
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(
+        serializer, succeed_after_n_runs, (tmp_path,), {"fail_count": fail_count}
+    )
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message)
+
+    flag = False
+    for _i in range(10):
+        q_msg = queue.get(timeout=5)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"
+
+
+def test_repeated_fail(gc_engine_with_retries, tmp_path):
+    engine = gc_engine_with_retries
+    engine.max_retries_on_system_failure = 2
+    fail_count = 3
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(
+        serializer, succeed_after_n_runs, (tmp_path,), {"fail_count": fail_count}
+    )
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message)
+
+    flag = False
+    for _i in range(10):
+        q_msg = queue.get(timeout=5)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details
+            assert "ManagerLost" in result.data
+            count = result.data.count("Traceback from attempt")
+            assert count == fail_count, "Got incorrect # of failure reports"
+            assert "final attempt" in result.data
+            flag = True
+            break
+
+    assert flag, "Expected ManagerLost in failed result.data, but none received"
+
+
+def test_default_retries_is_0():
+    engine = GlobusComputeEngine(address="127.0.0.1")
+    assert engine.max_retries_on_system_failure == 0, "Users must knowingly opt-in"

--- a/compute_endpoint/tests/utils.py
+++ b/compute_endpoint/tests/utils.py
@@ -1,4 +1,5 @@
 import itertools
+import pathlib
 import sys
 import time
 import types
@@ -101,8 +102,26 @@ def kill_manager():
     import signal
 
     manager_pid = os.getppid()
-    os.kill(manager_pid, signal.SIGKILL)
+    manager_pgid = os.getpgid(manager_pid)
+    os.killpg(manager_pgid, signal.SIGKILL)
 
 
 def div_zero(x: int):
     return x / 0
+
+
+def succeed_after_n_runs(dirpath: pathlib.Path, fail_count: int = 1):
+    import os
+    import signal
+    from glob import glob
+
+    prior_run_count = len(glob(os.path.join(dirpath, "foo.*.txt")))
+    with open(os.path.join(dirpath, f"foo.{prior_run_count+1}.txt"), "w+") as f:
+        f.write(f"Hello at {time} counter={prior_run_count+1}")
+
+    if prior_run_count < fail_count:
+        manager_pid = os.getppid()
+        manager_pgid = os.getpgid(manager_pid)
+        os.killpg(manager_pgid, signal.SIGKILL)
+
+    return f"Success on attempt: {prior_run_count+1}"


### PR DESCRIPTION
# Description

This PR adds support for automatically retrying tasks that fail due to infrastructure failures. Here's how we present this to users:
1. Set `GlobusComputeEngine(max_retries_on_system_failure: int = N)`
2. If a task fails due to `ManagerLost`, GCE retries task and produces a traceback like this:

```
++++++++++++++++++++ Traceback from attempt:0 ++++++++++++++++++++
Traceback (most recent call last):
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/parsl/executors/high_throughput/interchange.py", line 572, in expire_bad_managers
    raise ManagerLost(manager_id, m['hostname'])
parsl.executors.high_throughput.interchange.ManagerLost: Task failure due to loss of manager f82ebe84b8a2 on host borgmachine3.local

------------------------------------------------------------------

++++++++++++++++++++ Traceback from attempt:1 ++++++++++++++++++++
Traceback (most recent call last):
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/parsl/executors/high_throughput/interchange.py", line 572, in expire_bad_managers
    raise ManagerLost(manager_id, m['hostname'])
parsl.executors.high_throughput.interchange.ManagerLost: Task failure due to loss of manager 39bc35d81a09 on host borgmachine3.local

------------------------------------------------------------------
            Traceback (most recent call last):
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/Users/yadu/src/funcx/compute_endpoint/.tox/py/lib/python3.10/site-packages/parsl/executors/high_throughput/interchange.py", line 572, in expire_bad_managers
    raise ManagerLost(manager_id, m['hostname'])
parsl.executors.high_throughput.interchange.ManagerLost: Task failure due to loss of manager 151cb3b8d687 on host borgmachine3.local
```
Fixes # (issue)
[sc-12989]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
- Code maintenance/cleanup
