### PR TITLE
Speed-up test by slicing time.sleep

### DIFF
--- a/compute_endpoint/tests/unit/test_worker.py
+++ b/compute_endpoint/tests/unit/test_worker.py
@@ -142,7 +142,10 @@ def test_execute_function_exceeding_result_size_limit(test_worker):
 def sleeper(t):
     import time
 
-    time.sleep(t)
+    now = start = time.monotonic()
+    while now - start < t:
+        time.sleep(0.0001)
+        now = time.monotonic()
     return True
 
 
@@ -153,7 +156,7 @@ def test_app_timeout(test_worker):
         messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
     )
 
-    with mock.patch.dict(os.environ, {"GC_TASK_TIMEOUT": "0.1"}):
+    with mock.patch.dict(os.environ, {"GC_TASK_TIMEOUT": "0.01"}):
         packed_result = execute_task(task_id, task_body)
 
     result = messagepack.unpack(packed_result)


### PR DESCRIPTION
CPython's `time.sleep()` holds the thread in C-land, making it, for most usages, uninterruptible.  Sleeping in small increments for the total duration allows the thread to be interrupted, which allows us to shave about 1 second off the run-time.

## Type of change

- Code maintenance/cleanup
