### PR TITLE
Change default engine type to `GlobusComputeEngine`

### DIFF
--- a/changelog.d/20240122_102159_30907815+rjmello_retain_uep_config_exception.rst
+++ b/changelog.d/20240122_102159_30907815+rjmello_retain_uep_config_exception.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Changed the default engine type for new endpoints to `GlobusComputeEngine`, which
+  utilizes the Parsl `HighThroughputExecutor` under the hood.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -5,10 +5,10 @@ import os
 import pathlib
 import warnings
 
-from globus_compute_endpoint.engines import HighThroughputEngine
+from globus_compute_endpoint.engines import GlobusComputeEngine
 from parsl.utils import RepresentationMixin
 
-_DEFAULT_EXECUTORS = [HighThroughputEngine()]
+_DEFAULT_EXECUTORS = [GlobusComputeEngine()]
 
 
 class Config(RepresentationMixin):
@@ -20,7 +20,7 @@ class Config(RepresentationMixin):
     executors : list of Executors
         A list of executors which serve as the backend for function execution.
         As of 0.2.2, this list should contain only one executor.
-        Default: [HighThroughputEngine()]
+        Default: [GlobusComputeEngine()]
 
     environment: str
         Environment the endpoint should connect to. Sets funcx_service_address and

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.py
@@ -1,11 +1,11 @@
 from globus_compute_endpoint.endpoint.config import Config
-from globus_compute_endpoint.engines import HighThroughputEngine
+from globus_compute_endpoint.engines import GlobusComputeEngine
 from parsl.providers import LocalProvider
 
 config = Config(
     display_name=None,  # If None, defaults to the endpoint name
     executors=[
-        HighThroughputEngine(
+        GlobusComputeEngine(
             provider=LocalProvider(
                 init_blocks=1,
                 min_blocks=0,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/default_config.yaml
@@ -1,7 +1,7 @@
 amqp_port: 443
 display_name: null
 engine:
-  type: HighThroughputEngine
+  type: GlobusComputeEngine
   provider:
     type: LocalProvider
     init_blocks: 1

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/user_config_template.yaml
@@ -24,7 +24,7 @@
 endpoint_setup: {{ endpoint_setup|default() }}
 
 engine:
-  type: HighThroughputEngine
+  type: GlobusComputeEngine
   max_workers_per_node: 1
 
   provider:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -208,13 +208,13 @@ def test_stop_remote_endpoint(mock_get_id, mock_get_gcc, mock_stop_endpoint):
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.engines import HighThroughputEngine\n"
+                "from funcx_endpoint.engines import GlobusComputeEngine\n"
                 "from funcx_endpoint.executors import HighThroughputExecutor\n"
                 "from parsl.providers import LocalProvider\n"
                 "\n"
                 "config = Config(\n"
                 "    executors=[\n"
-                "        HighThroughputEngine(\n"
+                "        GlobusComputeEngine(\n"
                 "            provider=LocalProvider(\n"
                 "                init_blocks=1,\n"
                 "                min_blocks=0,\n"
@@ -228,7 +228,7 @@ def test_stop_remote_endpoint(mock_get_id, mock_get_gcc, mock_stop_endpoint):
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.engines import HighThroughputEngine\n"
+                "from funcx_endpoint.engines import GlobusComputeEngine\n"
                 "from funcx_endpoint.executors import HighThroughputExecutor\n"
                 "from parsl.providers import LocalProvider\n"
             ),
@@ -239,7 +239,7 @@ def test_stop_remote_endpoint(mock_get_id, mock_get_gcc, mock_stop_endpoint):
         [
             (
                 "from funcx_endpoint.endpoint.utils.config import Config\n"
-                "from funcx_endpoint.engines import HighThroughputEngine\n"
+                "from funcx_endpoint.engines import GlobusComputeEngine\n"
                 "from funcx_endpoint.executors import HighThroughputExecutor\n"
                 "from parsl.providers import LocalProvider\n"
             ),
@@ -251,7 +251,7 @@ def test_stop_remote_endpoint(mock_get_id, mock_get_gcc, mock_stop_endpoint):
             (
                 "def abc():"
                 "    from funcx_endpoint.endpoint.utils.config import Config\n"
-                "    from funcx_endpoint.engines import HighThroughputEngine\n"
+                "    from funcx_endpoint.engines import GlobusComputeEngine\n"
                 "    from funcx_endpoint.executors import HighThroughputExecutor\n"
                 "    from parsl.providers import LocalProvider\n"
                 "    return 'hello'\n"

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -67,7 +67,7 @@ def make_endpoint_dir(mock_command_ensure, ep_name):
             """
 display_name: null
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     provider:
         type: LocalProvider
         init_blocks: 1
@@ -79,7 +79,7 @@ engine:
             """
 heartbeat_period: {{ heartbeat }}
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     provider:
         type: LocalProvider
         init_blocks: 1

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -8,7 +8,7 @@ from pydantic.error_wrappers import ValidationError
 
 @pytest.fixture
 def config_dict():
-    return {"engine": {"type": "HighThroughputEngine"}}
+    return {"engine": {"type": "GlobusComputeEngine"}}
 
 
 @pytest.fixture
@@ -34,11 +34,11 @@ def test_config_model_tuple_conversions(config_dict: dict, data: t.Tuple[str, t.
 
     config_dict["engine"][field] = expected_val
     model = ConfigModel(**config_dict)
-    assert getattr(model.engine, field) == expected_val
+    assert getattr(model.engine.executor, field) == expected_val
 
     config_dict["engine"][field] = list(expected_val)
     model = ConfigModel(**config_dict)
-    assert getattr(model.engine, field) == expected_val
+    assert getattr(model.engine.executor, field) == expected_val
 
     config_dict["engine"][field] = 50000
     with pytest.raises(ValueError):

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -519,8 +519,8 @@ def test_endpoint_get_metadata(mocker):
     config = meta["config"]
     assert "funcx_service_address" in config
     assert len(config["executors"]) == 1
-    assert config["executors"][0]["type"] == "HighThroughputEngine"
-    assert config["executors"][0]["provider"]["type"] == "LocalProvider"
+    assert config["executors"][0]["type"] == "GlobusComputeEngine"
+    assert config["executors"][0]["executor"]["provider"]["type"] == "LocalProvider"
 
 
 @pytest.mark.parametrize("env", [None, "blar", "local", "production"])
@@ -711,7 +711,7 @@ def test_serialize_config_field_types():
     result = serialize_config(ep_config)
 
     # Objects with a __dict__ attr are expanded
-    assert "type" in result["executors"][0]["provider"]
+    assert "type" in result["executors"][0]["executor"]["provider"]
 
     # Only constructor parameters should be included
     assert "_hidden_attr" not in result

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -98,7 +98,7 @@ def user_conf_template(conf_dir):
         """
 heartbeat_period: {{ heartbeat }}
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
     provider:
         type: LocalProvider
         init_blocks: 1


### PR DESCRIPTION
# Description

We will soon mark the `HighThroughputEngine` for deprecation.

## Type of change

- Code maintenance/cleanup
