### PR TITLE
Fix GlobusComputeEngine's scale_in method

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -133,8 +133,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
 
     def scale_in(self, blocks: int):
         logger.info(f"Scaling in {blocks} blocks")
-        to_kill = list(self.executor.blocks.values())[:blocks]
-        return self.provider.cancel(to_kill)
+        return self.executor.scale_in(blocks=blocks)
 
     def get_status_report(self) -> EPStatusReport:
         """


### PR DESCRIPTION
# Description

`GlobusComputeEngine.scale_in(blocks:int)` picks the first `blocks` number of blocks to cancel. Instead we should be
using the `HighThroughputExecutor`'s `scale_in` method that has handling for tracking and placing `blocks` on hold
when they are mostly idle.

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Code maintenance/cleanup
