### PR TITLE
Reinstate AMQP changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,12 @@ New Functionality
   existing tokens.  This removes the need to implement a custom login manager
   to create a client from authorizers.
 
+- The ``Executor`` can now be told which port to use to listen to AMQP results, via
+  either the ``amqp_port`` keyword argument or the ``amqp_port`` property.
+
+- Endpoints can be configured to talk to RMQ over a different port via the ``amqp_port``
+  configuration option.
+
 - Added support for endpoint status reports when using ``GlobusComputeEngine``.
   The report includes information such as the total number of active workers,
   idle workers, and pending tasks.


### PR DESCRIPTION
Turns out 443 is already exposed to the world - not sure how we missed that, and hoping to make that more obvious for the future, but that does mean that the AMQP port feature is ready for prime time.
