### PR TITLE
Centralize location of serialization/deserialization errors

### DIFF
--- a/compute_sdk/globus_compute_sdk/errors/__init__.py
+++ b/compute_sdk/globus_compute_sdk/errors/__init__.py
@@ -1,6 +1,8 @@
 from .error_types import (
     ComputeError,
+    DeserializationError,
     MaxResultSizeExceeded,
+    SerdeError,
     SerializationError,
     TaskExecutionFailed,
     TaskPending,
@@ -11,7 +13,9 @@ __all__ = (
     "ComputeError",
     "TaskExecutionFailed",
     "MaxResultSizeExceeded",
+    "SerdeError",
     "SerializationError",
+    "DeserializationError",
     "TaskPending",
     "VersionMismatch",
 )

--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -21,14 +21,28 @@ class VersionMismatch(ComputeError):
         return f"Globus Compute Versioning Issue: {self.version_message}"
 
 
-class SerializationError(ComputeError):
-    """Something failed during serialization or deserialization."""
+class SerdeError(ComputeError):
+    """Base class for SerializationError and DeserializationError"""
 
-    def __init__(self, message):
-        self.message = message
+
+class SerializationError(SerdeError):
+    """Something failed during serialization."""
+
+    def __init__(self, reason):
+        self.reason = reason
 
     def __repr__(self):
-        return f"Serialization Error during: {self.message}"
+        return f"Serialization failed due to {self.reason}"
+
+
+class DeserializationError(SerdeError):
+    """Something failed during deserialization."""
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __repr__(self):
+        return f"Deserialization failed due to {self.reason}"
 
 
 class TaskPending(ComputeError):

--- a/compute_sdk/globus_compute_sdk/serialize/base.py
+++ b/compute_sdk/globus_compute_sdk/serialize/base.py
@@ -1,5 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
+from globus_compute_sdk.errors import DeserializationError
+
 
 class SerializationStrategy(metaclass=ABCMeta):
     """A SerializationStrategy is in charge of converting function source code or
@@ -33,19 +35,3 @@ class SerializationStrategy(metaclass=ABCMeta):
     @abstractmethod
     def deserialize(self, payload):
         raise NotImplementedError("Concrete class did not implement deserialize")
-
-
-class SerializationError(Exception):
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __repr__(self):
-        return f"Serialization failed due to {self.reason}"
-
-
-class DeserializationError(Exception):
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __repr__(self):
-        return f"Deserialization failed due to {self.reason}"

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -8,11 +8,8 @@ import typing as t
 from collections import OrderedDict
 
 import dill
-from globus_compute_sdk.serialize.base import (
-    DeserializationError,
-    SerializationError,
-    SerializationStrategy,
-)
+from globus_compute_sdk.errors import DeserializationError, SerializationError
+from globus_compute_sdk.serialize.base import SerializationStrategy
 
 logger = logging.getLogger(__name__)
 

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -3,11 +3,8 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_compute_sdk.serialize.base import (
-    DeserializationError,
-    SerializationError,
-    SerializationStrategy,
-)
+from globus_compute_sdk.errors import DeserializationError, SerializationError
+from globus_compute_sdk.serialize.base import SerializationStrategy
 from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_CODE,
     DEFAULT_STRATEGY_DATA,

--- a/compute_sdk/tests/integration/test_serialization.py
+++ b/compute_sdk/tests/integration/test_serialization.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 import globus_compute_sdk.serialize.concretes as concretes
 import pytest
-from globus_compute_sdk.serialize.base import SerializationError, SerializationStrategy
+from globus_compute_sdk.errors import SerializationError
+from globus_compute_sdk.serialize.base import SerializationStrategy
 from globus_compute_sdk.serialize.facade import ComputeSerializer
 
 # length of serializer identifier


### PR DESCRIPTION
# Description

When implementing user-definable serialization, we were still using our original forked HighThroughputExecutor. That executor relied on globus_compute_sdk.errors.SerializationError. At the same time, the serialization module relied on its own SerializationError. To avoid mixing their semantics up, I left them in place. Now that we've moved away from HighThroughputExecutor, we no longer need that differentiation, so for consistency's sake, this moves the ser/de errors into the SDK's common errors module.

At the same time, introduce a base class to catch both serialization and deserialization errors, and ensure that all three error classes are also ComputeErrors.

## Type of change

- Code maintenance/cleanup
