### PR TITLE
Quiet some test output

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -285,9 +285,11 @@ class EndpointInterchange:
             except pika.exceptions.ProbableAuthenticationError as e:
                 log.error(f"Unable to connect to AMQP service: {e}")
                 self._kill_event.set()
-            except Exception:
-                log.error("Unhandled exception in main kernel.")
-                log.debug("Unhandled exception in main kernel.", exc_info=True)
+            except Exception as e:
+                log.error(
+                    f"Unhandled exception in main kernel: ({type(e).__name__}) {e}"
+                )
+                log.debug("Unhandled exception in main kernel.", exc_info=e)
             finally:
                 if not self._kill_event.is_set():
                     self._reconnect_fail_counter += 1

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -5,7 +5,7 @@ import pathlib
 import shutil
 import uuid
 from importlib.machinery import SourceFileLoader
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import globus_compute_endpoint.endpoint
 import pytest
@@ -16,6 +16,7 @@ from globus_sdk import GlobusAPIError
 
 logger = logging.getLogger("mock_funcx")
 
+_MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint."
 DEF_CONFIG_DIR = (
     pathlib.Path(globus_compute_endpoint.endpoint.config.__file__).resolve().parent
 )
@@ -104,7 +105,7 @@ class TestStart:
         "This test needs to be re-written after endpoint_register is updated"
     )
     def test_start(self, mocker):
-        mock_client = mocker.patch("globus_compute_endpoint.endpoint.endpoint.Client")
+        mock_client = mocker.patch(f"{_MOCK_BASE}Client")
         reg_info = {
             "endpoint_id": "abcde12345",
             "address": "localhost",
@@ -130,17 +131,13 @@ class TestStart:
 
         mock_daemon = mocker.patch.object(Endpoint, "daemon_launch", return_value=None)
 
-        mock_uuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.uuid.uuid4")
+        mock_uuid = mocker.patch(f"{_MOCK_BASE}uuid.uuid4")
         mock_uuid.return_value = 123456
 
-        mock_pidfile = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.daemon.pidfile.PIDLockFile"
-        )
+        mock_pidfile = mocker.patch(f"{_MOCK_BASE}daemon.pidfile.PIDLockFile")
         mock_pidfile.return_value = None
 
-        mock_results_ack_handler = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.ResultsAckHandler"
-        )
+        mock_results_ack_handler = mocker.patch(f"{_MOCK_BASE}ResultsAckHandler")
 
         manager = Endpoint(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
@@ -189,11 +186,9 @@ class TestStart:
         being asserted against because this zmq setup happens before registration
         occurs.
         """
-        mocker.patch("globus_compute_endpoint.endpoint.endpoint.Client")
+        mocker.patch(f"{_MOCK_BASE}Client")
 
-        mock_register_endpoint = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.register_endpoint"
-        )
+        mock_register_endpoint = mocker.patch(f"{_MOCK_BASE}register_endpoint")
         mock_register_endpoint.side_effect = GlobusAPIError(
             _fake_http_response(status=400, method="POST")
         )
@@ -206,15 +201,13 @@ class TestStart:
             return_value=(b"12345abcde", b"12345abcde"),
         )
 
-        mock_uuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.uuid.uuid4")
+        mock_uuid = mocker.patch(f"{_MOCK_BASE}uuid.uuid4")
         mock_uuid.return_value = 123456
 
-        mock_pidfile = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.daemon.pidfile.PIDLockFile"
-        )
+        mock_pidfile = mocker.patch(f"{_MOCK_BASE}daemon.pidfile.PIDLockFile")
         mock_pidfile.return_value = None
 
-        mocker.patch("globus_compute_endpoint.endpoint.endpoint.ResultsAckHandler")
+        mocker.patch(f"{_MOCK_BASE}ResultsAckHandler")
 
         manager = Endpoint(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
@@ -247,11 +240,9 @@ class TestStart:
         own. mock_zmq_create and mock_zmq_load are being asserted against because this
         zmq setup happens before registration occurs.
         """
-        mocker.patch("globus_compute_endpoint.endpoint.endpoint.Client")
+        mocker.patch(f"{_MOCK_BASE}Client")
 
-        mock_register_endpoint = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.register_endpoint"
-        )
+        mock_register_endpoint = mocker.patch(f"{_MOCK_BASE}register_endpoint")
         mock_register_endpoint.side_effect = GlobusAPIError(
             _fake_http_response(status=500, method="POST")
         )
