### PR TITLE
Globally address non-seekable log file

### DIFF
--- a/compute_endpoint/tests/unit/test_logging_config.py
+++ b/compute_endpoint/tests/unit/test_logging_config.py
@@ -1,0 +1,63 @@
+import os
+import pathlib
+
+import pytest
+from globus_compute_endpoint.logging_config import _get_file_dict_config, setup_logging
+
+_MOCK_BASE = "globus_compute_endpoint.logging_config."
+
+
+@pytest.fixture
+def anon_pipe():
+    read, write = os.pipe()
+    yield read, write
+    os.close(write)
+    os.close(read)
+
+
+def test_verify_setup_logging_test_hookups_metatest(mocker):
+    mock_impl_file = mocker.patch(f"{_MOCK_BASE}_get_file_dict_config")
+    mock_impl_stream = mocker.patch(f"{_MOCK_BASE}_get_stream_dict_config")
+    mock_log_config = mocker.patch(f"{_MOCK_BASE}logging.config.dictConfig")
+
+    k = {"console_enabled": False, "debug": False, "no_color": True}
+    setup_logging(**k)
+    assert mock_impl_stream.called, "Verify test module assumption"
+    assert not mock_impl_file.called, "Verify test module assumption"
+    assert mock_log_config.called, "Verify test module assumption"
+
+    mock_impl_stream.reset_mock()
+    mock_log_config.reset_mock()
+
+    k["logfile"] = "/some/path"
+    setup_logging(**k)
+    assert not mock_impl_stream.called, "Verify test module assumption"
+    assert mock_impl_file.called, "Verify test module assumption"
+    assert mock_log_config.called, "Verify test module assumption"
+
+
+def test_file_config_rotates_log(fs):
+    logp = pathlib.Path("/some/path/some/file.log")
+    conf = _get_file_dict_config(logp, False, False, True)
+    file_handler = conf["handlers"]["logfile"]
+
+    assert "Rotating" in file_handler["class"]
+    assert "maxBytes" in file_handler, "Without maxBytes, default setup won't rotate"
+
+
+def test_file_config_rotates_at_reasonable_size(fs):
+    logp = pathlib.Path("/some/path/some/file.log")
+    conf = _get_file_dict_config(logp, False, False, True)
+    file_handler = conf["handlers"]["logfile"]
+
+    assert file_handler["maxBytes"] > 1024, "Expected *some* file-rotation threshold"
+    assert file_handler["maxBytes"] <= 2**30, "A gigabyte is perhaps large enough"
+
+
+def test_file_config_does_not_rotate_unrotatable_sc30480(anon_pipe):
+    read_h, write_h = anon_pipe
+    logp = pathlib.Path(f"/proc/self/fd/{write_h}")
+    conf = _get_file_dict_config(logp, False, False, True)
+
+    file_handler = conf["handlers"]["logfile"]
+    assert "Rotating" not in file_handler["class"], "Expected a non-rotating handler"


### PR DESCRIPTION
PR #1475 addressed the case of the UEP incorrectly assuming grandfathered access to the MEP's log file descriptor.  A tangential issue, however, is that some files are not rotatable.  For example, it is entirely feasible to symlink `endpoint.log` to `/dev/stdout`, in which case the RFH does the right thing and ignores it -- but it shouldn't have been setup in the first place.  So, do the first place thing, and don't set up the more correct logging handler.

[sc-30480]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup