### PR TITLE
Fix docs build

### DIFF
--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -26,8 +26,8 @@ REQUIRES = [
     "texttable>=1.6.7",
 ]
 DOCS_REQUIRES = [
-    "sphinx<5",
-    "furo==2021.09.08",
+    "sphinx",
+    "furo==2023.9.10",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
Building the docs recently broke with a requirement requiring a more recent version of Sphinx.  We last touched this in Mar 2022, so it's perhaps time for at least a library update.

## Type of change

- Code maintenance/cleanup