### PR TITLE
Add container location to internal `Task` object

### DIFF
--- a/compute_endpoint/tests/unit/test_htex.py
+++ b/compute_endpoint/tests/unit/test_htex.py
@@ -4,15 +4,19 @@ import uuid
 
 import pytest
 from globus_compute_common import messagepack
-from globus_compute_endpoint.executors import HighThroughputExecutor
+from globus_compute_endpoint.engines import HighThroughputEngine
+from globus_compute_endpoint.engines.high_throughput.messages import (
+    Task as InternalTask,
+)
 from globus_compute_sdk.serialize import ComputeSerializer
+from pytest_mock import MockFixture
 from tests.utils import div_zero, double, ez_pack_function, kill_manager
 
 
 @pytest.fixture
 def htex():
     ep_id = uuid.uuid4()
-    executor = HighThroughputExecutor(
+    executor = HighThroughputEngine(
         address="127.0.0.1",
         heartbeat_period=1,
         heartbeat_threshold=1,
@@ -140,3 +144,43 @@ def test_htex_manager_lost(htex):
         assert result.error_details.code == "RemoteExecutionError"
         assert "ManagerLost" in result.data
         break
+
+
+def test_engine_submit_container_location(
+    mocker: MockFixture, htex: HighThroughputEngine
+):
+    engine = htex
+    task_id = uuid.uuid4()
+    container_id = uuid.uuid4()
+    container_type = "singularity"
+    container_loc = "/path/to/container"
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, double, (10,), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(
+            task_id=task_id,
+            container_id=container_id,
+            container=messagepack.message_types.Container(
+                container_id=container_id,
+                name="RedSolo",
+                images=[
+                    messagepack.message_types.ContainerImage(
+                        image_type=container_type,
+                        location=container_loc,
+                        created_at=1699389746.8433976,
+                        modified_at=1699389746.8433977,
+                    )
+                ],
+            ),
+            task_buffer=task_body,
+        )
+    )
+
+    mock_put = mocker.patch.object(engine.outgoing_q, "put")
+
+    engine.container_type = container_type
+    engine.submit(str(task_id), task_message)
+
+    a, _ = mock_put.call_args
+    unpacked_msg = InternalTask.unpack(a[0])
+    assert unpacked_msg.container_id == container_loc


### PR DESCRIPTION
# Description

I've reimplemented the code that we mistakenly broke in PR #1140. The main difference is that we now unpack the task message in the `submit()` method of the `HighThroughputEngine` rather than the `EndpointManager` since the former will be deprecated.

[sc-27595]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
