### PR TITLE
Bump versions for release 2.11.0 Jan 17 2024

### DIFF
--- a/changelog.d/20231215_125237_chris_hardware_details.rst
+++ b/changelog.d/20231215_125237_chris_hardware_details.rst
@@ -1,8 +1,0 @@
-New Functionality
-^^^^^^^^^^^^^^^^^
-
-- Added ``Executor.get_worker_hardware_details`` helper function to retrieve
-  information on the hardware an endpoint is running on
-
-  - Added ``Client.get_worker_hardware_details`` for the same functionality on the
-    Client

--- a/changelog.d/20240104_141408_chris_endpoint_default_443.rst
+++ b/changelog.d/20240104_141408_chris_endpoint_default_443.rst
@@ -1,5 +1,0 @@
-Changed
-^^^^^^^
-
-- Newly created endpoints now use 443 by default for communicating via AMQPS; this can
-  be changed via the ``amqp_port`` config option.

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==2.10.0",
+    "globus-compute-sdk==2.11.0",
     "globus-compute-common==0.3.0",
     "globus-identity-mapping==0.2.0",
     # table printing used in list-endpoints

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 
 
 def compare_versions(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,26 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-2.11.0:
+
+globus-compute-sdk & globus-compute-endpoint v2.11.0
+----------------------------------------------------
+
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added ``Executor.get_worker_hardware_details`` helper function to retrieve
+  information on the hardware an endpoint is running on
+
+  - Added ``Client.get_worker_hardware_details`` for the same functionality on the
+    Client
+
+Changed
+^^^^^^^
+
+- Newly created endpoints now use 443 by default for communicating via AMQPS; this can
+  be changed via the ``amqp_port`` config option.
+
 .. _changelog-2.10.0:
 
 globus-compute-sdk & globus-compute-endpoint v2.10.0


### PR DESCRIPTION
PR for today's release, bumping versions.

For the AMQP change, the documentation change in https://github.com/funcx-faas/funcX/pull/1405 can be merged in afterwards, assuming the SDK/EP release goes as planned.  (readthedocs updates when it's merged to main, so #1405 does not need to be part of the release, but it can be)