### PR TITLE
Removing dead code. BaseStrategy.notify is never used.

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/strategies/base.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/base.py
@@ -118,17 +118,6 @@ class BaseStrategy:
             else:
                 print("Sleeping a bit more")
 
-    def notify(self, event_id: t.Any):
-        """Let the FlowControl system know that there is an event.
-
-        This method is to be called from the Interchange to notify the flowcontrol
-        """
-        self._event_buffer.extend([event_id])
-        self._event_count += 1
-        if self._event_count >= self.threshold:
-            log.debug("Eventcount >= threshold")
-            self.make_callback(kind="event")
-
     def make_callback(self, kind=None):
         """Makes the callback and resets the timer.
 


### PR DESCRIPTION
# Description

This PR removes `BaseStrategy.notify` that is never used. 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
