### PR TITLE
Do not escape containerized launch command

### DIFF
--- a/changelog.d/20240302_235505_30907815+rjmello_container_launch_cmd.rst
+++ b/changelog.d/20240302_235505_30907815+rjmello_container_launch_cmd.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a bug that caused errors on containerized endpoints when certain
+  configuration fields (e.g., ``address_probe_timeout``) were not defined.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -143,6 +143,8 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
             )
             launch_cmd = template.replace("{EXECUTOR_LAUNCH_CMD}", launch_cmd)
 
+        # Remove extra whitespace between tokens
+        launch_cmd = " ".join(shlex.split(launch_cmd))
         return launch_cmd
 
     def start(
@@ -162,8 +164,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         script_dir = os.path.join(self.run_dir, "submit_scripts")
         self.executor.provider.script_dir = script_dir
         if self.container_type:
-            containerized_launch_cmd = self.containerized_launch_cmd()
-            self.executor.launch_cmd = shlex.join(shlex.split(containerized_launch_cmd))
+            self.executor.launch_cmd = self.containerized_launch_cmd()
             logger.info(
                 f"Containerized launch cmd template: {self.executor.launch_cmd}"
             )

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gce_container.py
@@ -13,6 +13,7 @@ def platinfo():
 
 def test_docker(tmp_path):
     gce = GlobusComputeEngine(
+        worker_debug=True,
         address="127.0.0.1",
         label="GCE_TEST",
         container_type="docker",
@@ -23,7 +24,7 @@ def test_docker(tmp_path):
     container_launch_cmd = gce.executor.launch_cmd
     expected = (
         "docker run --FABRICATED -v /tmp:/tmp -t "
-        "funcx/kube-endpoint:main-3.10 process_worker_pool.py"
+        "funcx/kube-endpoint:main-3.10 process_worker_pool.py --debug"
     )
     assert container_launch_cmd.startswith(expected)
 
@@ -32,6 +33,7 @@ def test_docker(tmp_path):
 
 def test_apptainer(tmp_path):
     gce = GlobusComputeEngine(
+        worker_debug=True,
         address="127.0.0.1",
         label="GCE_TEST",
         container_type="apptainer",
@@ -40,7 +42,9 @@ def test_apptainer(tmp_path):
     )
     gce.start(endpoint_id=uuid.uuid4(), run_dir="/tmp")
     container_launch_cmd = gce.executor.launch_cmd
-    expected = "apptainer run --FABRICATED APPTAINER_PATH process_worker_pool.py"
+    expected = (
+        "apptainer run --FABRICATED APPTAINER_PATH process_worker_pool.py --debug"
+    )
     assert container_launch_cmd.startswith(expected)
 
     gce.shutdown()
@@ -48,6 +52,7 @@ def test_apptainer(tmp_path):
 
 def test_singularity(tmp_path):
     gce = GlobusComputeEngine(
+        worker_debug=True,
         address="127.0.0.1",
         max_workers=1,
         label="GCE_TEST",
@@ -59,7 +64,7 @@ def test_singularity(tmp_path):
     container_launch_cmd = gce.executor.launch_cmd
     expected = (
         "singularity run /home/yadunand/kube-endpoint.py3.9.sif"
-        " process_worker_pool.py"
+        " process_worker_pool.py --debug"
     )
     assert container_launch_cmd.startswith(expected)
 


### PR DESCRIPTION
# Description

`shlex.join()` adds quotes around launch command template placeholders for variables that do not have an option defined in the template. Thus, when the associated configuration variables are absent, the submit script will trigger an unrecognized arguments error.

I've decided to remove the code rather than fix it because we already have a Jinja template filter, `shell_escape` (see #1264), that enables endpoint admins to escape user-provided shell commands.

[sc-30541]

## Type of change

- Bug fix (non-breaking change that fixes an issue)