### PR TITLE
Send endpoint_id to workers and back to SDK

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -219,7 +219,7 @@ class GlobusComputeEngineBase(ABC):
                 "packed_task": packed_task,
                 "exception_history": [],
             }
-        future = self._submit(execute_task, task_id, packed_task)
+        future = self._submit(execute_task, task_id, packed_task, self.endpoint_id)
         self._setup_future_done_callback(task_id, future)
         return future
 

--- a/compute_endpoint/globus_compute_endpoint/engines/helper.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/helper.py
@@ -24,7 +24,10 @@ serializer = ComputeSerializer()
 
 
 def execute_task(
-    task_id: uuid.UUID, task_body: bytes, result_size_limit: int = 10 * 1024 * 1024
+    task_id: uuid.UUID,
+    task_body: bytes,
+    endpoint_id: t.Optional[uuid.UUID],
+    result_size_limit: int = 10 * 1024 * 1024,
 ) -> bytes:
     """Execute task is designed to enable any executor to execute a Task payload
     and return a Result payload, where the payload follows the globus-compute protocols
@@ -33,6 +36,7 @@ def execute_task(
     ----------
     task_id: uuid string
     task_body: packed message as bytes
+    endpoint_id: uuid string or None
     result_size_limit: result size in bytes
     Returns
     -------
@@ -66,6 +70,7 @@ def execute_task(
             error_details=error_details,
         )
 
+    env_details["endpoint_id"] = endpoint_id
     result_message["details"] = env_details
 
     exec_end = TaskTransition(

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -745,7 +745,9 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
         self.tasks[task_id] = future
 
         container_loc = self._get_container_location(packed_task)
-        ser = serializer.serialize((execute_task, [task_id, packed_task], {}))
+        ser = serializer.serialize(
+            (execute_task, [task_id, packed_task, self.endpoint_id], {})
+        )
         payload = Task(task_id, container_loc, ser).pack()
         assert self.outgoing_q  # Placate mypy
         self.outgoing_q.put(payload)


### PR DESCRIPTION
# Description

Another small preliminary PR for https://github.com/funcx-faas/funcX/pull/1434. Communicates the endpoint ID to workers so that they can return it as part of their task reporting, as discussed in scrum. 

## Type of change

- New feature (non-breaking change that adds functionality)