@@ -274,17 +265,13 @@ class TestStart:
 
         mock_daemon = mocker.patch.object(Endpoint, "daemon_launch", return_value=None)
 
-        mock_uuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.uuid.uuid4")
+        mock_uuid = mocker.patch(f"{_MOCK_BASE}uuid.uuid4")
         mock_uuid.return_value = 123456
 
-        mock_pidfile = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.daemon.pidfile.PIDLockFile"
-        )
+        mock_pidfile = mocker.patch(f"{_MOCK_BASE}daemon.pidfile.PIDLockFile")
         mock_pidfile.return_value = None
 
-        mock_results_ack_handler = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.ResultsAckHandler"
-        )
+        mock_results_ack_handler = mocker.patch(f"{_MOCK_BASE}ResultsAckHandler")
 
         manager = Endpoint(funcx_dir=os.getcwd())
         config_dir = os.path.join(manager.funcx_dir, "mock_endpoint")
@@ -328,7 +315,7 @@ class TestStart:
         )
 
     def test_start_without_executors(self, mocker):
-        mock_client = mocker.patch("globus_compute_endpoint.endpoint.endpoint.Client")
+        mock_client = mocker.patch(f"{_MOCK_BASE}Client")
         mock_client.return_value.register_endpoint.return_value = {
             "endpoint_id": "abcde12345",
             "address": "localhost",
@@ -365,9 +352,7 @@ class TestStart:
 
     @pytest.mark.skip("This test doesn't make much sense")
     def test_daemon_launch(self, mocker):
-        mock_interchange = mocker.patch(
-            "globus_compute_endpoint.endpoint.endpoint.EndpointInterchange"
-        )
+        mock_interchange = mocker.patch(f"{_MOCK_BASE}EndpointInterchange")
         mock_interchange.return_value.start.return_value = None
         mock_interchange.return_value.stop.return_value = None
 
@@ -456,7 +441,7 @@ class TestStart:
         )
 
     def test_get_or_create_endpoint_uuid_no_json_no_uuid(self, mocker):
-        mock_uuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.uuid.uuid4")
+        mock_uuid = mocker.patch(f"{_MOCK_BASE}uuid.uuid4")
         mock_uuid.return_value = 123456
 
         config_dir = pathlib.Path("/some/path/mock_endpoint")
@@ -481,15 +466,15 @@ class TestStart:
 
         assert "abcde12345" == manager.get_or_create_endpoint_uuid(config_dir, "234567")
 
-    @pytest.mark.parametrize("dir_exists", [True, False])
-    @pytest.mark.parametrize("web_svc_ok", [True, False])
-    @pytest.mark.parametrize("force", [True, False])
+    @pytest.mark.parametrize("dir_exists", (True, False))
+    @pytest.mark.parametrize("web_svc_ok", (True, False))
+    @pytest.mark.parametrize("force", (True, False))
     def test_delete_endpoint(self, mocker, dir_exists, web_svc_ok, force):
         manager = Endpoint()
         config_dir = pathlib.Path("/some/path/mock_endpoint")
         ep_uuid_str = str(uuid.uuid4())
 
-        mock_client = mocker.patch("globus_compute_endpoint.endpoint.endpoint.Client")
+        mock_client = mocker.patch(f"{_MOCK_BASE}Client")
         mock_stop_endpoint = mocker.patch.object(Endpoint, "stop_endpoint")
         mock_rmtree = mocker.patch.object(shutil, "rmtree")
         mocker.patch.object(Endpoint, "get_endpoint_id", return_value=ep_uuid_str)
