### PR TITLE
Ensure parsl logs propagate

### DIFF
--- a/changelog.d/20240305_135742_30907815+rjmello.rst
+++ b/changelog.d/20240305_135742_30907815+rjmello.rst
@@ -1,0 +1,4 @@
+Bug Fixes
+^^^^^^^^^
+
+- Logs from ``parsl`` (providers, etc.) are now showing in ``endpoint.log``.

--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -193,9 +193,12 @@ def _get_file_dict_config(
                 "level": "DEBUG" if debug else "INFO",
                 "handlers": log_handlers,
             },
-            # configure for the Globus Compute SDK as well
             "globus_compute_sdk": {
                 "level": "DEBUG" if debug else "WARNING",
+                "handlers": log_handlers,
+            },
+            "parsl": {
+                "level": "DEBUG" if debug else "INFO",
                 "handlers": log_handlers,
             },
         },
@@ -225,9 +228,12 @@ def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:
                 "level": "DEBUG",
                 "handlers": ["console"],
             },
-            # configure for the Globus Compute SDK as well
             "globus_compute_sdk": {
                 "level": "DEBUG" if debug else "WARNING",
+                "handlers": ["console"],
+            },
+            "parsl": {
+                "level": "DEBUG" if debug else "INFO",
                 "handlers": ["console"],
             },
         },


### PR DESCRIPTION
# Description

Our logging config did not include the parsl logger, resulting in no parsl logs showing up in `endpoint.log`.

[sc-30588]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
