### PR TITLE
Pass `label` to Parsl HTEX

### DIFF
--- a/changelog.d/20231106_152114_30907815+rjmello_gcengine_label_passthrough.rst
+++ b/changelog.d/20231106_152114_30907815+rjmello_gcengine_label_passthrough.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- The engine configuration variable `label`, which defines the name of
+  the engine log directory, now works with `GlobusComputeEngine.`

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -41,7 +41,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.max_workers_per_node = 1
         if executor is None:
             executor = HighThroughputExecutor(  # type: ignore
-                *args, address=address, heartbeat_period=heartbeat_period, **kwargs
+                *args,
+                label=label,
+                address=address,
+                heartbeat_period=heartbeat_period,
+                **kwargs,
             )
         self.executor = executor
 

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -194,7 +194,12 @@ def test_gcengine_pass_through_to_executor(mocker: MockFixture):
     )
 
     args = ("arg1", 2)
-    kwargs = {"address": "127.0.0.1", "heartbeat_period": 10, "foo": "bar"}
+    kwargs = {
+        "label": "VroomEngine",
+        "address": "127.0.0.1",
+        "heartbeat_period": 10,
+        "foo": "bar",
+    }
     GlobusComputeEngine(*args, **kwargs)
 
     a, k = mock_executor.call_args


### PR DESCRIPTION
# Description

We now pass the `label` argument for the `GlobusComputeEngine` to the Parsl `HighThroughputExecutor`.

## Type of change

- Bug fix (non-breaking change that fixes an issue)