### PR TITLE
Remove temporary cqs_/rp_ kwargs hack

### DIFF
--- a/changelog.d/20240326_114255_kevin_mu_more_robust_aws_amq_interaction.rst
+++ b/changelog.d/20240326_114255_kevin_mu_more_robust_aws_amq_interaction.rst
@@ -1,0 +1,13 @@
+Changed
+^^^^^^^
+
+- Update AMQP reconnection handling; previously the reopen-connection logic was
+  woefully optimistic of service or network downtime, assuming connectivity
+  would be restored in ~a minute.  Reality is that a network can be down for
+  hours and a service can take multiple minutes to update.  Consequently,
+  update the number of retry attempts from 3 or 5 to 7,200.  (For context,
+  reconnection attempts occur randomly between every 0.5s and 10s, so this
+  means than an endpoint that has lost connectivity will attempt to reconnect
+  to the web-services for somewhere between 1 and 20 hours.)  Hopefully, this
+  is an adequate value to ensure that Compute endpoints weather most relevant
+  connectivity outages.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -165,16 +165,6 @@ class Config(RepresentationMixin):
         stderr="./endpoint.log",
         **kwargs,
     ):
-        # A temporary measure; at some point in the near future, we'll split out
-        # multi-user from single-user configs.  At that point, this particular stanza
-        # will be incorporated more naturally into the multi-user handling.  Meanwhile,
-        # `cqs_kwargs` and `rp_kwargs` are interfaces to internal class instantiations
-        # for the multi-user endpoint; for now, I intend these to be "hidden" keys (or
-        # at least not advertised, and will change, and will eat your cat if you touch
-        # them).
-        _internal = kwargs.pop("_internal", {})
-        self._cqs_kwargs = _internal.pop("cqs_kwargs", None)
-        self._rp_kwargs = _internal.pop("rp_kwargs", None)
 
         for unknown_arg in kwargs:
             # Calculated multiple times, but only in errant case -- nominally

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -286,19 +286,13 @@ class EndpointManager:
         ptitle += f" [{setproctitle.getproctitle()}]"
         setproctitle.setproctitle(ptitle)
 
-        cqs_kwargs = config._cqs_kwargs or {}
-        cqs_kwargs.update(
-            dict(
-                queue_info=cq_info,
-                command_queue=self._command_queue,
-                stop_event=self._command_stop_event,
-                thread_name="CQS",
-            )
+        self._command = CommandQueueSubscriber(
+            queue_info=cq_info,
+            command_queue=self._command_queue,
+            stop_event=self._command_stop_event,
+            thread_name="CQS",
         )
-        rp_kwargs = config._rp_kwargs or {}
-        rp_kwargs["queue_info"] = rq_info
-        self._command = CommandQueueSubscriber(**cqs_kwargs)
-        self._heartbeat_publisher = ResultPublisher(**rp_kwargs)
+        self._heartbeat_publisher = ResultPublisher(queue_info=rq_info)
 
     @staticmethod
     def get_metadata(config: Config, conf_dir: pathlib.Path) -> dict:


### PR DESCRIPTION
These were a temporary data structure hack for understanding interactions with AWS' RMQ.  Replace with the only important change: lots of retry attempts.

Meanwhile, per the ticket and identified needs, improve the logging situation by emitting RMQ connection updates at key times, while simultaneously not spamming the logs.

[sc-30467]

## Type of change

- New feature (non-breaking change that adds functionality)