### PR TITLE
Implement identity mapping

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import inspect
+import os
+import pathlib
 import warnings
 
 from globus_compute_endpoint.engines import HighThroughputEngine
@@ -147,6 +149,7 @@ class Config(RepresentationMixin):
         # Tuning info
         heartbeat_period=30,
         heartbeat_threshold=120,
+        identity_mapping_config_path: os.PathLike | None = None,
         idle_heartbeats_soft=0,
         idle_heartbeats_hard=5760,  # Two days, divided by `heartbeat_period`
         detach_endpoint=True,
@@ -194,6 +197,11 @@ class Config(RepresentationMixin):
         self.multi_user = multi_user is True
         self.force_mu_allow_same_user = force_mu_allow_same_user is True
         self.mu_child_ep_grace_period_s = mu_child_ep_grace_period_s
+        self.identity_mapping_config_path = identity_mapping_config_path
+        if self.identity_mapping_config_path:
+            _p = pathlib.Path(self.identity_mapping_config_path)
+            if not _p.exists():
+                warnings.warn(f"Identity mapping config path not found ({_p})")
 
         # Auth
         self.allowed_functions = allowed_functions

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/example_identity_mapping_config.json
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/example_identity_mapping_config.json
@@ -1,0 +1,18 @@
+[
+  {
+    "comment": "For more examples, see: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/",
+    "DATA_TYPE": "external_identity_mapping#1.0.0",
+    "command": ["/bin/false", "--some", "flag", "-a", "-b", "-c"]
+  },
+  {
+    "comment": "For more examples, see: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/",
+    "DATA_TYPE": "expression_identity_mapping#1.0.0",
+    "mappings": [
+      {
+        "source": "{username}",
+        "match": "(.*)@example.com",
+        "output": "{0}"
+      }
+    ]
+  }
+]

