### PR TITLE
Pin Parsl to 2023.12.18

### DIFF
--- a/changelog.d/20231219_144502_30907815+rjmello.rst
+++ b/changelog.d/20231219_144502_30907815+rjmello.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Pin Parsl version requirement to ``2023.12.18``.

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2023.12.4",
+    "parsl==2023.12.18",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

This version contains a few improvements to worker robustness. For example, workers will now shut themselves down if their associated manager processes terminate for any reason.

[sc-25274]

## Type of change

- New feature (non-breaking change that adds functionality)
