### PR TITLE
Refactor test

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -399,12 +399,12 @@ class Endpoint:
                     HTTPStatus.LOCKED,
                     HTTPStatus.NOT_FOUND,
                 ):
-                    exit(os.EX_UNAVAILABLE)
+                    raise SystemExit(os.EX_UNAVAILABLE) from e
                 elif e.http_status in (
                     HTTPStatus.BAD_REQUEST,
                     HTTPStatus.UNPROCESSABLE_ENTITY,
                 ):
-                    exit(os.EX_DATAERR)
+                    raise SystemExit(os.EX_DATAERR) from e
                 raise
 
             except NetworkError as e:


### PR DESCRIPTION
Rather than mocking the functional call, inject a fake API response&nbsp;&mdash;&nbsp;this is a little more "honest" about testing what _actually_ gets sent to the API.  Additionally, verify the expected exit code.

## Type of change

- Code maintenance/cleanup
