### PR TITLE
Pass `address` to Parsl HTEX via `kwargs` catch-all

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -24,12 +24,10 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self,
         *args,
         label: str = "GlobusComputeEngine",
-        address: t.Optional[str] = None,
         strategy: t.Optional[SimpleStrategy] = SimpleStrategy(),
         executor: t.Optional[HighThroughputExecutor] = None,
         **kwargs,
     ):
-        self.address = address
         self.run_dir = os.getcwd()
         self.label = label
         self._status_report_thread = ReportingThread(target=self.report_status, args=[])
@@ -38,10 +36,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.max_workers_per_node = 1
         if executor is None:
             executor = HighThroughputExecutor(  # type: ignore
-                *args,
-                label=label,
-                address=address,
-                **kwargs,
+                *args, label=label, **kwargs
             )
         self.executor = executor
 

--- a/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/process_pool.py
@@ -22,20 +22,12 @@ logger = logging.getLogger(__name__)
 
 
 class ProcessPoolEngine(GlobusComputeEngineBase):
-    def __init__(
-        self,
-        *args,
-        label: str = "ProcessPoolEngine",
-        **kwargs,
-    ):
+    def __init__(self, *args, label: str = "ProcessPoolEngine", **kwargs):
         self.label = label
         self.executor: t.Optional[NativeExecutor] = None
         self._executor_args = args
         self._executor_kwargs = kwargs
-        self._status_report_thread = ReportingThread(
-            target=self.report_status,
-            args=[],
-        )
+        self._status_report_thread = ReportingThread(target=self.report_status, args=[])
         super().__init__(*args, **kwargs)
 
     def start(

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -22,18 +22,10 @@ logger = logging.getLogger(__name__)
 
 
 class ThreadPoolEngine(GlobusComputeEngineBase):
-    def __init__(
-        self,
-        *args,
-        label: str = "ThreadPoolEngine",
-        **kwargs,
-    ):
+    def __init__(self, *args, label: str = "ThreadPoolEngine", **kwargs):
         self.label = label
         self.executor = NativeExecutor(*args, **kwargs)
-        self._status_report_thread = ReportingThread(
-            target=self.report_status,
-            args=[],
-        )
+        self._status_report_thread = ReportingThread(target=self.report_status, args=[])
         super().__init__(*args, **kwargs)
 
     def start(


### PR DESCRIPTION
# Description

We can pass the `address` arg to the Parsl HTEX via the `kwargs` catch-all since we aren't doing anything special with it.

## Type of change

- Code maintenance/cleanup
