### PR TITLE
Isolate the Python environment that Safety is checking

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -5,8 +5,12 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+env:
+  TARGET_PYTHON_VERSION: '3.11'
+
 jobs:
   smoke-test-dev:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -14,14 +18,17 @@ jobs:
         ref: main
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
-    - run: python -m pip install -U pip setuptools
-    - run: python -m pip install 'tox'
+        python-version: '${{ env.TARGET_PYTHON_VERSION }}'
+    - run: |
+        python -m venv .venv
+        .venv/bin/python -m pip install --upgrade pip setuptools wheel
+        .venv/bin/python -m pip install tox
     - name: run smoke tests (dev)
       env:
         FUNCX_SMOKE_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
         FUNCX_SMOKE_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
       run: |
+        source .venv/bin/activate
         cd smoke_tests
         make dev
 
@@ -32,13 +39,16 @@ jobs:
       with:
         ref: main
     - uses: actions/setup-python@v4
+      with:
+        python-version: '${{ env.TARGET_PYTHON_VERSION }}'
     - name: install requirements
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install './compute_sdk'
-        python -m pip install safety
+        python -m venv .venv
+        .venv/bin/python -m pip install --upgrade pip setuptools wheel
+        .venv/bin/python -m pip install './compute_sdk'
+        .venv/bin/python -m pip install safety
     - name: run safety check
-      run: safety check
+      run: .venv/bin/safety check
 
   safety-check-endpoint:
     runs-on: ubuntu-latest
@@ -47,13 +57,16 @@ jobs:
       with:
         ref: main
     - uses: actions/setup-python@v4
+      with:
+        python-version: '${{ env.TARGET_PYTHON_VERSION }}'
     - name: install requirements
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install './compute_endpoint'
-        python -m pip install safety
+        python -m venv .venv
+        .venv/bin/python -m pip install --upgrade pip setuptools wheel
+        .venv/bin/python -m pip install './compute_endpoint'
+        .venv/bin/python -m pip install safety
     - name: run safety check
-      run: safety check
+      run: .venv/bin/safety check
 
   slack-notify:
     needs:
@@ -66,7 +79,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - run: python -m pip install -U requests
+        with:
+          python-version: '${{ env.TARGET_PYTHON_VERSION }}'
+      - run: python -m pip install --upgrade requests
       - name: notify slack
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/20231216_131520_kurtmckee_fix_daily_workflow.rst
+++ b/changelog.d/20231216_131520_kurtmckee_fix_daily_workflow.rst
@@ -1,0 +1,7 @@
+Development
+^^^^^^^^^^^
+
+-   Update the ``daily`` workflow.
+    -   Add a timeout to the smoke test job.
+    -   Use virtual environments to isolate dependencies that Safety is checking.
+    -   Enforce a singular Python version across all configured jobs.


### PR DESCRIPTION
The daily workflow's Safety checks are failing due to what appear to be pre-installed Python packages. These are not getting overwritten/updated because pip is defaulting to user installation.

### Step: `python -m pip install './compute_sdk'`

```
Defaulting to user installation because normal site-packages is not writeable

Requirement already satisfied: pyjwt<3.0.0,>=2.0.0 in /usr/lib/python3/dist-packages
Requirement already satisfied: cryptography!=3.4.0,>=3.3.1 in /usr/lib/python3/dist-packages
```

### Step: `safety check`

```
  Safety v2.3.5 is scanning for Vulnerabilities...
  Scanning dependencies in your environment:

  -> /usr/local/lib/python3.10/dist-packages
  -> /usr/lib/python3/dist-packages
  -> /home/runner/.local/lib/python3.10/site-packages

...

-> Vulnerability found in pyjwt version 2.3.0
-> Vulnerability found in cryptography version 3.4.8
```

The Safety checks therefore seem to be simply linting GitHub's runner environments, not pinned dependencies of the Compute project.

The side-effect of the Safety failures is that the smoketest is getting canceled due to fast-fail behavior but isn't properly exiting, resulting in the daily workflow running for 6 hours before timing out.

![image](https://github.com/funcx-faas/funcX/assets/39996/7bb23ece-fb26-4adf-9d6c-9b4dfe32f26e)

Finally, the workflow is [throwing warnings](https://github.com/funcx-faas/funcX/actions/runs/7229735889) because `setup-python` is not consistently configured to setup a Python version:

![image](https://github.com/funcx-faas/funcX/assets/39996/aa7134dd-0a41-44bc-9ff9-9b835efa5e46)

----

This PR attempts to address these problems by:

* Creating virtual environments, installing the Compute dependencies, and then running Safety
* Establishing a 10 minute timeout for the smoke test runs
* Enforcing a consistent Python target version

I've not used the `${{ env.XYZ }}` syntax before, so this aspect of the PR may need tweaking. I'm happy to resolve any issues that crop up, so please let me know if this needs some additional work.