### PR TITLE
GCE container support

### DIFF
--- a/changelog.d/20240111_165100_yadudoc1729_GCE_container_support_sc_28238.rst
+++ b/changelog.d/20240111_165100_yadudoc1729_GCE_container_support_sc_28238.rst
@@ -1,0 +1,16 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Implement ability to launch workers in containerized environments, with support for
+  Docker, Singularity, and Apptainer.  Use by setting ``container_type``, ``container_uri``
+  and  additional options may be specified via ``container_cmd_options``.
+  Sample configuration:
+
+  .. code-block:: yaml
+
+    display_name: Docker
+    engine:
+      type: GlobusComputeEngine
+      container_type: docker
+      container_uri: funcx/kube-endpoint:main-3.10
+      container_cmd_options: -v /tmp:/tmp

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import queue
+import shlex
 import typing as t
 import uuid
 from concurrent.futures import Future
@@ -17,6 +18,10 @@ from globus_compute_endpoint.strategies import SimpleStrategy
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
+DOCKER_CMD_TEMPLATE = "docker run {options} -v {rundir}:{rundir} -t {image} {command}"
+APPTAINER_CMD_TEMPLATE = "apptainer run {options} {image} {command}"
+SINGULARITY_CMD_TEMPLATE = "singularity run {options} {image} {command}"
+VALID_CONTAINER_TYPES = ("docker", "singularity", "apptainer", "custom", None)
 
 
 class GlobusComputeEngine(GlobusComputeEngineBase):
@@ -27,6 +32,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         max_retries_on_system_failure: int = 0,
         strategy: t.Optional[SimpleStrategy] = SimpleStrategy(),
         executor: t.Optional[HighThroughputExecutor] = None,
+        container_type: t.Literal[VALID_CONTAINER_TYPES] = None,  # type: ignore
+        container_uri: t.Optional[str] = None,
+        container_cmd_options: t.Optional[str] = None,
         **kwargs,
     ):
         self.run_dir = os.getcwd()
@@ -37,6 +45,14 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         )
         self.strategy = strategy
         self.max_workers_per_node = 1
+
+        self.container_type = container_type
+        assert (
+            self.container_type in VALID_CONTAINER_TYPES
+        ), f"{self.container_type} is not a valid container_type"
+        self.container_uri = container_uri
+        self.container_cmd_options = container_cmd_options
+
         if executor is None:
             executor = HighThroughputExecutor(  # type: ignore
                 *args,
@@ -44,6 +60,46 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 **kwargs,
             )
         self.executor = executor
