### PR TITLE
bump versions for release testing for 2.13.0a1 feb-09-2024

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.12.0"
+__version__ = "2.13.0a0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "2.12.0"
+__version__ = "2.13.0a0"
 
 
 def compare_versions(


### PR DESCRIPTION
As usual, this is an alpha release and thus does not include collecting the changelog fragments.

There is only 1 fragment for the prod release next Wed -

- Improved handling of unexpected errors in the `HighThroughputEngine`

2.13.0 prod release Wed Feb 14 will contain the above in release notes.

