### PR TITLE
Pass `run_dir` to Parsl HTEX when starting engine

### DIFF
--- a/changelog.d/20231106_203334_30907815+rjmello.rst
+++ b/changelog.d/20231106_203334_30907815+rjmello.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- The `GlobusComputeEngine` worker logs will appear in the `~/.globus_compute`
+  directory rather than the current working directory.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -53,12 +53,12 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         results_passthrough: t.Optional[queue.Queue] = None,
         **kwargs,
     ):
-        assert run_dir, "GCExecutor requires kwarg:run_dir at start"
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
+        assert run_dir, "GCExecutor requires kwarg:run_dir at start"
 
         self.endpoint_id = endpoint_id
-        self.run_dir = os.path.join(os.getcwd(), run_dir)
-        self.executor.run_dir = run_dir
+        self.run_dir = run_dir
+        self.executor.run_dir = self.run_dir
         script_dir = os.path.join(self.run_dir, "submit_scripts")
         self.executor.provider.script_dir = script_dir
         if (

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -55,8 +55,10 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
     ):
         assert run_dir, "GCExecutor requires kwarg:run_dir at start"
         assert endpoint_id, "GCExecutor requires kwarg:endpoint_id at start"
-        self.run_dir = os.path.join(os.getcwd(), run_dir)
+
         self.endpoint_id = endpoint_id
+        self.run_dir = os.path.join(os.getcwd(), run_dir)
+        self.executor.run_dir = run_dir
         script_dir = os.path.join(self.run_dir, "submit_scripts")
         self.executor.provider.script_dir = script_dir
         if (

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -1,8 +1,11 @@
 import concurrent.futures
 import logging
+import pathlib
 import random
 import time
 import uuid
+from queue import Queue
+from unittest import mock
 
 import pytest
 from globus_compute_common import messagepack
@@ -200,3 +203,25 @@ def test_gcengine_pass_through_to_executor(mocker: MockFixture):
     a, k = mock_executor.call_args
     assert a == args
     assert kwargs == k
+
+
+def test_gcengine_start_pass_through_to_executor(
+    mocker: MockFixture, tmp_path: pathlib.Path
+):
+    mock_executor = mocker.patch(
+        "globus_compute_endpoint.engines.globus_compute.HighThroughputExecutor"
+    )
+    mock_executor.provider = mock.MagicMock()
+
+    run_dir = tmp_path
+    scripts_dir = str(tmp_path / "submit_scripts")
+    engine = GlobusComputeEngine(executor=mock_executor)
+
+    assert mock_executor.run_dir != run_dir
+    assert mock_executor.provider.script_dir != scripts_dir
+
+    engine.start(endpoint_id=uuid.uuid4(), run_dir=run_dir, results_passthrough=Queue())
+    engine.shutdown()
+
+    assert mock_executor.run_dir == run_dir
+    assert mock_executor.provider.script_dir == scripts_dir


### PR DESCRIPTION
# Description

The `GlobusComputeEngine` worker logs will appear in the `~/.globus_compute` directory rather than the current working directory.

## Type of change

- Bug fix (non-breaking change that fixes an issue)