### PR TITLE
Update to parsl 2023.12.4

### DIFF
--- a/changelog.d/20231212_095641_yadudoc1729_update_to_parsl_2023_12_4.rst
+++ b/changelog.d/20231212_095641_yadudoc1729_update_to_parsl_2023_12_4.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Parsl version requirements updated from ``2023.7.3`` to ``2023.12.4``

--- a/compute_endpoint/globus_compute_endpoint/strategies/simple.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/simple.py
@@ -5,7 +5,7 @@ import math
 import time
 
 from globus_compute_endpoint.strategies.base import BaseStrategy
-from parsl.providers.base import JobState
+from parsl.jobs.states import JobState
 
 log = logging.getLogger(__name__)
 

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2023.7.3",
+    "parsl==2023.12.4",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

There are a bunch of fixes and updates to the `HighThroughputExecutor` on the Parsl side that we are not using because the endpoint is pinned to `parsl==2023.7.3`. This PR updates the Parsl version requirements to `parsl==2023.12.4`, and makes adds a minor fix to an updated import path on the parsl side.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
