### PR TITLE
Read template before dropping privs

### DIFF
--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -21,6 +21,7 @@ from globus_compute_endpoint.endpoint.config.default_config import (
     config as default_config,
 )
 from globus_compute_endpoint.endpoint.config.utils import (
+    load_user_config_template,
     render_config_user_template,
     serialize_config,
 )
@@ -622,8 +623,9 @@ def test_mu_endpoint_user_ep_sensible_default(tmp_path):
     ep_dir = tmp_path / "new_endpoint_dir"
     Endpoint.init_endpoint_dir(ep_dir, multi_user=True)
 
+    tmpl_str, schema = load_user_config_template(ep_dir)
     # Doesn't crash; loads yaml, jinja template has defaults
-    render_config_user_template(ep_dir, {})
+    render_config_user_template(tmpl_str, schema, {})
 
 
 def test_always_prints_endpoint_id_to_terminal(mocker, mock_ep_data, mock_reg_info):

--- a/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
+++ b/compute_sdk/globus_compute_sdk/sdk/login_manager/tokenstore.py
@@ -35,7 +35,7 @@ def invalidate_old_config() -> None:
             os.remove(token_file)
 
 
-def ensure_compute_dir() -> pathlib.Path:
+def ensure_compute_dir(home: os.PathLike | None = None) -> pathlib.Path:
     legacy_dirname = _home() / ".funcx"
     dirname = _home() / ".globus_compute"
 


### PR DESCRIPTION
The error was in attempting to read a file to which the dropped-privileges process did not have access:

    /root/

`root`'s home directory is (very correctly) set to 0o40700, meaning that only `root` can access anything inside of `/root/`.  This is a problem for the user endpoint as it is unable to read the `user_config_template.yaml` file that is located at

    /root/.globus_compute/<multi_user_endpoint>/user_config_template.yaml

Addressed by reading the file into a string *before* dropping privileges.

[sc-28360]

## Type of change

- Bug fix (non-breaking change that fixes an issue)