### PR TITLE
Two dependency updates

### DIFF
--- a/changelog.d/20240301_105729_kevin_update_two_deps.rst
+++ b/changelog.d/20240301_105729_kevin_update_two_deps.rst
@@ -1,0 +1,10 @@
+Changed
+^^^^^^^
+
+- Update ``globus-sdk`` dependency to at least 3.28.0
+
+Security
+^^^^^^^^
+
+- Bump ``jinja2`` dependency to 3.1.3
+

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -39,7 +39,7 @@ REQUIRES = [
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",
     "pyyaml>=6.0,<7.0",
-    "jinja2>=3.1.2,<3.2",
+    "jinja2>=3.1.3,<3.2",
     "jsonschema>=4.19.0,<4.20",
     "cachetools>=5.3.1",
     "types-cachetools>=5.3.0.6",

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_namespace_packages, setup
 REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
-    "globus-sdk>=3.20.1,<4",
+    "globus-sdk>=3.28.0,<4",
     "globus-compute-common==0.3.0",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",


### PR DESCRIPTION
Jinja2 update to silence the IDE complaint, but the Globus SDK update as we march toward Python 3.12 support (or, more sanguinely, ~6 months back is what we support).

## Type of change

- Code maintenance/cleanup