### PR TITLE
Trying again to fix GLOBUS_SDK_ENVIRONMENT for smoke tests

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -27,10 +27,11 @@ jobs:
       env:
         FUNCX_SMOKE_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
         FUNCX_SMOKE_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET_STAGING }}
+        GLOBUS_SDK_ENVIRONMENT: "staging"
       run: |
         source .venv/bin/activate
         cd smoke_tests
-        GLOBUS_SDK_ENVIRONMENT=staging make staging
+        make staging
 
   safety-check-sdk:
     runs-on: ubuntu-latest

--- a/smoke_tests/tests/conftest.py
+++ b/smoke_tests/tests/conftest.py
@@ -197,6 +197,11 @@ def compute_test_config(pytestconfig, compute_test_config_name):
     if api_uri:
         client_args["funcx_service_address"] = api_uri
 
+    # Manually add the env here in case the GH actions yaml doesn't pick it up
+    sdk_env = client_args.get("environment")
+    if sdk_env:
+        os.environ["GLOBUS_SDK_ENVIRONMENT"] = sdk_env
+
     if api_client_id and api_client_secret:
         _add_args_for_client_creds_login(api_client_id, api_client_secret, client_args)
 


### PR DESCRIPTION
The previous attempt, adding ``GLOBUS_SDK_ENVIRONMENT=staging make staging`` to the run command apparently isn't sufficient to set the env var.

Trying a different syntax - Adding it directly to the ``env:`` section.  That *could* work, but it's difficult to test it locally.  The second change - setting it manually in conftest.py - is the backup option.

My strategy is to merge in both methods, confirm that this does resolve the issue, then try removing the conftest change and seeing if the daily.yaml change is sufficient. (via followup PR).