### PR TITLE
Remove detritus from CI image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,10 @@ jobs:
           python-version: "3.11"
       - name: install requirements
         run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install './compute_sdk'
-          python -m pip install './compute_endpoint'
+          python -m pip install -U pip setuptools
+          python -m pip install './compute_sdk' './compute_endpoint'
           python -m pip install safety
+          rm -rf /opt/hostedtoolcache/Python/*/x64/lib/python3.*/site-packages/pip-23.{0,1,2}*
       - name: run safety check
         run: safety check
 


### PR DESCRIPTION
Safety is pedantically correct, if overzealous, and the provided image in ubuntu-latest contains some extra pre-installed packages.  This appears to amount to a situation where pip does not properly remove an old version of an updated package.  In this case, `pip` itself.  So ... help it along by manually removing the offending package.

Hopefully, this will become a non-issue shortly once the image is updated again -- a transient error.  Meanwhile, we have a new CI cruft of our own (`rm -rf ...`)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup

(With thanks to @kurtmckee for the pointer!)