### PR TITLE
Implement MEP heartbeats

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/__init__.py
@@ -1,10 +1,12 @@
 from .base import RabbitPublisherStatus, SubscriberProcessStatus
+from .command_queue_subscriber import CommandQueueSubscriber
 from .result_publisher import ResultPublisher
 from .task_queue_subscriber import TaskQueueSubscriber
 
 __all__ = (
-    "TaskQueueSubscriber",
+    "CommandQueueSubscriber",
     "ResultPublisher",
+    "TaskQueueSubscriber",
     "RabbitPublisherStatus",
     "SubscriberProcessStatus",
 )


### PR DESCRIPTION
On the heels of [PR #578 (web-service)](https://github.com/globusonline/funcx-services/pull/578), implement the client-side aspect of informing the web-services that the MEP process is online and available.

[sc-30054]

## Type of change

- New feature (non-breaking change that adds functionality)