### PR TITLE
Remove unnecessary event

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -132,9 +132,9 @@ def test_die_with_parent_refuses_to_start_if_not_parent(mocker):
         parent_pid=os.getpid(),  # _not_ ppid; that's the test.
     )
     mock_warn = mocker.patch.object(log, "warning")
-    assert not ei._kill_event.is_set()
+    assert not ei.time_to_quit, "Verify test setup"
     ei.start()
-    assert ei._kill_event.is_set()
+    assert ei.time_to_quit
 
     warn_msg = str(list(a[0] for a, _ in mock_warn.call_args_list))
     assert "refusing to start" in warn_msg
@@ -154,9 +154,9 @@ def test_die_with_parent_goes_away_if_parent_dies(mocker):
     )
     ei.executors = {"mock_executor": mocker.Mock()}
     mock_warn = mocker.patch.object(log, "warning")
-    assert not ei._kill_event.is_set()
+    assert not ei.time_to_quit, "Verify test setup"
     ei.start()
-    assert ei._kill_event.is_set()
+    assert ei.time_to_quit
 
     warn_msg = str(list(a[0] for a, _ in mock_warn.call_args_list))
     assert "refusing to start" not in warn_msg

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -10,26 +10,26 @@ _mock_base = "globus_compute_endpoint.endpoint.interchange."
 
 def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals):
     num_iterations = random.randint(1, 10)
+    excepts_left = num_iterations
     exc_text = f"Woot {randomstring()}"
+    exc = Exception(exc_text)
 
-    # [False, ...] * num because _kill_event and _quiesce_event are the same mock;
-    #  .is_set() is called twice per loop
-    is_set_returns = [False, False, False] * num_iterations + [True]
-    false_true_g = iter(is_set_returns)
+    def _mock_start_threads(*a, **k):
+        nonlocal excepts_left
+        excepts_left -= 1
+        ei.time_to_quit = excepts_left <= 0
+        raise exc
 
-    def false_true():
-        return next(false_true_g)
-
+    mocker.patch(f"{_mock_base}time.sleep")
     mocker.patch(f"{_mock_base}multiprocessing")
     ei = EndpointInterchange(
         config=Config(executors=[mocker.Mock()]),
         reg_info={"task_queue_info": {}, "result_queue_info": {}},
         reconnect_attempt_limit=num_iterations + 10,
     )
-    ei._task_puller_proc = mocker.MagicMock()
-    ei._start_threads_and_main = mocker.MagicMock()
-    ei._start_threads_and_main.side_effect = Exception(exc_text)
-    ei._kill_event.is_set = false_true
+    ei._task_puller_proc = mocker.Mock()
+    ei._start_threads_and_main = mocker.Mock()
+    ei._start_threads_and_main.side_effect = _mock_start_threads
     with mock.patch(f"{_mock_base}log") as mock_log:
         ei.start()
     assert mock_log.error.call_count == num_iterations
@@ -44,15 +44,15 @@ def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals)
 @pytest.mark.parametrize("reconnect_attempt_limit", [-1, 0, 1, 2, 3, 5, 10])
 def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_signals):
     num_iterations = reconnect_attempt_limit * 2 + 5  # overkill "just to be sure"
+    excepts_left = num_iterations
 
-    # [False, False] * num because _kill_event and _quiesce_event are the same mock;
-    #  .is_set() is called twice per loop
-    is_set_returns = [False, False] * num_iterations + [True]
-    false_true_g = iter(is_set_returns)
+    def _mock_start_threads(*a, **k):
+        nonlocal excepts_left
+        excepts_left -= 1
+        ei.time_to_quit = excepts_left <= 0
+        raise Exception()
 
-    def false_true():
-        return next(false_true_g)
-
+    mocker.patch(f"{_mock_base}time.sleep")
     mocker.patch(f"{_mock_base}multiprocessing")
     mock_log = mocker.patch(f"{_mock_base}log")
     ei = EndpointInterchange(
@@ -62,8 +62,7 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     )
     ei._task_puller_proc = mocker.MagicMock()
     ei._start_threads_and_main = mocker.MagicMock()
-    ei._start_threads_and_main.side_effect = Exception("Woot")
-    ei._kill_event.is_set = false_true
+    ei._start_threads_and_main.side_effect = _mock_start_threads
     ei.start()
 
     reconnect_attempt_limit = max(1, reconnect_attempt_limit)  # checking boundary
@@ -72,3 +71,4 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     expected_msg = f"Failed {reconnect_attempt_limit} consecutive"
     assert mock_log.critical.called
     assert expected_msg in mock_log.critical.call_args[0][0]
+    assert excepts_left > 0, "expect reconnect limit to stop loop, not test backup"


### PR DESCRIPTION
There's no need to incur the overhead of `mp.Event`; we don't use `.wait()`, and we don't pass the event to any external processes.  Internally, we treat it as a set-only flag, so just use a simple boolean.

## Type of change

- Code maintenance/cleanup