@@ -508,11 +493,13 @@ class TestStart:
             mock_client.return_value.delete_endpoint.side_effect = exc
 
             if not force:
-                with pytest.raises(SystemExit):
+                with pytest.raises(SystemExit), patch(f"{_MOCK_BASE}log") as mock_log:
                     manager.delete_endpoint(config_dir, None, force)
+                a, _k = mock_log.critical.call_args
+                assert "without deleting the endpoint" in a[0], "expected notice"
 
-                mock_stop_endpoint.assert_not_called()
-                mock_rmtree.assert_not_called()
+                assert not mock_stop_endpoint.called
+                assert not mock_rmtree.called
                 return
 
         manager.delete_endpoint(config_dir, None, force)

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_manager.py
@@ -2,10 +2,13 @@ import os
 import pickle
 import queue
 import shutil
+import subprocess
 
 import pytest
 from globus_compute_endpoint.engines.high_throughput.manager import Manager
 from globus_compute_endpoint.engines.high_throughput.messages import Task
+
+_MOCK_BASE = "globus_compute_endpoint.engines.high_throughput.manager."
 
 
 class TestManager:
@@ -17,9 +20,7 @@ class TestManager:
 
     def test_remove_worker_init(self, mocker):
         # zmq is being mocked here because it was making tests hang
-        mocker.patch(
-            "globus_compute_endpoint.engines.high_throughput.manager.zmq.Context"  # noqa: E501
-        )
+        mocker.patch(f"{_MOCK_BASE}zmq.Context")  # noqa: E501
 
         manager = Manager(logdir="./", uid="mock_uid")
         manager.worker_map.to_die_count["RAW"] = 0
@@ -33,19 +34,13 @@ class TestManager:
 
     def test_poll_funcx_task_socket(self, mocker):
         # zmq is being mocked here because it was making tests hang
-        mocker.patch(
-            "globus_compute_endpoint.engines.high_throughput.manager.zmq.Context"  # noqa: E501
-        )
-
-        mock_worker_map = mocker.patch(
-            "globus_compute_endpoint.engines.high_throughput.manager.WorkerMap"
-        )
+        mocker.patch(f"{_MOCK_BASE}zmq.Context")  # noqa: E501
+        mock_worker_map = mocker.patch(f"{_MOCK_BASE}WorkerMap")
 
         manager = Manager(logdir="./", uid="mock_uid")
         manager.task_queues["RAW"] = queue.Queue()
-        manager.logdir = "./"
         manager.worker_type = "RAW"
