### PR TITLE
Set quiesce event when task RMQ channel closes

### DIFF
--- a/changelog.d/20240102_141658_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20240102_141658_30907815+rjmello_HEAD.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Improved handling of communication issues related to receiving tasks
+  from the Compute web services.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -174,12 +174,12 @@ class TaskQueueSubscriber(multiprocessing.Process):
                     "ownership by an active endpoint"
                 )
                 logger.warning("Channel will close without connection retry")
-                self.status = SubscriberProcessStatus.closing
-                self.quiesce_event.set()
         elif isinstance(exception, pika.exceptions.ChannelClosedByClient):
             logger.debug("Detected channel closed by client")
         else:
             logger.exception("Channel closed by unhandled exception.")
+        self.status = SubscriberProcessStatus.closing
+        self.quiesce_event.set()
         logger.debug("marking channel as closed")
         self._channel_closed.set()
 


### PR DESCRIPTION
# Description

The interchange should quiesce when the task RabbitMQ channel closes for any reason. This enables the endpoint to shut down when, for example, the task queue is deleted.

Fixes [sc-28687]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