--- a/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import threading
+import typing as t
+
+from globus_identity_mapping.loader import load_mappers
+from globus_identity_mapping.protocol import IdentityMappingProtocol
+
+log = logging.getLogger(__name__)
+
+# From: https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/#command_line_options  # noqa
+POSIX_CONNECTOR_ID = "145812c8-decc-41f1-83cf-bb2a85a2a70b"
+
+
+class PosixIdentityMapper:
+    """
+    IdentityMapper is a wrapper around IdentityMappingProtocol implementations,
+    performing two main functions:
+
+        - auto-loading the correct IdentityMappingProtocol implementation class,
+          based on a configuration file's defined DATA_TYPE.  (See
+          https://docs.globus.org/globus-connect-server/v5.4/identity-mapping-guide/ )
+        - atomically updating the loaded configuration without requiring an
+          application restart
+
+    To construct, specify an identity-mapping configuration in a JSON file and
+    then pass the path to the constructor with a tool or utility identifier.
+    Example:
+
+        >>> import json, pathlib
+        >>> from globus_compute_endpoint.endpoint.identity_mapper import PosixIdentityMapper  # noqa
+
+        >>> identity_mapping_conf_path = "some/identity_mapping_configuration.json"
+        >>> im_path = pathlib.Path(identity_mapping_conf_path)  # for convenience
+        >>> print(im_path.read_text())
+        [
+          {
+            "DATA_TYPE": "expression_identity_mapping#1.0.0",
+            "mappings": [
+              {
+                "source": "{username}",
+                "match": "(.*)@university\\.example\\.edu",
+                "output": "{0}"
+              }
+            ]
+          }
+        ]
+
+        >>> some_utility_identifier = "some identifier"
+        >>> im = PosixIdentityMapper(
+        ...    identity_mapping_conf_path, some_utility_identifier
+        ... )
+
+    Currently, the DATA_TYPE must map to an implementing class in the
+    ``globus-identity-mapping`` Python library.
+
+    Now any valid Globus identity can be mapped to a local user via either the
+    ``.map_identity()`` method:
+
+        >>> globus_identity_set = json.loads(  # usually collected from an API ...
+        ... '''
+        ... [
+        ...     {
+        ...         "id": "1c6dbe57-4a3e-44e5-826e-0280003585ae",
+        ...         "sub": "1c6dbe57-4a3e-44e5-826e-0280003585ae",
+        ...         "organization": "Example Widgets, Co",
+        ...         "name": "Jessie Jess",
+        ...         "username": "jess@example.org",
+        ...         "identity_provider": "62dc25b7-c693-4528-831b-4557a7a0d1e4",
+        ...         "identity_provider_display_name": "Example Identities, Ltd",
+        ...         "email": "jess@example.org",
+        ...         "last_authentication": 1029384756
+        ...     },
+        ...     {
+        ...         "id": "d427502d-722b-4361-ad34-9327010a7b81",
+        ...         "sub": "d427502d-722b-4361-ad34-9327010a7b81",
+        ...         "name": "Jessie Jess",
+        ...         "username": "jessica.jazz.jess@university.example.edu",
+        ...         "identity_provider": "09a7033a-b53b-44e2-8c71-b60f0468df07",
+        ...         "identity_provider_display_name": "University of Example",
+        ...         "email": "jessica.jess@example-2.com",
+        ...         "last_authentication": 1629384750
+        ...     }
+        ... ]
+        ... '''
+        ... )
+
+        >>> im.map_identity(globus_identity_set)
+        'jessica.jazz.jess'
+
+    Meanwhile, if requirements change and the identity mapping configuration
+    must be changed, the changes will be atomically discovered:
+
+        >>> im_path.write_text('''
+        ... [
+        ...   {
+        ...     "DATA_TYPE": "expression_identity_mapping#1.0.0",
+        ...     "mappings": [
+        ...       {
+        ...         "source": "{username}",
+        ...         "match": "(.*)@example\\.org",
+        ...         "output": "{0}"
+        ...       }
+        ...     ]
+        ...   }
+        ... ]
+        ... ''')
+        >>> time.sleep(im.poll_interval_s)  # for example, wait until reloaded
+        >>> im.map_identity(globus_identity_set)
+        'jess'
+
+
+    """
+
+    def __init__(
+        self,
+        identity_mapping_config_path: os.PathLike,
+        endpoint_identifier: str,
+        poll_interval_s: float = 5.0,
+    ):
+        """
+        :param identity_mapping_config_path:
+        :param endpoint_identifier:
+        :param poll_interval_s:
+        """
+        self._time_to_stop = threading.Event()
+        self.config_path = pathlib.Path(identity_mapping_config_path)
+        self._config_stat = self.config_path.stat()
+        self._endpoint_identifier = endpoint_identifier
+        self.poll_interval_s = poll_interval_s
+
+        self._identity_mappings: list[IdentityMappingProtocol] = []
+
+        self.load_configuration()  # Executed on main thread
+
+        threading.Thread(target=self._poll_config, daemon=True).start()
+
+    def __del__(self):
+        self.stop_watching()
+
+    def stop_watching(self):
+        self._time_to_stop.set()
+
+    @property
+    def poll_interval_s(self) -> float:
+        return self._poll_interval_s
+
+    @poll_interval_s.setter
+    def poll_interval_s(self, new_interval_s: float) -> None:
+        self._poll_interval_s = max(0.5, new_interval_s)
+
+    def _poll_config(self):
+        fail_msg_fmt = (
+            "Unable to update identity configuration -- ({}) {}"
+            f"\n  Identity configuration path: {self.config_path}"
+        )
+
+        while not self._time_to_stop.wait(self.poll_interval_s):
+            try:
+                self._update_if_config_changed()
+            except Exception as e:
+                msg = fail_msg_fmt.format(type(e).__name__, e)
+                log.debug(msg, exc_info=e)
+                log.error(msg)
+        log.debug("Polling thread stops")
+
+    def _update_if_config_changed(self):
+        cstat = self._config_stat  # "current stat"
+        nstat = self.config_path.stat()  # "new stat"
+        cur_s = (cstat.st_ino, cstat.st_ctime, cstat.st_mtime, cstat.st_size)
+        new_s = (nstat.st_ino, nstat.st_ctime, nstat.st_mtime, nstat.st_size)
+
+        if cur_s == new_s:
+            # no change; suggests the file has *also* not changed
+            return
+
+        log.info(
+            "Identity mapping configuration change detected; rereading:"
+            f" {self.config_path}"
+        )
+        self.load_configuration()
+
+    def load_configuration(self):
+        self._config_stat = self.config_path.stat()
+        self.identity_mappings = json.loads(self.config_path.read_bytes())
+
+    @property
+    def identity_mappings(self) -> list[IdentityMappingProtocol]:
+        return self._identity_mappings
+
+    @identity_mappings.setter
+    def identity_mappings(self, mappings_list: t.Iterable[dict] | None):
+        self._identity_mappings = load_mappers(
+            mappings_list, POSIX_CONNECTOR_ID, self._endpoint_identifier
+        )
+
+    @identity_mappings.deleter
+    def identity_mappings(self):
+        self.identity_mappings = None
+
+    def map_identity(self, identity_set: t.Iterable[t.Mapping[str, str]]) -> str | None:
+        for mapper in self.identity_mappings:
+            for identity_data in identity_set:
+                try:
+                    identity = mapper.map_identity(identity_data)
+                except Exception as e:
+                    log.warning(f"Identity mapper failed -- ({type(e).__name__}) {e}")
+                    continue
+                if identity:
+                    return identity
+        return None

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -8,6 +8,7 @@ REQUIRES = [
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
     "globus-compute-sdk==2.6.0",
     "globus-compute-common==0.3.0a2",
+    "globus-identity-mapping==0.1.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",
     # although psutil does not declare itself to use semver, it appears to offer

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -42,6 +42,7 @@ class TestStart:
         fs.add_real_file(DEF_CONFIG_DIR / "user_config_template.yaml")
         fs.add_real_file(DEF_CONFIG_DIR / "user_config_schema.json")
         fs.add_real_file(DEF_CONFIG_DIR / "user_environment.yaml")
+        fs.add_real_file(DEF_CONFIG_DIR / "example_identity_mapping_config.json")
 
         yield
 
@@ -98,6 +99,9 @@ class TestStart:
             config_dict = yaml.safe_load(f)
         if mu:
             assert config_dict["multi_user"] == mu is True
+            assert "engine" not in config_dict
+            assert "identity_mapping_config_path" in config_dict
+            assert pathlib.Path(config_dict["identity_mapping_config_path"]).exists()
         else:
             assert "multi_user" not in config_dict
 

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -37,6 +37,7 @@ def mock_spt(mocker):
 def test_endpoint_id_conveyed_to_executor(funcx_dir):
     manager = Endpoint()
     config_dir = funcx_dir / "mock_endpoint"
+    expected_ep_id = str(uuid.uuid1())
 
     manager.configure_endpoint(config_dir, None)
 
@@ -46,11 +47,11 @@ def test_endpoint_id_conveyed_to_executor(funcx_dir):
     ic = EndpointInterchange(
         endpoint_config,
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
-        endpoint_id="mock_endpoint_id",
+        endpoint_id=expected_ep_id,
     )
     ic.executor = engines.ThreadPoolEngine()  # test does not need a child process
     ic.start_engine()
-    assert ic.executor.endpoint_id == "mock_endpoint_id"
+    assert ic.executor.endpoint_id == expected_ep_id
     ic.executor.shutdown()
 
 

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -1,0 +1,4 @@
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "no_mock_pim: In test_endpointmanager_unit, disable autouse fixture"
+    )

