### PR TITLE
Add support for `public` config field 

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -82,7 +82,7 @@ class Config(RepresentationMixin):
         Default: ./interchange.stderr
 
     detach_endpoint : Bool
-        Should the endpoint deamon be run as a detached process? This is good for
+        Should the endpoint daemon be run as a detached process? This is good for
         a real edge node, but an anti-pattern for kubernetes pods
         Default: True
 
@@ -92,6 +92,12 @@ class Config(RepresentationMixin):
 
     multi_user : bool | None
         Designates the endpoint as a multi-user endpoint
+        Default: None
+
+    public : bool | None
+        Indicates if all users can discover the multi-user endpoint via our web UI and
+        API. This field is only supported on multi-user endpoints and does not control
+        access to the endpoint; therefore, it should not be used as a security feature.
         Default: None
 
     allowed_functions : list[str] | None
@@ -146,6 +152,7 @@ class Config(RepresentationMixin):
         environment: str | None = None,
         funcx_service_address=None,
         multi_user: bool | None = None,
+        public: bool | None = None,
         allowed_functions: list[str] | None = None,
         authentication_policy: str | None = None,
         subscription_id: str | None = None,
@@ -217,6 +224,7 @@ class Config(RepresentationMixin):
             _p = pathlib.Path(self.identity_mapping_config_path)
             if not _p.exists():
                 warnings.warn(f"Identity mapping config path not found ({_p})")
+        self.public = public is True
 
         # Auth
         self.allowed_functions = allowed_functions

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -430,6 +430,7 @@ class Endpoint:
                     allowed_functions=endpoint_config.allowed_functions,
                     auth_policy=endpoint_config.authentication_policy,
                     subscription_id=endpoint_config.subscription_id,
+                    public=endpoint_config.public,
                 )
 
             except GlobusAPIError as e:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -158,6 +158,7 @@ class EndpointManager:
                     metadata=EndpointManager.get_metadata(config, conf_dir),
                     display_name=config.display_name,
                     multi_user=True,
+                    public=config.public,
                 )
 
                 # Mostly to appease mypy, but also a useful text if it ever

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -111,6 +111,7 @@ def test_start_endpoint_data_passthrough(fs):
     ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
     ep_conf.authentication_policy = str(uuid.uuid4())
     ep_conf.subscription_id = str(uuid.uuid4())
+    ep_conf.public = True
 
     with pytest.raises(SystemExit) as pyt_exc:
         ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
@@ -123,6 +124,7 @@ def test_start_endpoint_data_passthrough(fs):
     assert req_json["allowed_functions"][1] == ep_conf.allowed_functions[1]
     assert req_json["authentication_policy"] == ep_conf.authentication_policy
     assert req_json["subscription_uuid"] == ep_conf.subscription_id
+    assert req_json["public"] is ep_conf.public
 
 
 def test_endpoint_logout(monkeypatch):

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -99,7 +99,7 @@ def test_start_endpoint_display_name(mocker, fs, display_name):
         assert "display_name" not in req_json
 
 
-def test_start_endpoint_allowlist_passthrough(mocker, fs):
+def test_start_endpoint_data_passthrough(fs):
     responses.add(  # 404 == we are verifying the POST, not the response
         responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
     )
@@ -109,49 +109,7 @@ def test_start_endpoint_allowlist_passthrough(mocker, fs):
     ep_dir = pathlib.Path("/some/path/some_endpoint_name")
     ep_dir.mkdir(parents=True, exist_ok=True)
     ep_conf.allowed_functions = [str(uuid.uuid4()), str(uuid.uuid4())]
-
-    with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
-    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
-
-    req = pyt_exc.value.__cause__._underlying_response.request
-    req_json = json.loads(req.body)
-    assert len(req_json["allowed_functions"]) == 2
-    assert req_json["allowed_functions"][1] == ep_conf.allowed_functions[1]
-
-
-def test_start_endpoint_auth_policy_passthrough(mocker, fs):
-    responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
-    )
-
-    ep_dir = pathlib.Path("/some/path/some_endpoint_name")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-
-    ep = endpoint.Endpoint()
-    ep_conf = Config()
     ep_conf.authentication_policy = str(uuid.uuid4())
-
-    with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={})
-    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
-
-    req = pyt_exc.value.__cause__._underlying_response.request
-    req_json = json.loads(req.body)
-
-    assert req_json["authentication_policy"] == ep_conf.authentication_policy
-
-
-def test_start_endpoint_subscription_id_passthrough(mocker, fs):
-    responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
-    )
-
-    ep_dir = pathlib.Path("/some/path/some_endpoint_name")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-
-    ep = endpoint.Endpoint()
-    ep_conf = Config()
     ep_conf.subscription_id = str(uuid.uuid4())
 
     with pytest.raises(SystemExit) as pyt_exc:
