### PR TITLE
Separate heartbeat_periods and reporting_period

### DIFF
--- a/changelog.d/20231108_133632_yadudoc1729_heartbeats_and_reporting_sc_28343.rst
+++ b/changelog.d/20231108_133632_yadudoc1729_heartbeats_and_reporting_sc_28343.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+  Setting `heartbeat_period` on the engines no longer change the
+  interval at which endpoint status messages are sent to the service.
+
+  Setting `GlobusComputeEngine(heartbeat_period=1)` now only sets the
+  frequency of heartbeats between the internal components of the Engine.

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -35,7 +35,7 @@ class ReportingThread:
         target: Target function to be invoked to get report and post to queue
         args: args to be passed to target fn
         kwargs: kwargs to be passed to target fn
-        reporting_period
+        reporting_period: float, defaults to 30.0s
         """
         self.status: Future = Future()
         self._shutdown_event = threading.Event()
@@ -75,12 +75,10 @@ class GlobusComputeEngineBase(ABC):
     def __init__(
         self,
         *args: object,
-        heartbeat_period: int = 30,
         endpoint_id: t.Optional[uuid.UUID] = None,
         **kwargs: object,
     ):
         self._shutdown_event = threading.Event()
-        self._heartbeat_period = heartbeat_period
         self.endpoint_id = endpoint_id
 
         # remove these unused vars that we are adding to just keep

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -25,7 +25,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         *args,
         label: str = "GlobusComputeEngine",
         address: t.Optional[str] = None,
-        heartbeat_period: int = 30,
         strategy: t.Optional[SimpleStrategy] = SimpleStrategy(),
         executor: t.Optional[HighThroughputExecutor] = None,
         **kwargs,
@@ -34,9 +33,10 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.run_dir = os.getcwd()
         self.label = label
         self._status_report_thread = ReportingThread(
-            target=self.report_status, args=[], reporting_period=heartbeat_period
+            target=self.report_status,
+            args=[],
         )
-        super().__init__(*args, heartbeat_period=heartbeat_period, **kwargs)
+        super().__init__(*args, **kwargs)
         self.strategy = strategy
         self.max_workers_per_node = 1
         if executor is None:
@@ -44,7 +44,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 *args,
                 label=label,
                 address=address,
-                heartbeat_period=heartbeat_period,
                 **kwargs,
             )
         self.executor = executor
@@ -258,7 +257,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 "min_blocks": self.executor.provider.min_blocks,
                 "max_workers_per_node": self.executor.max_workers,
                 "nodes_per_block": self.executor.provider.nodes_per_block,
-                "heartbeat_period": self._heartbeat_period,
+                "heartbeat_period": self.executor.heartbeat_period,
             },
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}  # TODO

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -32,10 +32,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.address = address
         self.run_dir = os.getcwd()
         self.label = label
-        self._status_report_thread = ReportingThread(
-            target=self.report_status,
-            args=[],
-        )
+        self._status_report_thread = ReportingThread(target=self.report_status, args=[])
         super().__init__(*args, **kwargs)
         self.strategy = strategy
         self.max_workers_per_node = 1

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -86,6 +86,7 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
                 "min_blocks": 1,
                 "max_workers_per_node": self.executor._max_workers,  # type: ignore
                 "nodes_per_block": 1,
+                "heartbeat_period": None,
             },
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -26,7 +26,6 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         label: str = "ProcessPoolEngine",
-        heartbeat_period: int = 30,
         **kwargs,
     ):
         self.label = label
@@ -34,9 +33,10 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
         self._executor_args = args
         self._executor_kwargs = kwargs
         self._status_report_thread = ReportingThread(
-            target=self.report_status, args=[], reporting_period=heartbeat_period
+            target=self.report_status,
+            args=[],
         )
-        super().__init__(*args, heartbeat_period=heartbeat_period, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def start(
         self,
@@ -86,7 +86,6 @@ class ProcessPoolEngine(GlobusComputeEngineBase):
                 "min_blocks": 1,
                 "max_workers_per_node": self.executor._max_workers,  # type: ignore
                 "nodes_per_block": 1,
-                "heartbeat_period": self._heartbeat_period,
             },
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -83,6 +83,7 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
                 "min_blocks": 1,
                 "max_workers_per_node": self.executor._max_workers,  # type: ignore
                 "nodes_per_block": 1,
+                "heartbeat_period": None,
             },
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -26,15 +26,15 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
         self,
         *args,
         label: str = "ThreadPoolEngine",
-        heartbeat_period: int = 30,
         **kwargs,
     ):
         self.label = label
         self.executor = NativeExecutor(*args, **kwargs)
         self._status_report_thread = ReportingThread(
-            target=self.report_status, args=[], reporting_period=heartbeat_period
+            target=self.report_status,
+            args=[],
         )
-        super().__init__(*args, heartbeat_period=heartbeat_period, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def start(
         self,
@@ -83,7 +83,6 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
                 "min_blocks": 1,
                 "max_workers_per_node": self.executor._max_workers,  # type: ignore
                 "nodes_per_block": 1,
-                "heartbeat_period": self._heartbeat_period,
             },
         }
         task_status_deltas: t.Dict[str, t.List[TaskTransition]] = {}

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -123,7 +123,7 @@ def test_engine_submit_internal(engine_type: GlobusComputeEngineBase, engine_run
 
 
 def test_proc_pool_engine_not_started():
-    engine = ProcessPoolEngine(heartbeat_period=1, max_workers=2)
+    engine = ProcessPoolEngine(max_workers=2)
 
     with pytest.raises(AssertionError) as pyt_exc:
         engine.submit(double, 10)
@@ -183,7 +183,7 @@ def test_gc_engine_system_failure(engine_runner):
 
 @pytest.mark.parametrize("engine_type", (GlobusComputeEngine, HighThroughputEngine))
 def test_serialized_engine_config_has_provider(engine_type: GlobusComputeEngineBase):
-    ep_config = Config(executors=[engine_type()])
+    ep_config = Config(executors=[engine_type(address="127.0.0.1")])
 
     res = serialize_config(ep_config)
     executor = res["executors"][0].get("executor") or res["executors"][0]
@@ -200,7 +200,6 @@ def test_gcengine_pass_through_to_executor(mocker: MockFixture):
     kwargs = {
         "label": "VroomEngine",
         "address": "127.0.0.1",
-        "heartbeat_period": 10,
         "foo": "bar",
     }
     GlobusComputeEngine(*args, **kwargs)

--- a/compute_endpoint/tests/unit/test_reporting_period.py
+++ b/compute_endpoint/tests/unit/test_reporting_period.py
@@ -1,7 +1,7 @@
 import time
 from unittest.mock import patch
 
-from globus_compute_endpoint.engines.base import _REPORTING_PERIOD, ReportingThread
+from globus_compute_endpoint.engines.base import ReportingThread
 from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
 from globus_compute_endpoint.engines.thread_pool import ThreadPoolEngine
 
@@ -18,15 +18,15 @@ def test_default_period():
     """Confirm that the default reporting period is maintained"""
 
     thread = ReportingThread(target=counter, args=[])
-    assert thread.reporting_period == _REPORTING_PERIOD
+    assert thread.reporting_period == 30.0
 
     thread_pool = ThreadPoolEngine()
     thread = thread_pool._status_report_thread
-    assert thread.reporting_period == _REPORTING_PERIOD
+    assert thread.reporting_period == 30.0
 
     gce = GlobusComputeEngine(address="127.0.0.1", heartbeat_period=1)
     thread = gce._status_report_thread
-    assert thread.reporting_period == _REPORTING_PERIOD
+    assert thread.reporting_period == 30.0
     assert gce.executor.heartbeat_period == 1
 
 

--- a/compute_endpoint/tests/unit/test_reporting_period.py
+++ b/compute_endpoint/tests/unit/test_reporting_period.py
@@ -1,0 +1,42 @@
+import time
+from unittest.mock import patch
+
+from globus_compute_endpoint.engines.base import _REPORTING_PERIOD, ReportingThread
+from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
+from globus_compute_endpoint.engines.thread_pool import ThreadPoolEngine
+
+G_COUNTER = 0
+REPORTING_PERIOD = 0.1
+
+
+def counter():
+    global G_COUNTER
+    G_COUNTER += 1
+
+
+def test_default_period():
+    """Confirm that the default reporting period is maintained"""
+
+    thread = ReportingThread(target=counter, args=[])
+    assert thread.reporting_period == _REPORTING_PERIOD
+
+    thread_pool = ThreadPoolEngine()
+    thread = thread_pool._status_report_thread
+    assert thread.reporting_period == _REPORTING_PERIOD
+
+    gce = GlobusComputeEngine(address="127.0.0.1", heartbeat_period=1)
+    thread = gce._status_report_thread
+    assert thread.reporting_period == _REPORTING_PERIOD
+    assert gce.executor.heartbeat_period == 1
+
+
+def test_reporting_period():
+    thread = ReportingThread(target=counter, args=[])
+
+    with patch.object(thread, "reporting_period", REPORTING_PERIOD):
+        assert thread.reporting_period == REPORTING_PERIOD
+        thread.start()
+        time.sleep(0.25)
+        thread.stop()
+
+    assert G_COUNTER == 3

--- a/compute_endpoint/tests/unit/test_status_reporting.py
+++ b/compute_endpoint/tests/unit/test_status_reporting.py
@@ -14,15 +14,13 @@ logger = logging.getLogger(__name__)
     "engine_type",
     (engines.ProcessPoolEngine, engines.ThreadPoolEngine, engines.GlobusComputeEngine),
 )
-def test_status_reporting(engine_type, engine_runner, engine_heartbeat: int):
+def test_status_reporting(engine_type, engine_runner):
     engine = engine_runner(engine_type)
 
     report = engine.get_status_report()
     assert isinstance(report, EPStatusReport)
 
     results_q = engine.results_passthrough
-
-    assert engine._status_report_thread.reporting_period == engine_heartbeat
 
     # Flush queue to start
     while not results_q.empty():
@@ -88,4 +86,4 @@ def test_gcengine_status_report(mocker: MockFixture, engine_runner: callable):
     assert info["min_blocks"] == engine.executor.provider.min_blocks
     assert info["max_workers_per_node"] == engine.executor.max_workers
     assert info["nodes_per_block"] == engine.executor.provider.nodes_per_block
-    assert info["heartbeat_period"] == engine._heartbeat_period
+    assert info["heartbeat_period"] == engine.executor.heartbeat_period


### PR DESCRIPTION
# Description

The `GlobusComputeEngine` has a notion of `hearbeat_period` and `heartbeat_threshold` used internally to track worker liveness. This is separate from the status reporting logic implemented in the `GlobusComputeEngineBase` that sends `EPStatusReports`.

This PR sets the `reporting period` to a constant. Users should not be able to tweak this, and we should not be supporting cases where there's any functionality built on faster updates.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
