### PR TITLE
Be more transparent with identity mapping errors

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/identity_mapper.py
@@ -202,13 +202,22 @@ class PosixIdentityMapper:
     def identity_mappings(self):
         self.identity_mappings = None
 
-    def map_identity(self, identity_set: t.Iterable[t.Mapping[str, str]]) -> str | None:
-        for mapper in self.identity_mappings:
-            for identity_data in identity_set:
+    def map_identity(
+        self, identity_set: t.Collection[t.Mapping[str, str]]
+    ) -> str | None:
+        num_mappers = len(self.identity_mappings)
+        num_idents = len(identity_set)
+        for m_i, mapper in enumerate(self.identity_mappings, start=1):
+            for id_i, ident_data in enumerate(identity_set, start=1):
                 try:
-                    identity = mapper.map_identity(identity_data)
+                    identity = mapper.map_identity(ident_data)
                 except Exception as e:
-                    log.warning(f"Identity mapper failed -- ({type(e).__name__}) {e}")
+                    sub = ident_data.get("sub")
+                    log.warning(
+                        f"Identity mapper failed for mapper {m_i} [of {num_mappers}]"
+                        f" ({type(mapper).__name__}) with identity {id_i}"
+                        f" [of {num_idents}] ({sub}) -- ({type(e).__name__}) {e}"
+                    )
                     continue
                 if identity:
                     return identity


### PR DESCRIPTION
If an identity fails to map with a particular mapper, the log output can by slightly confusing.  In particular, there's no indication of which mapper is failing with which identity.  Improve that situation with the index of each mapper, the mapper class, the index of the identity (which is, admittedly, arbitrary, but at least shows that the tested identity is *different* from the previous iteration), and the sub of the identity.

Old output looked like:

    2023-12-15 [...]:212 map_identity Identity mapper failed -- (IdentityMappingError) Error mapping identity

New output looks like:

    2023-12-15 [...]:213 map_identity Identity mapper failed for mapper 1 (ExternalIdentityMapping) with identity 2 (abc91c2e-1234-4d38-9a8f-1cbf4a6ce811) -- (IdentityMappingError) Error mapping identity

There's further work to go to learn *what* happened, but that needs to happen in the library.

## Type of change

- New feature (non-breaking change that adds functionality)