-        manager.worker_procs["0"] = "proc"
+        manager.worker_procs["0"] = mocker.Mock(spec=subprocess.Popen)
 
         manager.funcx_task_socket.recv_multipart.return_value = (
             b"0",

--- a/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
+++ b/compute_endpoint/tests/integration/test_rabbit_mq/test_task_q.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import multiprocessing
 import threading
 import time
@@ -7,6 +6,8 @@ import uuid
 
 import pytest
 from globus_compute_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
+
+_MOCK_BASE = "globus_compute_endpoint.endpoint.rabbit_mq.task_queue_subscriber."
 
 
 def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
@@ -19,9 +20,6 @@ def test_synch(start_task_q_publisher, start_task_q_subscriber, count=10):
         b_message = json.dumps(message).encode()
         messages.append(b_message)
         task_q_pub.publish(b_message)
-
-    logging.warning(f"Published {count} messages, closing task_q_pub")
-    logging.warning("Starting task_q_subscriber")
 
     tasks_out = multiprocessing.Queue()
     start_task_q_subscriber(queue=tasks_out)
@@ -46,14 +44,12 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
     tasks_out = multiprocessing.Queue()
     quiesce_event = multiprocessing.Event()
     proc = start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
-    logging.warning("Proc started")
     for i in range(10):
         _, message = tasks_out.get()
         assert messages[i] == message
 
     # Terminate the connection
     proc.stop()
-    logging.warning("Disconnected")
 
     # Launch 10 more messages
     messages = []
@@ -68,27 +64,25 @@ def test_subscriber_recovery(start_task_q_publisher, start_task_q_subscriber):
 
     # Listen for the messages on a new connection
     quiesce_event.clear()
-    proc = start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
+    start_task_q_subscriber(queue=tasks_out, quiesce_event=quiesce_event)
 
-    logging.warning("Replacement proc started")
     for i in range(10):
-        logging.warning("getting message")
         _, message = tasks_out.get()
-        logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
 
-def test_exclusive_subscriber(start_task_q_publisher, start_task_q_subscriber):
+def test_exclusive_subscriber(mocker, start_task_q_publisher, start_task_q_subscriber):
     """2 subscribers connect, only first one should get any messages"""
     task_q_pub = start_task_q_publisher()
 
     # Start two subscribers on the same rabbit queue
     tasks_out_1, tasks_out_2 = multiprocessing.Queue(), multiprocessing.Queue()
     start_task_q_subscriber(queue=tasks_out_1)
-    time.sleep(1)
+    time.sleep(0.1)
+
+    mocker.patch(f"{_MOCK_BASE}logger")
     start_task_q_subscriber(queue=tasks_out_2)
 
-    logging.warning("TEST: Launching messages")
     # Launch 10 messages
     messages = []
     for i in range(10):
@@ -99,12 +93,10 @@ def test_exclusive_subscriber(start_task_q_publisher, start_task_q_subscriber):
         b_message = json.dumps(message).encode("utf-8")
         task_q_pub.publish(b_message)
         messages.append(b_message)
-    logging.warning("TEST: Launching messages")
 
     # Confirm that the first subscriber received all the messages
     for i in range(10):
         _, message = tasks_out_1.get(timeout=1)
-        logging.warning(f"Got message: {message}")
         assert messages[i] == message
 
     # Check that the second subscriber did not receive any messages
@@ -129,10 +121,6 @@ def test_perf_combined_pub_sub_latency(start_task_q_publisher, start_task_q_subs
         assert b_message == x
 
     avg_latency = sum(latency) / len(latency)
-    logging.warning(
-        f"Message latencies in milliseconds, min:{1000*min(latency):.2f}, "
-        f"max:{1000*max(latency):.2f}, avg:{1000*avg_latency:.2f}"
-    )
     # average latency is expected to be below 5ms
     # if it exceeds this, it means something is wrong
     assert avg_latency < 0.005
@@ -164,10 +152,6 @@ def test_perf_combined_pub_sub_throughput(
         sent_per_second = num_messages / send_time
         messages_per_second = num_messages / total_time
 
-        logging.warning(
-            f"task throughput for {num_messages} messages at {message_size}B = "
-            f"{messages_per_second:.2f} messages/s"
-        )
         # each size should record at least 500 messages per second even in an
         # untuned context with other processes running
         # slower than that indicates that a serious performance regression has
@@ -203,9 +187,8 @@ def test_graceful_shutdown_if_connection_closed_unexpectedly(mocker, task_queue_
 
 def test_terminate(start_task_q_subscriber):
     task_q = start_task_q_subscriber()
-    time.sleep(1)
+    time.sleep(0.1)
     task_q.stop()
-    logging.warning("Calling terminate")
     with pytest.raises(ValueError):
         # Expected to raise ValueError since the process should
         # be terminated at this point from the close() call

--- a/compute_endpoint/tests/unit/test_bad_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_bad_endpoint_config.py
@@ -1,18 +1,21 @@
+from unittest import mock
+
 import pytest
 from globus_compute_endpoint.engines import HighThroughputEngine
 
-invalid_addresses = ["localhost", "login1.theta.alcf.anl.gov", "*"]
+_MOCK_BASE = "globus_compute_endpoint.engines.high_throughput.engine."
 
 
-@pytest.mark.parametrize("address", invalid_addresses)
+@pytest.mark.parametrize("address", ("localhost", "login1.theta.alcf.anl.gov", "*"))
 def test_invalid_address(address):
-    with pytest.raises(ValueError):
-        HighThroughputEngine(address=address)
+    with mock.patch(f"{_MOCK_BASE}log") as mock_log:
+        with pytest.raises(ValueError):
+            HighThroughputEngine(address=address)
+    assert mock_log.critical.called
 
 
-valid_addresses = ["192.168.64.12", "fe80::e643:4bff:fe61:8f72", "129.114.44.12"]
-
-
-@pytest.mark.parametrize("address", valid_addresses)
+@pytest.mark.parametrize(
+    "address", ("192.168.64.12", "fe80::e643:4bff:fe61:8f72", "129.114.44.12")
+)
 def test_valid_address(address):
     HighThroughputEngine(address=address)

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -500,8 +500,11 @@ def test_restarts_running_endpoint_with_cached_args(epmanager, mocker):
     em._cached_cmd_start_args[child_pid] = args_tup
     em.cmd_start_endpoint = mocker.Mock()
 
-    em.wait_for_children()
+    with mock.patch(f"{_MOCK_BASE}log") as mock_log:
+        em.wait_for_children()
 
+    a, _k = mock_log.info.call_args
+    assert "using cached arguments to start" in a[0]
     assert em.cmd_start_endpoint.call_args.args == args_tup
 
 

--- a/compute_endpoint/tests/unit/test_execute_task.py
+++ b/compute_endpoint/tests/unit/test_execute_task.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from unittest import mock
 
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines.helper import execute_task
@@ -7,6 +8,8 @@ from globus_compute_sdk.serialize import ComputeSerializer
 from tests.utils import ez_pack_function
 
 logger = logging.getLogger(__name__)
+
+_MOCK_BASE = "globus_compute_endpoint.engines.helper."
 
 
 def divide(x, y):
@@ -56,7 +59,13 @@ def test_execute_task_with_exception():
         )
     )
 
-    packed_result = execute_task(task_id, task_message)
+    with mock.patch(f"{_MOCK_BASE}log") as mock_log:
+        packed_result = execute_task(task_id, task_message)
+
+    assert mock_log.exception.called
+    a, _k = mock_log.exception.call_args
+    assert "while executing user function" in a[0]
+
     assert isinstance(packed_result, bytes)
     result = messagepack.unpack(packed_result)
     assert isinstance(result, messagepack.message_types.Result)

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -10,16 +10,14 @@ extras = test
 usedevelop = true
 commands =
     coverage erase
-    coverage run -m pytest --durations 5 {posargs}
+    coverage run -m pytest --durations 5 --log-cli-level=ERROR {posargs}
     coverage report
 
 [testenv:mypy]
 deps =
-    mypy==1.5.1
-    types-requests
-    types-click
+    mypy==1.6.1
     ../compute_sdk/
-commands = mypy -p globus_compute_endpoint {posargs}
+commands = mypy --install-types --non-interactive -p globus_compute_endpoint {posargs}
 
 
 [testenv:publish-release]


### PR DESCRIPTION
While en route to tracking down a test failure in another branch (only occurring in CI&nbsp;&mdash;&nbsp;doh!), was overwhelmed with a number of superfluous output generated by some tests.  Realized that we don't see this locally because we have not had parity with CI `--log-cli-level=ERROR` flag to `pytest`.  Changing that (`tox.ini`), and then clearing up the then-apparent noisy tests.

As a side-benefit, some of these noisy tests weren't actually testing what they were supposed to, and the error messages were, in fact, telling us so.  So ... "fixed."

Take the opportunity to update mypy

## Type of change

- Code maintenance/cleanup