### PR TITLE
Bump parsl pinned version to 2023.3.18

### DIFF
--- a/changelog.d/20240321_121200_kevin_update_parsl.rst
+++ b/changelog.d/20240321_121200_kevin_update_parsl.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+- Update Parsl from ``2024.3.4`` to ``2024.3.18``
+

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2024.3.4",
+    "parsl==2024.3.18",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",


### PR DESCRIPTION
Mostly to aid development and testing; there's nothing groundbreaking in this update of Parsl.

## Type of change

- Code maintenance
