### PR TITLE
Gracefully handle invalid result msg for HTEngine

### DIFF
--- a/changelog.d/20240205_123835_30907815+rjmello_HEAD.rst
+++ b/changelog.d/20240205_123835_30907815+rjmello_HEAD.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Improved handling of unexpected errors in the `HighThroughputEngine`.

--- a/compute_endpoint/tests/unit/test_htex.py
+++ b/compute_endpoint/tests/unit/test_htex.py
@@ -1,7 +1,11 @@
 import os
 import queue
+import threading
+import typing as t
 import uuid
+from unittest import mock
 
+import dill
 import pytest
 from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import HighThroughputEngine
@@ -10,7 +14,7 @@ from globus_compute_endpoint.engines.high_throughput.messages import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer
 from pytest_mock import MockFixture
-from tests.utils import div_zero, double, ez_pack_function, kill_manager
+from tests.utils import div_zero, double, ez_pack_function, kill_manager, try_assert
 
 
 @pytest.fixture
@@ -184,3 +188,33 @@ def test_engine_submit_container_location(
     a, _ = mock_put.call_args
     unpacked_msg = InternalTask.unpack(a[0])
     assert unpacked_msg.container_id == container_loc
+
+
+@pytest.mark.parametrize("task_id", (str(uuid.uuid4()), None))
+def test_engine_invalid_result_data(task_id: t.Optional[str]):
+    htex = HighThroughputEngine(address="127.0.0.1")
+    htex.incoming_q = mock.MagicMock()
+    htex.results_passthrough = mock.MagicMock()
+    htex.tasks = mock.MagicMock()
+    htex.is_alive = True
+    htex._engine_bad_state = threading.Event()
+
+    result_message = {"task_id": task_id}
+    htex.incoming_q.get.return_value = [dill.dumps(result_message)]
+
+    queue_mgmt_thread = threading.Thread(target=htex._queue_management_worker)
+    queue_mgmt_thread.start()
+
+    if task_id:
+        try_assert(lambda: htex.results_passthrough.put.called)
+        res = htex.results_passthrough.put.call_args[0][0]
+        msg = messagepack.unpack(res["message"])
+        assert res["task_id"] == task_id
+        assert f"{task_id} failed to run" in msg.data
+    else:
+        try_assert(lambda: htex.incoming_q.get.call_count > 1)
+        assert not htex.results_passthrough.put.called
+
+    htex.is_alive = False
+    htex._engine_bad_state.set()
+    queue_mgmt_thread.join()


### PR DESCRIPTION
# Description

Instead of breaking the endpoint, we now return an error to the user and log the exception.

[sc-27140]

## Type of change

- Bug fix (non-breaking change that fixes an issue)