### PR TITLE
Bump parsl pinned version to 2023.3.4

### DIFF
--- a/changelog.d/20240308_113821_yadudoc1729_bump_parsl_pinned_version_to_2023_3_4.rst
+++ b/changelog.d/20240308_113821_yadudoc1729_bump_parsl_pinned_version_to_2023_3_4.rst
@@ -1,0 +1,42 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. New Functionality
+.. ^^^^^^^^^^^^^^^^^
+..
+.. - A bullet item for the New Functionality category.
+..
+.. Bug Fixes
+.. ^^^^^^^^^
+..
+.. - A bullet item for the Bug Fixes category.
+..
+.. Removed
+.. ^^^^^^^
+..
+.. - A bullet item for the Removed category.
+..
+.. Deprecated
+.. ^^^^^^^^^^
+..
+.. - A bullet item for the Deprecated category.
+..
+Changed
+^^^^^^^
+
+- Bumped parsl pinned version from ``2024.02.05`` to ``2024.3.4``
+  This version bump brings in following fixes:
+
+  - HTEX to support `max_workers_per_node` as a kwarg
+  - Better stdout/err reporting from failed tasks
+  - Support for detecting MISSING jobs
+  - Better HTEX interchange shutdown logic to avoid hung processes
+..
+.. - A bullet item for the Changed category.
+..
+.. Security
+.. ^^^^^^^^
+..
+.. - A bullet item for the Security category.
+..

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.02.05",
+    "parsl==2024.3.4",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
# Description

Bumped parsl pinned version from ``2024.02.05`` to ``2024.3.4``
  This version bump brings in following fixes:

  - HTEX to support `max_workers_per_node` as a kwarg
  - Better stdout/err reporting from failed tasks
  - Support for detecting MISSING jobs
  - Better HTEX interchange shutdown logic to avoid hung processes

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup
