### PR TITLE
Change default AMQP port for new endpoints to 443

### DIFF
--- a/changelog.d/20240104_141408_chris_endpoint_default_443.rst
+++ b/changelog.d/20240104_141408_chris_endpoint_default_443.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Newly created endpoints now use 443 by default for communicating via AMQPS; this can
+  be changed via the ``amqp_port`` config option.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
@@ -1,3 +1,4 @@
+amqp_port: 443
 display_name: null
 engine:
   type: HighThroughputEngine

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -9,6 +9,7 @@ import globus_compute_sdk.sdk.client
 import globus_compute_sdk.sdk.login_manager
 import pytest
 import responses
+import yaml
 from click import ClickException
 from click.testing import CliRunner
 from globus_compute_endpoint.cli import (
@@ -50,6 +51,21 @@ def test_non_configured_endpoint(mocker, tmp_path):
         result = CliRunner().invoke(app, ["start", "newendpoint"])
         assert "newendpoint" in result.stdout
         assert "not configured" in result.stdout
+
+
+def test_newly_configured_endpoint_amqp_port(tmp_path, randomstring):
+    env = {"GLOBUS_COMPUTE_USER_DIR": str(tmp_path)}
+    ep_name = randomstring()
+    with mock.patch.dict(os.environ, env):
+        result = CliRunner().invoke(app, ["configure", ep_name])
+
+        assert ep_name in result.stdout
+        assert result.exit_code == 0
+
+        config_path = tmp_path / ep_name / "config.yaml"
+        config_dict = yaml.safe_load(config_path.read_text())
+
+        assert config_dict["amqp_port"] == 443
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Motivated by a [conversation in Slack](https://funcx.slack.com/archives/C016JMYST9C/p1704308608039249?thread_ts=1704306163.967149&cid=C016JMYST9C). 

## Type of change

- New feature (non-breaking change that adds functionality)
