### PR TITLE
Fix two assertions

### DIFF
--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -325,7 +325,7 @@ def test_get_function():
 
     gcc.get_function(func_uuid_str)
 
-    assert gcc.web_client.get_function.called_with(func_uuid_str)
+    gcc.web_client.get_function.assert_called_with(func_uuid_str)
 
 
 def test_delete_function():
@@ -335,7 +335,7 @@ def test_delete_function():
 
     gcc.delete_function(func_uuid_str)
 
-    assert gcc.web_client.delete_function.called_with(func_uuid_str)
+    gcc.web_client.delete_function.assert_called_with(func_uuid_str)
 
 
 def test_missing_task_info(mocker, login_manager):


### PR DESCRIPTION
The `assert` statement merely checks the truthiness of its operand. Unfornately, that's a problem when there's a typo, as was the case here. `MagicMock().called` returns a boolean of whether that attribute was called as a function, but `MagicMock().called_with(...)` is not defined specially by `unittest.mock`.  Thus, it is magically being created by that very statement, and just passing.

What _does_ exist is `.assert_called_with(...)`, so alter tests accordingly.

## Type of change

- Bug fix (non-breaking change that fixes an issue)