### PR TITLE
Remove `max_workers` rename in GCEngine

### DIFF
--- a/changelog.d/20240227_130057_30907815+rjmello_gcengine_max_workers.rst
+++ b/changelog.d/20240227_130057_30907815+rjmello_gcengine_max_workers.rst
@@ -1,6 +1,0 @@
-Bug Fixes
-^^^^^^^^^
-
-- Users can now define the ``max_workers_per_node`` configuration variable
-  for the ``GlobusComputeEngine``, which is equivalent to the ``max_workers``
-  variable. When both are defined, ``max_workers_per_node`` will take precedence.

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -85,13 +85,6 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.container_uri = container_uri
         self.container_cmd_options = container_cmd_options
 
-        # We can remove this code once we rename the max_workers attribute on
-        # the Parsl HTEX to max_workers_per_node, which is more explicit.
-        max_workers_per_node = kwargs.pop("max_workers_per_node", None)
-        max_workers = max_workers_per_node or kwargs.get("max_workers", float("inf"))
-        kwargs["max_workers"] = max_workers
-        self.max_workers_per_node = max_workers
-
         if executor is None:
             executor = HighThroughputExecutor(  # type: ignore
                 *args,
@@ -100,6 +93,11 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 **kwargs,
             )
         self.executor = executor
+
+    @property
+    def max_workers_per_node(self):
+        # Needed for strategies (e.g., SimpleStrategy)
+        return self.executor.max_workers_per_node
 
     @property
     def encrypted(self):
@@ -380,7 +378,7 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 "prefetch_capacity": self.executor.prefetch_capacity,
                 "max_blocks": self.executor.provider.max_blocks,
                 "min_blocks": self.executor.provider.min_blocks,
-                "max_workers_per_node": self.executor.max_workers,
+                "max_workers_per_node": self.executor.max_workers_per_node,
                 "nodes_per_block": self.executor.provider.nodes_per_block,
                 "heartbeat_period": self.executor.heartbeat_period,
             },


### PR DESCRIPTION
# Description

The Parsl HTEX supports both `max_workers` and `max_workers_per_node` as initialization arguments starting in version `2024.03.04`. The former is deprecated and will be removed in a future release.

[sc-30483]

## Type of change

- Code maintenance/cleanup
