### PR TITLE
Send UEP startup failure AMQP message

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -543,8 +543,7 @@ def _do_start_endpoint(
 
         if reg_info:
             # We're quitting anyway, so just let any exceptions bubble
-            exc_type = type(e).__name__
-            msg = f"Failed to start or unexpected error:\n  ({exc_type}) {e}"
+            msg = f"Failed to start or unexpected error:\n  ({type(e).__name__}) {e}"
             send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
 
         raise

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -17,6 +17,7 @@ import click
 from click import ClickException
 from globus_compute_endpoint.endpoint.config.utils import get_config, load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
+from globus_compute_endpoint.endpoint.utils import send_endpoint_startup_failure_to_amqp
 from globus_compute_endpoint.exception_handling import handle_auth_errors
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_endpoint.self_diagnostic import run_self_diagnostic
@@ -491,47 +492,62 @@ def _do_start_endpoint(
             log.debug("Invalid info on stdin -- (%s) %s", exc_type, e)
 
     try:
-        if config_str is not None:
-            ep_config = load_config_yaml(config_str)
-        else:
-            ep_config = get_config(ep_dir)
-    except Exception as e:
-        if isinstance(e, ClickException):
+        try:
+            if config_str is not None:
+                ep_config = load_config_yaml(config_str)
+            else:
+                ep_config = get_config(ep_dir)
+        except Exception as e:
+            if isinstance(e, ClickException):
+                raise
+
+            # We've likely not exported to the log, so at least put _something_ in the
+            # logs for the human to debug; motivated by SC-28607
+            exc_type = type(e).__name__
+            msg = (
+                "Failed to find or parse endpoint configuration.  Endpoint will not"
+                f" start. ({exc_type}) {e}"
+            )
+            log.critical(msg)
             raise
 
-        # We've likely not exported to the log, so at least put _something_ in the
-        # logs for the human to debug; motivated by SC-28607
-        exc_type = type(e).__name__
-        msg = (
-            "Failed to find or parse endpoint configuration.  Endpoint will not"
-            f" start. ({exc_type}) {e}"
-        )
-        log.critical(msg)
-        raise
+        if die_with_parent:
+            # The endpoint cannot die with its parent if it
+            # doesn't have one :)
+            ep_config.detach_endpoint = False
+            log.debug("The --die-with-parent flag has set detach_endpoint to False")
 
-    if die_with_parent:
-        # The endpoint cannot die with its parent if it
-        # doesn't have one :)
-        ep_config.detach_endpoint = False
-        log.debug("The --die-with-parent flag has set detach_endpoint to False")
-
-    if ep_config.multi_user:
-        if not _has_multi_user:
-            raise ClickException(
-                "multi-user endpoints are not supported on this system"
+        if ep_config.multi_user:
+            if not _has_multi_user:
+                raise ClickException(
+                    "multi-user endpoints are not supported on this system"
+                )
+            epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
+            epm.start()
+        else:
+            get_cli_endpoint().start_endpoint(
+                ep_dir,
+                endpoint_uuid,
+                ep_config,
+                state.log_to_console,
+                state.no_color,
+                reg_info,
+                die_with_parent,
             )
-        epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
-        epm.start()
-    else:
-        get_cli_endpoint().start_endpoint(
-            ep_dir,
-            endpoint_uuid,
-            ep_config,
-            state.log_to_console,
-            state.no_color,
-            reg_info,
-            die_with_parent,
-        )
+
+    except (SystemExit, Exception) as e:
+        if isinstance(e, SystemExit):
+            if e.code in (0, None):
+                # normal, system exit
+                raise
+
+        if reg_info:
+            # We're quitting anyway, so just let any exceptions bubble
+            exc_type = type(e).__name__
+            msg = f"Failed to start or unexpected error:\n  ({exc_type}) {e}"
+            send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
+
+        raise
 
 
 @app.command("stop")

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -518,7 +518,7 @@ class EndpointManager:
                     f"\n  Endpoint timestamp: {now} ({endp_pp_ts})"
                 )
                 log.warning(msg)
-                self.cmd_send_failure(command_kwargs, msg=msg)
+                self.send_failure_notice(command_kwargs, msg=msg)
                 continue
 
             try:
@@ -528,7 +528,7 @@ class EndpointManager:
             except Exception as e:
                 msg = f"Invalid server command.  ({e.__class__.__name__}) {e}"
                 log.error(msg)
-                self.cmd_send_failure(command_kwargs, msg=msg)
+                self.send_failure_notice(command_kwargs, msg=msg)
                 continue
 
             identity_for_log = (
@@ -559,7 +559,7 @@ class EndpointManager:
                         f"{identity_for_log}"
                     )
                     log.error(msg)
-                    self.cmd_send_failure(
+                    self.send_failure_notice(
                         command_kwargs, msg=msg, user_ident=identity_for_log
                     )
                     continue
@@ -577,7 +577,7 @@ class EndpointManager:
                         f"  ({type(e).__name__}) {e}{identity_for_log}"
                     )
                     log.error(msg)
-                    self.cmd_send_failure(
+                    self.send_failure_notice(
                         command_kwargs, msg=msg, user_ident=identity_for_log
                     )
                     continue
@@ -587,7 +587,7 @@ class EndpointManager:
                     log.error(f"{msg}  ({type(e).__name__}) {e}{identity_for_log}")
 
                     fail_msg = f"{msg}{identity_for_log}"
-                    self.cmd_send_failure(
+                    self.send_failure_notice(
                         command_kwargs, msg=fail_msg, user_ident=identity_for_log
                     )
                     continue
@@ -604,7 +604,7 @@ class EndpointManager:
                     )
                     log.error(f"({exc_type}) {e}\n{msg}")
                     fail_msg = f"({exc_type})\n{msg}"
-                    self.cmd_send_failure(
+                    self.send_failure_notice(
                         command_kwargs, msg=fail_msg, user_ident=identity_for_log
                     )
                     continue
@@ -631,7 +631,7 @@ class EndpointManager:
                     " recreate this error message at will, consider reaching out to the"
                     " endpoint administrator or the Globus Compute team."
                 )
-                self.cmd_send_failure(
+                self.send_failure_notice(
                     command_kwargs, msg=msg, user_ident=identity_for_log
                 )
 
@@ -644,9 +644,9 @@ class EndpointManager:
                     f"    args: {msg_a}\n"
                     f"  kwargs: {msg_kw}{identity_for_log}"
                 )
-                self.cmd_send_failure(command_kwargs, user_ident=identity_for_log)
+                self.send_failure_notice(command_kwargs, user_ident=identity_for_log)
 
-    def cmd_send_failure(
+    def send_failure_notice(
         self,
         kwargs: dict,
         msg: str | None = None,
@@ -658,7 +658,7 @@ class EndpointManager:
         that the given endpoint has failed to start up.
 
         This method conditionally forks (if ``fork == True``), but always exits.  The
-        exit is always "clean" (exit code of 0) -- this is true even if their is an
+        exit is always "clean" (exit code of 0) -- this is true even if there is an
         unhandled error as the assumption is that this is a last-ditch effort to be
         kind to the user (better UX).  If it fails, "oh well," and then it is time for
         the administrator to investigate the logs.
@@ -970,7 +970,7 @@ class EndpointManager:
             )
             log.error(msg)
             log.debug(f"Failed to exec for {uname}", exc_info=e)
-            self.cmd_send_failure(kwargs, msg=msg, fork=False)
+            self.send_failure_notice(kwargs, msg=msg, fork=False)
         finally:
             # Only executed if execvpe fails (or isn't reached)
             sys.exit(exit_code)

--- a/compute_endpoint/tests/unit/test_utils.py
+++ b/compute_endpoint/tests/unit/test_utils.py
@@ -1,9 +1,14 @@
+import sys
+import uuid
 from collections import namedtuple
+from unittest import mock
 
+import pika
 import pytest
 from globus_compute_endpoint.endpoint.utils import (
     _redact_url_creds,
     is_privileged,
+    send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
 
@@ -16,6 +21,20 @@ except AttributeError:
 
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.utils."
+
+
+@pytest.fixture
+def mock_mq_chan(mocker):
+    _mq_conn = mocker.MagicMock(spec=pika.BlockingConnection)
+    _mq_conn.__enter__.return_value = _mq_conn
+    _mq_chan = mocker.MagicMock(spec=pika.adapters.blocking_connection.BlockingChannel)
+    _mq_chan.__enter__.return_value = _mq_chan
+
+    mock_pika = mocker.Mock(spec=pika)
+    mock_pika.BlockingConnection.return_value = _mq_conn
+    _mq_conn.channel.return_value = _mq_chan
+    with mock.patch.dict(sys.modules, {"pika": mock_pika}):
+        yield _mq_chan
 
 
 def test_url_redaction(randomstring):
@@ -96,3 +115,33 @@ if _has_pyprctl:
 )
 def test_update_url_port(start_url, port, end_url):
     assert update_url_port(start_url, port) == end_url
+
+
+@pytest.mark.parametrize("err_msg", (None, "asdf"))
+def test_cmd_send_failure_publishes_message(mock_mq_chan, randomstring, err_msg):
+    mock_exchange_name = randomstring()
+    mock_routing_key = randomstring()
+    uep_uuid = str(uuid.uuid4())
+    amqp_creds = {
+        "endpoint_id": uep_uuid,
+        "result_queue_info": {
+            "connection_url": "abc",
+            "queue_publish_kwargs": {
+                "exchange": mock_exchange_name,
+                "routing_key": mock_routing_key,
+            },
+        },
+    }
+    send_endpoint_startup_failure_to_amqp(amqp_creds, msg=err_msg)
+
+    assert mock_mq_chan.basic_publish.called
+    _a, k = mock_mq_chan.basic_publish.call_args
+    assert k["exchange"] == mock_exchange_name
+    assert k["routing_key"] == mock_routing_key
+    assert k["mandatory"]
+
+    if err_msg is None:
+        err_msg = "General or unknown failure starting user endpoint"
+
+    assert uep_uuid.encode() in k["body"]
+    assert err_msg.encode() in k["body"]


### PR DESCRIPTION
When an endpoint fails to start up, if the endpoint manager has at least acquired the UEP's AMQP credentials, it can send a failure status to the web services.  In the majority of cases then, the SDK need not wait for the web-service to time out -- it can get near-instantaneous feedback.

This changeset addresses both the pre-exec states (e.g., the user cannot be mapped to local uid) and in the post-exec UEP startup failures (e.g., an invalid configuration).

[sc-28883]

## Type of change

- New feature (non-breaking change that adds functionality)