### PR TITLE
Upgrade pip before running safety checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           python-version: "3.11"
       - name: install requirements
         run: |
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade pip setuptools
           python -m pip install './compute_sdk'
           python -m pip install './compute_endpoint'
           python -m pip install safety


### PR DESCRIPTION
# Description

Minor update to safety checks to upgrade pip. This addresses recent safety check failures:

```
-> Vulnerability found in pip version 23.2.1
   Vulnerability ID: 62044
   Affected spec: <23.3
   ADVISORY: Pip 23.3 includes a fix for CVE-2023-57[52](https://github.com/funcx-faas/funcX/actions/runs/7009364373/job/19067627381?pr=1342#step:5:53): When installing
   a package from a Mercurial VCS URL (ie "pip install hg+...") with pip...
   CVE-2023-5752
   For more information, please visit
   https://data.safetycli.com/v/62044/f17

 Scan was completed. 1 vulnerability was found.
```