### PR TITLE
Utilize v3 POST/PUT routes for EP registration

### DIFF
--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -77,7 +77,7 @@ class FakeLoginManager:
 
     def get_web_client(self, *, base_url: str | None = None) -> WebClient:
         return WebClient(
-            base_url="https://compute.api.globus.org/v2/",
+            base_url="https://compute.api.globus.org",
             authorizer=globus_sdk.NullAuthorizer(),
         )
 

--- a/compute_endpoint/tests/integration/endpoint/conftest.py
+++ b/compute_endpoint/tests/integration/endpoint/conftest.py
@@ -51,7 +51,18 @@ def setup_register_endpoint_response(
 
         responses.add(
             method=responses.POST,
-            url="https://compute.api.globus.org/v2/endpoints",
+            url="https://compute.api.globus.org/v3/endpoints",
+            headers={"Content-Type": "application/json"},
+            json={
+                "endpoint_id": endpoint_uuid,
+                "task_queue_info": task_queue_info,
+                "result_queue_info": rq_info,
+            },
+        )
+
+        responses.add(
+            method=responses.PUT,
+            url=f"https://compute.api.globus.org/v3/endpoints/{endpoint_uuid}",
             headers={"Content-Type": "application/json"},
             json={
                 "endpoint_id": endpoint_uuid,

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -60,7 +60,7 @@ def test_non_configured_endpoint(mocker):
 )
 def test_start_endpoint_display_name(mocker, fs, display_name):
     responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v2/endpoints", json={}, status=404
+        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
     )
 
     ep = endpoint.Endpoint()
@@ -70,7 +70,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
     ep_conf.display_name = display_name
 
     with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, str(uuid.uuid4()), ep_conf, False, True, reg_info={})
+        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
     assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
 
     req = pyt_exc.value.__cause__._underlying_response.request
@@ -83,7 +83,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
 
 def test_start_endpoint_allowlist_passthrough(mocker, fs):
     responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v2/endpoints", json={}, status=404
+        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
     )
 
     ep = endpoint.Endpoint()
@@ -93,7 +93,7 @@ def test_start_endpoint_allowlist_passthrough(mocker, fs):
     ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
 
     with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, str(uuid.uuid4()), ep_conf, False, True, reg_info={})
+        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
     assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
 
     req = pyt_exc.value.__cause__._underlying_response.request
@@ -104,7 +104,7 @@ def test_start_endpoint_allowlist_passthrough(mocker, fs):
 
 def test_start_endpoint_auth_policy_passthrough(mocker, fs):
     responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v2/endpoints", json={}, status=404
+        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
     )
 
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
@@ -115,7 +115,7 @@ def test_start_endpoint_auth_policy_passthrough(mocker, fs):
     ep_conf.authentication_policy = str(uuid.uuid4())
 
     with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, str(uuid.uuid4()), ep_conf, False, True, reg_info={})
+        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
     assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
 
     req = pyt_exc.value.__cause__._underlying_response.request

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint_manager.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import pathlib
@@ -443,32 +442,6 @@ class TestStart:
             results_ack_handler=None,
             **mock_optionals,
         )
-
-    def test_get_or_create_endpoint_uuid_no_json_no_uuid(self, mocker):
-        mock_uuid = mocker.patch(f"{_MOCK_BASE}uuid.uuid4")
-        mock_uuid.return_value = 123456
-
-        config_dir = pathlib.Path("/some/path/mock_endpoint")
-        manager = Endpoint()
-        manager.configure_endpoint(config_dir, None)
-        assert "123456" == manager.get_or_create_endpoint_uuid(config_dir, None)
-
-    def test_get_or_create_endpoint_uuid_no_json_given_uuid(self):
-        config_dir = pathlib.Path("/some/path/mock_endpoint")
-        manager = Endpoint()
-        manager.configure_endpoint(config_dir, None)
-        assert "234567" == manager.get_or_create_endpoint_uuid(config_dir, "234567")
-
-    def test_get_or_create_endpoint_uuid_given_json(self):
-        config_dir = pathlib.Path("/some/path/mock_endpoint")
-        manager = Endpoint()
-        manager.configure_endpoint(config_dir, None)
-
-        mock_dict = {"endpoint_id": "abcde12345"}
-        with open(os.path.join(config_dir, "endpoint.json"), "w") as fd:
-            json.dump(mock_dict, fd)
-
-        assert "abcde12345" == manager.get_or_create_endpoint_uuid(config_dir, "234567")
 
     @pytest.mark.parametrize("dir_exists", (True, False))
     @pytest.mark.parametrize("web_svc_ok", (True, False))

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -416,7 +416,7 @@ class Client:
     def register_endpoint(
         self,
         name,
-        endpoint_id: UUID_LIKE_T,
+        endpoint_id: UUID_LIKE_T | None,
         metadata: dict | None = None,
         multi_user: bool | None = None,
         display_name: str | None = None,
@@ -429,7 +429,7 @@ class Client:
         ----------
         name : str
             Name of the endpoint
-        endpoint_id : str | UUID
+        endpoint_id : str | UUID | None
             The uuid of the endpoint
         metadata : dict | None
             Endpoint metadata

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -167,7 +167,7 @@ class WebClient(globus_sdk.BaseClient):
     def register_endpoint(
         self,
         endpoint_name: str,
-        endpoint_id: UUID_LIKE_T,
+        endpoint_id: t.Optional[UUID_LIKE_T] = None,
         *,
         metadata: t.Optional[dict] = None,
         multi_user: t.Optional[bool] = None,
@@ -176,10 +176,7 @@ class WebClient(globus_sdk.BaseClient):
         auth_policy: t.Optional[UUID_LIKE_T] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
-        data: t.Dict[str, t.Any] = {
-            "endpoint_name": endpoint_name,
-            "endpoint_uuid": str(endpoint_id),
-        }
+        data: t.Dict[str, t.Any] = {"endpoint_name": endpoint_name}
 
         # Only populate if not None.  "" is valid and will be included
         # No value or a 'None' on an existing endpoint will leave
@@ -200,7 +197,11 @@ class WebClient(globus_sdk.BaseClient):
             data["authentication_policy"] = auth_policy
         if additional_fields is not None:
             data.update(additional_fields)
-        return self.post("/v2/endpoints", data=data)
+
+        if endpoint_id:
+            return self.put(f"/v3/endpoints/{endpoint_id}", data=data)
+        else:
+            return self.post("/v3/endpoints", data=data)
 
     def get_result_amqp_url(self) -> globus_sdk.GlobusHTTPResponse:
         return self.get("/v2/get_amqp_result_connection_url")


### PR DESCRIPTION
# Description

Utilize the v3 POST/PUT routes for endpoint registration and rely on the web service to generate endpoint UUIDs.

[sc-28410]

## Type of change

- New feature (non-breaking change that adds functionality)