--- a/compute_endpoint/tests/unit/test_identity_mapper.py
+++ b/compute_endpoint/tests/unit/test_identity_mapper.py
@@ -1,0 +1,185 @@
+import json
+import pathlib
+import threading
+
+import pytest
+from globus_compute_endpoint.endpoint.identity_mapper import PosixIdentityMapper
+from tests.utils import try_assert
+
+_MOCK_BASE = "globus_compute_endpoint.endpoint.identity_mapper."
+
+
+def _expression_identity_mapper_conf() -> str:
+    return """[{
+        "DATA_TYPE": "expression_identity_mapping#1.0.0",
+        "mappings": [
+            {"source": "{uname}", "match": "(.*)@a.local", "output": "{0}"},
+            {"source": "{uname}", "match": "(.*)@b.local", "output": "{0}"}
+        ]
+    }]"""
+
+
+def _external_identity_mapper_conf() -> str:
+    return """
+    [{
+        "DATA_TYPE": "external_identity_mapping#1.0.0",
+        "command": ["/some/executable.py_or_sh_or_rb_or_exe_or..."]
+    }]""".strip()
+
+
+@pytest.fixture
+def conf_p(tmp_path):
+    yield tmp_path / "some_file"
+
+
+class NoWaitPosixIdentityMapper(PosixIdentityMapper):
+    def __init__(self, *args, poll_interval_s: float = 0.0, **kwargs):
+        self.test_poll_interval_s = poll_interval_s
+        super().__init__(*args, **kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop_watching()
+
+    @property
+    def poll_interval_s(self) -> float:
+        return self.test_poll_interval_s
+
+    @poll_interval_s.setter
+    def poll_interval_s(self, new_interval_s: float) -> None:
+        pass
+
+
+def test_fails_to_handle_configuration_load_failures_at_initialization(fs):
+    # important to give main thread chance to handle failure (e.g., to quit)
+    conf_p = pathlib.Path("/some_file")
+
+    with pytest.raises(FileNotFoundError):
+        PosixIdentityMapper(conf_p, "some_id")
+
+    conf_p.touch(mode=0o000)
+    with pytest.raises(PermissionError):
+        PosixIdentityMapper(conf_p, "some_id")
+
+    conf_p.chmod(mode=0o644)
+    conf_p.write_text('{"unclosed": "quote}')
+    with pytest.raises(json.JSONDecodeError):
+        PosixIdentityMapper(conf_p, "some_id")
+
+
+def test_poll_interval_setter_enforces_minimum(fs):
+    conf_p = pathlib.Path("/some_file")
+    conf_p.write_text("[]")
+    pim = PosixIdentityMapper(conf_p, "some_id", poll_interval_s=-5)
+    assert pim.poll_interval_s >= 0.5
+
+    pim.poll_interval_s = 0.3
+    assert pim.poll_interval_s >= 0.5
+    pim.stop_watching()
+
+
+def test_atomically_loads_new_configurations(mocker, conf_p):
+    def write_configs():
+        assert pim.identity_mappings == []
+
+        mock_log.reset_mock()
+        conf_p.write_text("[adsfasdf")
+        yield False
+
+        assert pim.identity_mappings == [], "bad config; expect not changed"
+
+        info_a = mock_log.info.call_args[0][0]
+        err_a = mock_log.error.call_args[0][0]
+        mock_log.reset_mock()
+        assert "change detected" in info_a
+        assert "rereading" in info_a
+        assert str(conf_p) in info_a
+        assert "Unable to update identity configuration" in err_a
+
+        conf_p.write_text(_external_identity_mapper_conf())
+        yield False
+
+        assert isinstance(pim.identity_mappings, list)
+        assert "py_or_sh_or_rb_or_exe_or" in str(pim.identity_mappings)
+
+        info_a = mock_log.info.call_args[0][0]
+        mock_log.reset_mock()
+
+        assert "change detected" in info_a
+        assert "rereading" in info_a
+        assert str(conf_p) in info_a
+
+        conf_p.write_text("]")
+        yield False
+
+        assert isinstance(pim.identity_mappings, list)
+        assert "py_or_sh_or_rb_or_exe_or" in str(
+            pim.identity_mappings
+        ), "bad config; expect not changed"
+
+        conf_p.write_text("[]")
+        yield False
+        assert pim.identity_mappings == []
+
+        yield True
+
+    mock_log = mocker.patch(f"{_MOCK_BASE}log")
+    mock_evt = mocker.Mock(spec=threading.Event)
+    mock_evt.wait.side_effect = write_configs()
+    mocker.patch(f"{_MOCK_BASE}threading.Event", return_value=mock_evt)
+    mocker.patch(f"{_MOCK_BASE}threading.Thread")
+
+    conf_p.write_text("[]")
+
+    pim = PosixIdentityMapper(conf_p, "some_id")
+    pim._poll_config()
+    pim.stop_watching()
+
+
+def test_automatically_loads_new_configurations(mocker, conf_p):
+    conf_p.write_text("[]")
+    mocker.patch(f"{_MOCK_BASE}log")
+    with NoWaitPosixIdentityMapper(conf_p, "some_id") as pim:
+        assert pim.identity_mappings == []
+
+        conf_p.write_text(_external_identity_mapper_conf())
+        try_assert(lambda: len(pim.identity_mappings) > 0)
+        assert "/some/executable.py_or_s" in str(pim.identity_mappings)
+
+        conf_p.write_text("[]")
+        try_assert(lambda: len(pim.identity_mappings) == 0)
+
+        conf_p.write_text(_expression_identity_mapper_conf())
+        try_assert(lambda: len(pim.identity_mappings) > 0)
+        assert "@a.local" in str(pim.identity_mappings)
+
+
+def test_delete_identity_mappings(conf_p):
+    conf_p.write_text(_expression_identity_mapper_conf())
+    with NoWaitPosixIdentityMapper(conf_p, "some_id") as pim:
+        assert len(pim.identity_mappings) > 0
+        del pim.identity_mappings
+        try_assert(lambda: pim.identity_mappings == [])
+
+
+@pytest.mark.parametrize("idset", ((), ({"some": "id"}, {"other": "id"})))
+def test_map_identity_falls_back_to_none(conf_p, idset):
+    conf_p.write_text(_expression_identity_mapper_conf())
+    with NoWaitPosixIdentityMapper(conf_p, "some_id", poll_interval_s=0.001) as pim:
+        assert pim.map_identity(idset) is None
+
+
+@pytest.mark.parametrize(
+    "expected,idset",
+    (
+        ("a", ({"uname": "a@a.local"}, {"uname": "b@b.local"})),
+        ("b", ({"uname": "b@b.local"}, {"uname": "a@a.local"})),
+        ("b", ({"uname": "a@c.local"}, {"uname": "b@b.local"})),
+    ),
+)
+def test_map_identity_returns_first_found_identity(conf_p, expected, idset):
+    conf_p.write_text(_expression_identity_mapper_conf())
+    with NoWaitPosixIdentityMapper(conf_p, "some_id", poll_interval_s=0.001) as pim:
+        assert pim.map_identity(idset) == expected


### PR DESCRIPTION
The main addition in this commit is the implementation and utilization of `PosixIdentityMapper`, which wraps the Globus Identity Mapper tool.  Basic use looks like:

```python
im = PosixIdentityMapper("path/some/conf.json", "some uuid or other id")
local_user_id = im.map_identity([{"some": "list"}, {"of": "globus ids"}])
```

The `im` object will watch the configuration file for changes (stat every few seconds), and atomically update the configuration accordingly.

The previous route of a simple JSON file (dictionary mapping) is no more.

Also:

- update the default configuration to point to an example configuration document
- disallow specification of an engine for a multi-user config (where it doesn't make any sense)

Note: Not adding a changelog at this time, as we aren't prepared to advertise this functionality yet.  Will add the changelog at a future date.

[sc-26671]

## Type of change

- New feature (non-breaking change that adds functionality)