### PR TITLE
set GLOBUS_SDK_ENVIRONMENT when make staging

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -30,7 +30,7 @@ jobs:
       run: |
         source .venv/bin/activate
         cd smoke_tests
-        make staging
+        GLOBUS_SDK_ENVIRONMENT=staging make staging
 
   safety-check-sdk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In the github actions is probably the best place to set GLOBUS_SDK_ENVIRONMENT for the tests.  client_args obeys environment=XXX which is set in client_args but globus_sdk needs the former.