@@ -161,6 +119,9 @@ def test_start_endpoint_subscription_id_passthrough(mocker, fs):
     req = pyt_exc.value.__cause__._underlying_response.request
     req_json = json.loads(req.body)
 
+    assert len(req_json["allowed_functions"]) == 2
+    assert req_json["allowed_functions"][1] == ep_conf.allowed_functions[1]
+    assert req_json["authentication_policy"] == ep_conf.authentication_policy
     assert req_json["subscription_uuid"] == ep_conf.subscription_id
 
 

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -91,3 +91,9 @@ def test_config_warns_bad_identity_mapping_path(mocker, config_dict_mu, tmp_path
     assert "Identity mapping config" in warn_a
     assert "path not found" in warn_a
     assert str(conf_p) in warn_a, "expect include location of file in warning"
+
+
+@pytest.mark.parametrize("public", (None, True, False, "a", 1))
+def test_public(public: t.Any):
+    c = Config(public=public)
+    assert c.public is (public is True)

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -420,9 +420,13 @@ def test_handles_provided_endpoint_id_with_json(
     assert k["endpoint_id"] == ep_uuid
 
 
-def test_sends_data_during_registration(conf_dir, mock_conf, mock_client):
+@pytest.mark.parametrize("public", (True, False))
+def test_sends_data_during_registration(
+    conf_dir, mock_conf: Config, mock_client, public: bool
+):
     ep_uuid, mock_gcc = mock_client
     mock_conf.multi_user = True
+    mock_conf.public = public
     EndpointManager(conf_dir, ep_uuid, mock_conf)
 
     assert mock_gcc.register_endpoint.called
@@ -433,6 +437,7 @@ def test_sends_data_during_registration(conf_dir, mock_conf, mock_client):
         "display_name",
         "metadata",
         "multi_user",
+        "public",
     ):
         assert key in k, "Expected minimal top-level fields"
 
@@ -456,6 +461,7 @@ def test_sends_data_during_registration(conf_dir, mock_conf, mock_client):
     ):
         assert key in k["metadata"]["config"]
 
+    assert k["public"] is mock_conf.public
     assert k["multi_user"] is True
     assert k["metadata"]["config"]["multi_user"] is True
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -432,6 +432,7 @@ class Client:
         allowed_functions: list[UUID_LIKE_T] | None = None,
         auth_policy: UUID_LIKE_T | None = None,
         subscription_id: UUID_LIKE_T | None = None,
+        public: bool | None = None,
     ):
         """Register an endpoint with the Globus Compute service.
 
@@ -453,6 +454,8 @@ class Client:
             Endpoint users are evaluated against this Globus authentication policy
         subscription_id : str | UUID | None
             Subscription ID to associate endpoint with
+        public : bool | None
+            Indicates if all users can discover the multi-user endpoint.
 
         Returns
         -------
@@ -472,6 +475,7 @@ class Client:
             allowed_functions=allowed_functions,
             auth_policy=auth_policy,
             subscription_id=subscription_id,
+            public=public,
         )
         return r.data
 

--- a/compute_sdk/globus_compute_sdk/sdk/web_client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/web_client.py
@@ -176,6 +176,7 @@ class WebClient(globus_sdk.BaseClient):
         allowed_functions: t.Optional[t.List[UUID_LIKE_T]] = None,
         auth_policy: t.Optional[UUID_LIKE_T] = None,
         subscription_id: t.Optional[UUID_LIKE_T] = None,
+        public: t.Optional[bool] = None,
         additional_fields: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> globus_sdk.GlobusHTTPResponse:
         data: t.Dict[str, t.Any] = {"endpoint_name": endpoint_name}
@@ -199,6 +200,8 @@ class WebClient(globus_sdk.BaseClient):
             data["authentication_policy"] = auth_policy
         if subscription_id:
             data["subscription_uuid"] = subscription_id
+        if public is not None:
+            data["public"] = public
         if additional_fields is not None:
             data.update(additional_fields)
 


### PR DESCRIPTION
# Description

The `public` field indicates if all users can discover the multi-user endpoint via our web UI and API. This field is only supported on multi-user endpoints and does not control access to the endpoint; therefore, it should not be used as a security feature.

[sc-30385]

## Type of change

- New feature (non-breaking change that adds functionality)
