### PR TITLE
remove references to sharing endpoints

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -32,9 +32,9 @@ You will be required to authenticate the first time you run ``globus-compute-end
 If you have authenticated previously, the endpoint will cache access tokens in
 the local configuration file.
 
-Globus Compute requires authentication in order to associate
-endpoints with users and ensure only authorized users can run tasks on that endpoint. As part of this step,
-we request access to your identity and Globus Groups.
+Globus Compute requires authentication in order to associate endpoints with
+users and that ensure only the authorized user can run tasks on that endpoint.
+As part of this step, we request access to your identity and Globus Groups.
 
 To get started, you will first want to configure a new endpoint.  ::
 

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -38,9 +38,9 @@ you have access.
 .. note::
     A friendly FYI: the tutorial endpoint is public -- available for any
     (authenticated) user.  You are welcome to use it, but please limit the size
-    and number of functions you send to this endpoint as it is a shared
-    resource that is (intentionally) not very powerful.  It's primary intended
-    purpose is for an introduction to the Globus Compute toolset.
+    and number of functions you send to this endpoint.  It is hosted on a small
+    VM with limited CPU and memory, intentionally underpowered.   Its primary
+    intended purpose is for an introduction to the Globus Compute toolset.
 
 Second, the waiting -- or "blocking" -- for a result is automatic.  The
 |.submit()|_ call returns a |Future|_ immediately; the actual HTTP call to the

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -42,6 +42,9 @@ you have access.
     VM with limited CPU and memory, intentionally underpowered.   Its primary
     intended purpose is for an introduction to the Globus Compute toolset.
 
+    This endpoint has been made public by the Globus Compute team for tutorial
+    use, but endpoints created by users can not be shared publicly.
+
 Second, the waiting -- or "blocking" -- for a result is automatic.  The
 |.submit()|_ call returns a |Future|_ immediately; the actual HTTP call to the
 Globus Compute web-services will not have occurred yet, and neither will the task even

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -143,6 +143,9 @@ use, it is hosted on a small VM with limited CPU and memory, intentionally
 underpowered.  As it is a shared resource, please be conscientious with the
 size and number of functions you send to this endpoint.
 
+This endpoint has been made public by the Globus Compute team for the purposes
+of this tutorial, but endpoints created by users can not be shared publicly.
+
 Deploying an endpoint
 ----------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -139,9 +139,9 @@ execution to available endpoints.  For most use-cases that will use the
     documentation), the above workflow will automatically handle registration.
 
 A word on the above example: while the tutorial endpoint is open for anyone to
-use, it is hosted on a small Kubernetes cluster -- somewhat intentionally
-underpowered.  As it is a shared (and tiny) resource, please be conscientious
-with the size and number of functions you send to this endpoint.
+use, it is hosted on a small VM with limited CPU and memory, intentionally
+underpowered.  As it is a shared resource, please be conscientious with the
+size and number of functions you send to this endpoint.
 
 Deploying an endpoint
 ----------------------

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -29,7 +29,7 @@ It also provides group and profile management for user accounts.
 As part of the authentication process, Globus Compute will request access
 to your identity (to retrieve your email address) and Globus Groups. Globus Compute uses
 Groups to facilitate sharing and to make authorization decisions.
-Globus Compute allows endpoints and functions to be shared by associating a Globus Group.
+Globus Compute allows functions to be shared by associating a Globus Group.
 
 .. note:: Globus Compute internally caches function, endpoint, and authorization lookups. Caches are based on user authentication tokens. To force refresh cached
           entries, you can re-authenticate your client with ``force_login=True``.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -14,6 +14,9 @@ clusters with batch schedulers (e.g., Slurm, PBS), Kubernetes, or on a
 local PC. After configuring an endpoint you can use it in this tutorial
 by simply setting the ``endpoint_id`` below.
 
+Note that although the tutorial endpoint has been made public by the Globus
+Compute team, endpoints created by users can not be shared publicly.
+
 Globus Compute Python SDK
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -31,7 +31,7 @@ Compute, you must first authenticate using one of hundreds of supported
 identity provides (e.g., your institution, ORCID, or Google). As part of
 the authentication process you must grant permission for Globus Compute
 to access your identity information (to retrieve your email address) and
-Globus Groups management access (to share endpoints).
+Globus Groups management access (for sharing functions).
 
 .. code:: python
 


### PR DESCRIPTION
# Description

Remove references to the sharing of endpoints, and make it more clear that only the single authorized user can access the endpoint.

## Type of change

- Documentation update