### PR TITLE
Enable users to install Pydantic V2

### DIFF
--- a/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
+++ b/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Enable users to install either Pydantic V1 or V2. The former remains
+  the recommended and officially supported version.

--- a/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
+++ b/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
@@ -3,3 +3,8 @@ New Functionality
 
 - Enable users to install either Pydantic V1 or V2. The former remains
   the recommended and officially supported version.
+
+Changed
+^^^^^^^
+
+- Bump ``globus-compute-common`` requirement to version ``0.4.0``.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import typing as t
 from types import ModuleType
 
-import pydantic
+from globus_compute_common.pydantic_v1 import (
+    BaseModel,
+    FilePath,
+    root_validator,
+    validator,
+)
 from globus_compute_endpoint import engines, strategies
 from parsl import addresses as parsl_addresses
 from parsl import channels as parsl_channels
 from parsl import launchers as parsl_launchers
 from parsl import providers as parsl_providers
-from pydantic import BaseModel, FilePath, validator
 
 
 def _validate_import(field: str, package: ModuleType):
@@ -116,7 +120,7 @@ class ConfigModel(BaseConfigModel):
 
     _validate_engine = _validate_params("engine")
 
-    @pydantic.root_validator
+    @root_validator
     @classmethod
     def _validate(cls, values):
         is_mu = values.get("multi_user") is True

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -9,8 +9,8 @@ import shlex
 
 import yaml
 from click import ClickException
+from globus_compute_common.pydantic_v1 import ValidationError
 from packaging.version import Version
-from pydantic import ValidationError
 
 from .config import Config
 from .model import ConfigModel

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -23,7 +23,6 @@ from http import HTTPStatus
 import globus_compute_sdk as GC
 from cachetools import TTLCache
 from globus_compute_endpoint.endpoint.identity_mapper import PosixIdentityMapper
-from pydantic import BaseModel
 
 try:
     import pyprctl
@@ -33,6 +32,7 @@ import setproctitle
 import yaml
 from globus_compute_common.messagepack import pack
 from globus_compute_common.messagepack.message_types import EPStatusReport
+from globus_compute_common.pydantic_v1 import BaseModel
 from globus_compute_endpoint import __version__
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.utils import (

--- a/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/high_throughput/engine.py
@@ -19,6 +19,9 @@ from multiprocessing import Process
 
 import dill
 from globus_compute_common import messagepack
+from globus_compute_common.messagepack.message_types import (
+    EPStatusReport as CommonEPStatusReport,
+)
 from globus_compute_common.messagepack.message_types import Result, ResultErrorDetails
 from globus_compute_endpoint.endpoint.messages_compat import convert_ep_status_report
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
@@ -476,7 +479,7 @@ class HighThroughputEngine(GlobusComputeEngineBase, RepresentationMixin):
             self.address, self.worker_result_port
         )
 
-    def get_status_report(self) -> EPStatusReport:
+    def get_status_report(self) -> CommonEPStatusReport:
         """HTEX Interchange reports EPStatusReport periodically"""
         raise NotImplementedError
 

--- a/compute_endpoint/setup.cfg
+++ b/compute_endpoint/setup.cfg
@@ -8,6 +8,8 @@ max-line-length = 88
 ignore = W503, W504, E203, B008, E704
 
 [mypy]
+plugins = pydantic.mypy
+
 # strict = true
 ignore_missing_imports = true
 warn_unreachable = true

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -7,7 +7,7 @@ REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
     "globus-compute-sdk==2.16.0",
-    "globus-compute-common==0.3.0",
+    "globus-compute-common==0.4.0",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -1,9 +1,9 @@
 import typing as t
 
 import pytest
+from globus_compute_common.pydantic_v1 import ValidationError
 from globus_compute_endpoint.endpoint.config import Config
 from globus_compute_endpoint.endpoint.config.model import ConfigModel
-from pydantic.error_wrappers import ValidationError
 
 
 @pytest.fixture

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
     "globus-sdk>=3.35.0,<4",
-    "globus-compute-common==0.3.0",
+    "globus-compute-common==0.4.0",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types


### PR DESCRIPTION
# Description

Version `0.4.0` of `globus-compute-common` contains a [module ](https://github.com/funcx-faas/funcx-common/blob/8fd10350629a4a5ca0e23440836d19d3b8fe5cda/src/globus_compute_common/pydantic_v1.py)that enables users to install either Pydantic V1 or V2. The former remains the recommended and officially supported version.

I also added the [Pydantic plugin for mypy](https://docs.pydantic.dev/1.10/usage/mypy/) to improve the ability of mypy to type-check our Pydantic code.

[sc-26075]

## Type of change

- New feature (non-breaking change that adds functionality)
