### PR TITLE
Reduce executor log noise

### DIFF
--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -688,6 +688,7 @@ def test_task_submitter_stops_executor_on_upstream_error_response(
     try_assert(lambda: gce._stopped)
     try_assert(lambda: gce._test_task_submitter_done, "Expect graceful shutdown")
     assert cf.exception() is upstream_error
+    assert gce._test_task_submitter_exception is None, "handled by future"
 
 
 def test_sc25897_task_submit_correctly_handles_multiple_tg_ids(mocker, gc_executor):


### PR DESCRIPTION
# Description

The original motivation of the `log.exception()` call was to ensure that the user saw any exceptions from the background thread.  However, if the exception *is* shared with the user (c.f., `Future.set_exception()`), then don't unnecessarily create an ugly traceback.  For example, if the user handles the exception in their codes, then instead of a background-thread generated traceback like (note the start of the traceback):
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/kevin/Dev/funcX/compute_sdk/globus_compute_sdk/sdk/executor.py", line 791, in _task_submitter_impl
   ...
globus_sdk.exc.api.GlobusAPIError: ('POST', ...)
```
the user can choose what they want to do.  For example, the above can be ignored, `str()`ified, or shown entirely (example exception):
```
Failed to start or unexpected error: ...
```
or
```
  File ".../test_script.py", line 32, in <module>
    res = fut.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/home/kevin/Dev/funcX/compute_sdk/globus_compute_sdk/sdk/executor.py", line 792, in _task_submitter_impl
    self._submit_tasks(
   ...
```

## Type of change

- New feature (non-breaking change that adds functionality)