### PR TITLE
Reduce unnecessary test delays

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/strategies/base.py
+++ b/compute_endpoint/globus_compute_endpoint/strategies/base.py
@@ -82,7 +82,7 @@ class BaseStrategy:
 
     @abstractmethod
     def strategize(self, *args, **kwargs):
-        """Strategize is called everytime he interval is hit"""
+        """Strategize is called everytime the interval is hit"""
         ...
 
     def _wake_up_timer(self):


### PR DESCRIPTION
Motivated by pytest's durations report, reduce the unnecessary test delays from the `test_interchange` set of tests.  The core concept here is the iterations, not the actual time waited.

Reduces time taken for this collection of tests from ~24s to ~1.5s on my local hardware.

## Type of change

- Code maintenance/cleanup