+
+    def containerized_launch_cmd(self) -> str:
+        """Recompose executor's launch_cmd to launch with containers
+
+        Returns
+        -------
+        str launch_cmd
+        """
+        launch_cmd = self.executor.launch_cmd
+        # Adding assert here since mypy can't figure out launch_cmd's type
+        assert launch_cmd
+        if self.container_type == "docker":
+            launch_cmd = DOCKER_CMD_TEMPLATE.format(
+                image=self.container_uri,
+                rundir=self.run_dir,
+                command=launch_cmd,
+                options=self.container_cmd_options or "",
+            )
+        elif self.container_type == "apptainer":
+            launch_cmd = APPTAINER_CMD_TEMPLATE.format(
+                image=self.container_uri,
+                command=launch_cmd,
+                options=self.container_cmd_options or "",
+            )
+        elif self.container_type == "singularity":
+            launch_cmd = SINGULARITY_CMD_TEMPLATE.format(
+                image=self.container_uri,
+                command=launch_cmd,
+                options=self.container_cmd_options or "",
+            )
+        elif self.container_type == "custom":
+            assert (
+                self.container_cmd_options
+            ), "GCE.container_cmd_options is required for GCE.container_type=custom"
+            template = self.container_cmd_options.replace(
+                "{EXECUTOR_RUNDIR}", str(self.run_dir)
+            )
+            launch_cmd = template.replace("{EXECUTOR_LAUNCH_CMD}", launch_cmd)
+
+        return launch_cmd
 
     def start(
         self,
@@ -61,6 +117,13 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.executor.run_dir = self.run_dir
         script_dir = os.path.join(self.run_dir, "submit_scripts")
         self.executor.provider.script_dir = script_dir
+        if self.container_type:
+            containerized_launch_cmd = self.containerized_launch_cmd()
+            self.executor.launch_cmd = shlex.join(shlex.split(containerized_launch_cmd))
+            logger.info(
+                f"Containerized launch cmd template: {self.executor.launch_cmd}"
+            )
+
         if (
             self.executor.provider.channel
             and not self.executor.provider.channel.script_dir

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
@@ -1,0 +1,95 @@
+import uuid
+
+import pytest
+from globus_compute_endpoint.engines import GlobusComputeEngine
+
+
+def platinfo():
+    import platform
+    import sys
+
+    return platform.uname(), sys.version_info
+
+
+def test_docker(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        label="GCE_TEST",
+        container_type="docker",
+        container_uri="funcx/kube-endpoint:main-3.10",
+        container_cmd_options="--FABRICATED",
+    )
+    gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = (
+        "docker run --FABRICATED -v /tmp:/tmp -t "
+        "funcx/kube-endpoint:main-3.10 process_worker_pool.py"
+    )
+    assert container_launch_cmd.startswith(expected)
+
+    gce.shutdown()
+
+
+def test_apptainer(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        label="GCE_TEST",
+        container_type="apptainer",
+        container_uri="APPTAINER_PATH",
+        container_cmd_options="--FABRICATED",
+    )
+    gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = "apptainer run --FABRICATED APPTAINER_PATH process_worker_pool.py"
+    assert container_launch_cmd.startswith(expected)
+
+    gce.shutdown()
+
+
+def test_singularity(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        label="GCE_TEST",
+        container_type="singularity",
+        container_uri="/home/yadunand/kube-endpoint.py3.9.sif",
+        container_cmd_options="",
+    )
+    gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = (
+        "singularity run /home/yadunand/kube-endpoint.py3.9.sif"
+        " process_worker_pool.py"
+    )
+    assert container_launch_cmd.startswith(expected)
+
+    gce.shutdown()
+
+
+def test_custom_missing_options(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        label="GCE_TEST",
+        container_type="custom",
+    )
+    with pytest.raises(AssertionError):
+        gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
+
+
+def test_custom(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        label="GCE_TEST",
+        container_type="custom",
+        container_cmd_options="FOO {EXECUTOR_RUNDIR} {EXECUTOR_LAUNCH_CMD}",
+    )
+
+    gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
+
+    container_launch_cmd = gce.executor.launch_cmd
+    expected = f"FOO {gce.run_dir} process_worker_pool.py"
+    assert container_launch_cmd.startswith(expected)
+
+    gce.shutdown()

--- a/compute_endpoint/tests/unit/test_gce_container.py
+++ b/compute_endpoint/tests/unit/test_gce_container.py
@@ -1,0 +1,71 @@
+import logging
+import uuid
+from unittest import mock
+
+import pytest
+from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
+
+
+def test_docker(tmp_path, uri="funcx/kube-endpoint:main-3.10"):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1", container_type="docker", container_uri=uri
+    )
+
+    gce.executor.start = mock.MagicMock()
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+
+    assert gce.executor.launch_cmd
+    assert gce.executor.launch_cmd.startswith("docker run")
+    assert uri in gce.executor.launch_cmd
+    gce.executor.start.assert_called()
+    # No cleanup necessary because HTEX was not started
+
+
+def test_apptainer(tmp_path, uri="/tmp/kube-endpoint.sif"):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1", container_type="apptainer", container_uri=uri
+    )
+
+    gce.executor.start = mock.MagicMock()
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+
+    assert gce.executor.launch_cmd
+    assert gce.executor.launch_cmd.startswith("apptainer run")
+    assert uri in gce.executor.launch_cmd
+    gce.executor.start.assert_called()
+
+
+def test_custom(tmp_path):
+    gce = GlobusComputeEngine(
+        address="127.0.0.1",
+        container_type="custom",
+        container_cmd_options=(
+            "mycontainer -v {EXECUTOR_RUNDIR}:"
+            "{EXECUTOR_RUNDIR} {EXECUTOR_LAUNCH_CMD}"
+        ),
+    )
+
+    gce.executor.start = mock.MagicMock()
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+    logging.warning(f"Got launch {gce.executor.launch_cmd}")
+
+    assert gce.executor.launch_cmd
+    assert gce.executor.launch_cmd.startswith("mycontainer")
+    assert f"{tmp_path}:{tmp_path}" in gce.executor.launch_cmd
+    assert "process_worker_pool.py" in gce.executor.launch_cmd
+    gce.executor.start.assert_called()
+
+
+def test_bad_container(tmp_path):
+    with pytest.raises(AssertionError):
+        GlobusComputeEngine(address="127.0.0.1", container_type="BAD")
+
+
+def test_no_container(tmp_path):
+    gce = GlobusComputeEngine(address="127.0.0.1")
+    original = gce.executor.launch_cmd
+
+    gce.executor.start = mock.MagicMock()
+    gce.start(endpoint_id=uuid.uuid4(), run_dir=tmp_path)
+
+    assert gce.executor.launch_cmd == original


### PR DESCRIPTION
# Description

This PR adds support for launching managers/workers in containers. Currently docker, singularity and apptainer are supported. Container support is limited to ``GlobusComputeEngine`` on the ``globus-compute-endpoint``. To
configure the endpoint the following options are now supported:

* `docker_container_uri` : Specify docker URI if using Docker
* `singularity_container_uri`: Specify singularity file path if using Singularity
* `apptainer_container_uri`: Specify path to apptainer sif file if using Apptainer
* `container_cmd_options`: Specify custom command options to pass to the container launch command,
such as filesystem mount paths, network options etc.

```
    display_name: Docker
    engine:
      type: GlobusComputeEngine
      docker_container_uri: funcx/kube-endpoint:main-3.10
      container_cmd_options: -v /tmp:/tmp
      provider:
        init_blocks: 1
        max_blocks: 1
        min_blocks: 0
        type: LocalProvider
```

Fixes # (issue)

[sc-28238]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
