### PR TITLE
Add a note about upgrading from previous Action Provider

### DIFF
--- a/docs/actionprovider.rst
+++ b/docs/actionprovider.rst
@@ -6,7 +6,14 @@ interface to allow functions to be used in a `Globus Flow <https://www.globus.or
 
 The Globus Compute Action Provider interface uses:
 
-* ``ActionUrl`` -- 'https://compute.actions.globus.org'
+* ``ActionUrl`` -- 'https://compute.actions.globus.org'  *Updated Apr 2023* [1]_
+
+.. [1] The previous version of the Action Provider, deprecated April 2023,
+   had an ActionUrl of https://dev.funcx.org/automate along with
+   a required ``ActionScope``.  The current Action Provider is backwards
+   compatible, provided the ``ActionUrl`` is updated to the new URL and the
+   ``ActionScope`` removed.  (The ActionScope is now populated from the
+   Action Provider's metadata URL)
 
 
 Action Input Schema


### PR DESCRIPTION
As discussed with Ryan, the old Action Provider (dev.funcx.org/automate) hosted on Lambda has been turned down.  See note in # dev - no users had been using it for months.

There shouldn't be any complaints but the old AP now returns a response which directs to the readthedocs AP page.  To make it easier in case anyone needs to update their old flows, this is a further clarification on the 'upgrade' path.

The footnote, referenced after the ActionUrl, is near the top of the page, a bit prominent?  Perhaps we can move it to  the bottom of the page later as it should be relevant to few users.