### PR TITLE
Include `display_name` in MEP registration payload

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -156,6 +156,7 @@ class EndpointManager:
                     name=conf_dir.name,
                     endpoint_id=endpoint_uuid,
                     metadata=EndpointManager.get_metadata(config, conf_dir),
+                    display_name=config.display_name,
                     multi_user=True,
                 )
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -420,13 +420,22 @@ def test_handles_provided_endpoint_id_with_json(
     assert k["endpoint_id"] == ep_uuid
 
 
-def test_sends_metadata_during_registration(conf_dir, mock_conf, mock_client):
+def test_sends_data_during_registration(conf_dir, mock_conf, mock_client):
     ep_uuid, mock_gcc = mock_client
     mock_conf.multi_user = True
     EndpointManager(conf_dir, ep_uuid, mock_conf)
 
     assert mock_gcc.register_endpoint.called
     _a, k = mock_gcc.register_endpoint.call_args
+    for key in (
+        "name",
+        "endpoint_id",
+        "display_name",
+        "metadata",
+        "multi_user",
+    ):
+        assert key in k, "Expected minimal top-level fields"
+
     for key in (
         "endpoint_version",
         "hostname",
@@ -447,6 +456,7 @@ def test_sends_metadata_during_registration(conf_dir, mock_conf, mock_client):
     ):
         assert key in k["metadata"]["config"]
 
+    assert k["multi_user"] is True
     assert k["metadata"]["config"]["multi_user"] is True
 
 


### PR DESCRIPTION
# Description

Users should be able to set a display name on a multi-user endpoint.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
