### PR TITLE
Enable encryption for `GlobusComputeEngine`

### DIFF
--- a/changelog.d/20240208_180713_30907815+rjmello_pasl_htex_encryption.rst
+++ b/changelog.d/20240208_180713_30907815+rjmello_pasl_htex_encryption.rst
@@ -1,0 +1,22 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Upgraded Parsl to version ``2024.02.05`` to enable encryption for the ``GlobusComputeEngine``.
+  Under the hood, Parsl uses CurveZMQ to encrypt all communication channels between the engine
+  and related nodes.
+
+  We enable encryption by default, but users can disable it by setting the ``encrypted``
+  configuration variable under the ``engine`` stanza to ``false``.
+
+  E.g.,
+
+  .. code-block:: yaml
+
+    engine:
+      type: GlobusComputeEngine
+      encrypted: false
+
+  Depending on the installation, encryption might noticeably degrade throughput performance.
+  If this is an issue for your workflow, please refer to `Parsl's documentation on encryption
+  performance <https://parsl.readthedocs.io/en/stable/userguide/execution.html#encryption-performance>`_
+  before disabling encryption.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -37,6 +37,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         container_type: t.Literal[VALID_CONTAINER_TYPES] = None,  # type: ignore
         container_uri: t.Optional[str] = None,
         container_cmd_options: t.Optional[str] = None,
+        encrypted: bool = True,
         **kwargs,
     ):
         """The ``GlobusComputeEngine`` is a shim over `Parsl's HighThroughputExecutor
@@ -65,6 +66,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
            Specify scaling strategy.
            default: SimpleStrategy
 
+        encrypted: bool
+            Flag to enable/disable encryption (CurveZMQ). Default is True.
+
         """  # noqa: E501
         self.run_dir = os.getcwd()
         self.label = label
@@ -86,9 +90,14 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             executor = HighThroughputExecutor(  # type: ignore
                 *args,
                 label=label,
+                encrypted=encrypted,
                 **kwargs,
             )
         self.executor = executor
+
+    @property
+    def encrypted(self):
+        return self.executor.encrypted
 
     def containerized_launch_cmd(self) -> str:
         """Recompose executor's launch_cmd to launch with containers

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.01.22",
+    "parsl==2024.02.05",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",

--- a/compute_endpoint/tests/conftest.py
+++ b/compute_endpoint/tests/conftest.py
@@ -112,7 +112,7 @@ def engine_heartbeat() -> int:
 def engine_runner(tmp_path, engine_heartbeat, reporting_period=0.1) -> t.Callable:
     engines_to_shutdown = []
 
-    def _runner(engine_type: t.Type[GlobusComputeEngineBase]):
+    def _runner(engine_type: t.Type[GlobusComputeEngineBase], **kwargs):
         ep_id = uuid.uuid4()
         queue = Queue()
         if engine_type is engines.ProcessPoolEngine:
@@ -127,6 +127,7 @@ def engine_runner(tmp_path, engine_heartbeat, reporting_period=0.1) -> t.Callabl
             )
         else:
             raise NotImplementedError(f"Unimplemented: {engine_type.__name__}")
+        k.update(**kwargs)
         engine = engine_type(**k)
         engine._status_report_thread.reporting_period = reporting_period
         engine.start(

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -173,6 +173,7 @@ def test_gcengine_pass_through_to_executor(mocker: MockFixture):
     kwargs = {
         "label": "VroomEngine",
         "address": "127.0.0.1",
+        "encrypted": False,
         "foo": "bar",
     }
     GlobusComputeEngine(*args, **kwargs)
@@ -202,3 +203,17 @@ def test_gcengine_start_pass_through_to_executor(
 
     assert mock_executor.run_dir == run_dir
     assert mock_executor.provider.script_dir == scripts_dir
+
+
+@pytest.mark.parametrize("encrypted", (True, False))
+def test_gcengine_encrypted(encrypted: bool, engine_runner):
+    engine: GlobusComputeEngine = engine_runner(
+        GlobusComputeEngine, encrypted=encrypted
+    )
+    assert engine.encrypted is engine.executor.encrypted is encrypted
+
+    with pytest.raises(AttributeError):
+        engine.encrypted = not encrypted
+
+    engine.executor.encrypted = not encrypted
+    assert engine.encrypted is not encrypted


### PR DESCRIPTION
# Description

Upgraded Parsl to version ``2024.02.05`` to enable encryption for the ``GlobusComputeEngine``. Under the hood, Parsl uses CurveZMQ to encrypt all communication channels between the engine and related nodes.

We enable encryption by default, but users can disable it by setting the ``encrypted`` configuration variable under the ``engine`` stanza to ``false``.

[sc-14420]

## Type of change

- New feature (non-breaking change that adds functionality)
