### PR TITLE
Fix broken fixture

### DIFF
--- a/compute_sdk/tests/conftest.py
+++ b/compute_sdk/tests/conftest.py
@@ -63,10 +63,3 @@ def compute_client_args(pytestconfig):
 def compute_client(compute_client_args):
     gcc = Client(**compute_client_args)
     return gcc
-
-
-@pytest.fixture
-def login_manager(mocker):
-    mock_login_manager = mocker.Mock()
-    mock_login_manager.get_web_client = mocker.Mock
-    return mock_login_manager


### PR DESCRIPTION
`login_manager` was setting the Mock class to the yielded object, rather than creating a new instance.  This was leading to leakage between tests, which work for PR #1428 highlighted.

For the reviewer: the main changes of note are

- Implementation of a `test_client.py` specific `gcc` fixture.
- Removal of the `login_manager` fixture.
- Updating the tests that used `login_manager` to use the `gcc` fixture.

I marked this an quick review because most of the changes are plug and chug of the third bullet point.

## Type of change

- Bug fix (non-breaking change that fixes an issue) [in tests]