### PR TITLE
Avoid potential MEP shutdown hang

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -443,7 +443,7 @@ class EndpointManager:
 
         try:
             f = self.send_heartbeat(shutting_down=True)
-            f.result()  # Ensure heartbeat sent prior to thread shutdown
+            f.result(10)  # Ensure heartbeat sent prior to thread shutdown
         except Exception as e:
             log.warning(f"Unable to send final heartbeat -- ({type(e).__name__}) {e}")
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -977,11 +977,16 @@ def test_send_heartbeat_shares_exception(
 
 def test_sends_heartbeat_at_shutdown(mocker, epmanager_as_root, noop, reset_signals):
     *_, em = epmanager_as_root
+    hb_fut = mocker.Mock(spec=Future)
     em.send_heartbeat = mocker.Mock(spec=EndpointManager.send_heartbeat)
+    em.send_heartbeat.return_value = hb_fut
     em._event_loop = noop
     em.start()
 
-    assert em.send_heartbeat.called
+    assert hb_fut.result.called
+    a, _ = hb_fut.result.call_args
+    assert isinstance(a[0], int), "Expected *some* timeout value for sending a HB"
+
     _, k = em.send_heartbeat.call_args
 
     assert k["shutting_down"] is True


### PR DESCRIPTION
When sending the final heartbeat, do not assume that the heartbeat will ever actually send.  Instead, give it an upper bound of 10 seconds (arbitrarily chosen).  This avoids the real case of the endpoint shutting down due to an RMQ connection issue (true AWS story!) but the result-publisher thread shutting down after having accepted to send the final HB but before it was sent.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
