### PR TITLE
Update GlobusComputeEngine to use Parsl's `Strategy`

### DIFF
--- a/changelog.d/20240313_135645_yadudoc1729_update_strategy.rst
+++ b/changelog.d/20240313_135645_yadudoc1729_update_strategy.rst
@@ -1,0 +1,21 @@
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a bug in ``GlobusComputeEngine`` where a faulty endpoint-config could result in
+  the endpoint repeatedly submitting jobs to the batch scheduler.  The endpoint will
+  not shut down, reporting the root cause in ``endpoint.log``
+
+- Fixed bug where ``GlobusComputeEngine`` lost track of submitted jobs that failed to
+  have workers connect back. The endpoint will now report a fault if multiple jobs
+  have failed to connect back and shutdown, tasks submitted to the endpoint will
+  return an exception.
+
+Changed
+^^^^^^^
+
+- ``GlobusComputeEngine``'s ``strategy`` kwarg now only accepts ``str``, valid options are
+  ``{'none', 'simple'}`` where ``simple`` is the default.
+- The maximum duration that workers are allowed to idle when using ``GlobusComputeEngine``
+  can now be configured with the new kwarg ``max_idletime`` which accepts a float and defaults
+  to 120s.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/interchange.py
@@ -370,6 +370,10 @@ class EndpointInterchange:
             # gracefully, iterate once a second whether a task has arrived.
             nonlocal num_tasks_forwarded
             while not self._quiesce_event.is_set():
+                if executor.executor_exception:
+                    self.time_to_quit = True
+                    log.exception(executor.executor_exception)
+
                 if self.time_to_quit:
                     self.stop()
                     continue  # nominally == break; but let event do it

--- a/compute_endpoint/globus_compute_endpoint/engines/base.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/base.py
@@ -90,7 +90,7 @@ class GlobusComputeEngineBase(ABC):
         self.run_dir: t.Optional[str] = None
         # This attribute could be set by the subclasses in their
         # start method if another component insists on owning the queue.
-        self.results_passthrough: queue.Queue[dict[str, bytes | str | None]] = (
+        self.results_passthrough: queue.Queue[dict[str, t.Union[bytes, str, None]]] = (
             queue.Queue()
         )
 
@@ -218,7 +218,11 @@ class GlobusComputeEngineBase(ABC):
                 "packed_task": packed_task,
                 "exception_history": [],
             }
-        future = self._submit(execute_task, task_id, packed_task, self.endpoint_id)
+        try:
+            future = self._submit(execute_task, task_id, packed_task, self.endpoint_id)
+        except Exception as e:
+            future = Future()
+            future.set_exception(e)
         self._setup_future_done_callback(task_id, future)
         return future
 

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -6,7 +6,6 @@ from queue import Queue
 
 import pytest
 from globus_compute_endpoint.engines import GlobusComputeEngine
-from globus_compute_endpoint.strategies import SimpleStrategy
 from parsl.providers import LocalProvider
 from tests.utils import double, try_assert
 
@@ -25,7 +24,7 @@ def gc_engine_scaling(tmp_path):
             min_blocks=0,
             max_blocks=1,
         ),
-        strategy=SimpleStrategy(interval=0.1, max_idletime=0),
+        job_status_kwargs={"max_idletime": 0, "strategy_period": 0.1},
     )
     queue = Queue()
     engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
@@ -46,7 +45,8 @@ def gc_engine_non_scaling(tmp_path):
             min_blocks=1,
             max_blocks=1,
         ),
-        strategy=None,
+        strategy="none",
+        job_status_kwargs={"max_idletime": 0, "strategy_period": 0.1},
     )
     queue = Queue()
     engine.start(endpoint_id=ep_id, run_dir=str(tmp_path), results_passthrough=queue)
@@ -83,7 +83,8 @@ def test_engine_no_scaling(gc_engine_non_scaling):
     """Confirm that Engine works with fixes # of blocks"""
 
     engine = gc_engine_non_scaling
-    assert engine.strategy is None
+
+    assert engine.job_status_poller
 
     # At the start there should be 0 managers
     outstanding = engine.get_outstanding_breakdown()
@@ -97,4 +98,4 @@ def test_engine_no_scaling(gc_engine_non_scaling):
 
     # Confirm that there's 1 manager
     outstanding = engine.get_outstanding_breakdown()
-    assert len(outstanding) == 2, "Expecting 1 manager+interchange"
+    assert len(outstanding) == 2, "Expecting 1 manager + interchange"

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -32,6 +32,7 @@ def run_interchange_process(
     def run_it(reg_info: dict, endpoint_uuid, endpoint_dir):
         mock_exe = MockExecutor()
         mock_exe.endpoint_id = endpoint_uuid
+        mock_exe.executor_exception = None
 
         if hasattr(request, "param") and request.param:
             config = request.param


### PR DESCRIPTION
# Description

`GlobusComputeEngine` currently uses globus-compute's `Strategy` code which is a fork of Parsl's `Strategy` implementation. This PR switched `GCE` over to use Parsl's `Strategy` instead.

Here's what to expect with these changes:

1. GlobusComputeEngine no longer takes the strategy class as a kwarg but rather you select from `None|'simple'`
2. Faulty configs where the batch scheduler immediately rejects jobs cause endpoint shutdown and submitted tasks that reach the endpoint return with an exception message with info on the failure
3. Faulty configs where batch jobs fail to have workers start (bad networking configuration, or python environment) are reported as `MissingJobs` that also cause endpoint shutdown.



## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
