### PR TITLE
Support `max_workers_per_node` attr for GCEngine

### DIFF
--- a/changelog.d/20240227_130057_30907815+rjmello_gcengine_max_workers.rst
+++ b/changelog.d/20240227_130057_30907815+rjmello_gcengine_max_workers.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Users can now define the ``max_workers_per_node`` configuration variable
+  for the ``GlobusComputeEngine``, which is equivalent to the ``max_workers``
+  variable. When both are defined, ``max_workers_per_node`` will take precedence.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -77,7 +77,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             *args, max_retries_on_system_failure=max_retries_on_system_failure, **kwargs
         )
         self.strategy = strategy
-        self.max_workers_per_node = 1
 
         self.container_type = container_type
         assert (
@@ -85,6 +84,13 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         ), f"{self.container_type} is not a valid container_type"
         self.container_uri = container_uri
         self.container_cmd_options = container_cmd_options
+
+        # We can remove this code once we rename the max_workers attribute on
+        # the Parsl HTEX to max_workers_per_node, which is more explicit.
+        max_workers_per_node = kwargs.pop("max_workers_per_node", None)
+        max_workers = max_workers_per_node or kwargs.get("max_workers", float("inf"))
+        kwargs["max_workers"] = max_workers
+        self.max_workers_per_node = max_workers
 
         if executor is None:
             executor = HighThroughputExecutor(  # type: ignore

--- a/compute_endpoint/tests/unit/test_engines.py
+++ b/compute_endpoint/tests/unit/test_engines.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import random
 import time
+import typing as t
 import uuid
 from queue import Queue
 from unittest import mock
@@ -174,6 +175,7 @@ def test_gcengine_pass_through_to_executor(mocker: MockFixture):
         "label": "VroomEngine",
         "address": "127.0.0.1",
         "encrypted": False,
+        "max_workers": 1,
         "foo": "bar",
     }
     GlobusComputeEngine(*args, **kwargs)
@@ -217,3 +219,20 @@ def test_gcengine_encrypted(encrypted: bool, engine_runner):
 
     engine.executor.encrypted = not encrypted
     assert engine.encrypted is not encrypted
+
+
+@pytest.mark.parametrize("max_workers_per_node", (1, 2, None))
+@pytest.mark.parametrize("max_workers", (3, 4, 5))
+def test_gcengine_max_workers_per_node(
+    engine_runner, max_workers_per_node: t.Union[int, None], max_workers: int
+):
+    engine: GlobusComputeEngine = engine_runner(
+        GlobusComputeEngine,
+        max_workers_per_node=max_workers_per_node,
+        max_workers=max_workers,
+    )
+
+    if max_workers_per_node:
+        assert engine.executor.max_workers == max_workers_per_node
+    else:
+        assert engine.executor.max_workers == max_workers


### PR DESCRIPTION
# Description

The default `user_config_template.yaml` file defines this attribute but the Parsl HTEX only supports `max_workers`. This is a temporary fix until we can update the attribute name in the Parsl HTEX.

If the user defines both `max_workers_per_node` and `max_workers`, the former will take precedence.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
