### PR TITLE
Update parsl to 2024.01.22

### DIFF
--- a/changelog.d/20240123_115035_kevin_update_parsl.rst
+++ b/changelog.d/20240123_115035_kevin_update_parsl.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+- Pin Parsl version requirement to ``2023.01.22``.

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2023.12.18",
+    "parsl==2024.01.22",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
Bring in a couple of minor fixes in Parsl, including some work relevant to endpoint robustness.

[sc-25274]

## Type of change

- Code maintenance/cleanup