### PR TITLE
Fully support Pydantic V2

### DIFF
--- a/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
+++ b/changelog.d/20240326_153234_30907815+rjmello_gc_common_pydantic_sc_26075.rst
@@ -1,10 +1,9 @@
 New Functionality
 ^^^^^^^^^^^^^^^^^
 
-- Enable users to install either Pydantic V1 or V2. The former remains
-  the recommended and officially supported version.
+- Add support for Pydantic V2.
 
 Changed
 ^^^^^^^
 
-- Bump ``globus-compute-common`` requirement to version ``0.4.0``.
+- Bump ``globus-compute-common`` requirement to version ``0.4.1``.

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -7,7 +7,7 @@ REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
     "globus-compute-sdk==2.16.0",
-    "globus-compute-common==0.4.0",
+    "globus-compute-common==0.4.1",
     "globus-identity-mapping==0.3.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -16,6 +16,8 @@ commands =
 [testenv:mypy]
 deps =
     mypy==1.8.0
+    # Ensure that the Pydantic mypy plugin uses the V1 API
+    pydantic>=1,<2
     ../compute_sdk/
 commands = mypy --install-types --non-interactive -p globus_compute_endpoint {posargs}
 

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     # request sending and authorization tools
     "requests>=2.31.0,<3",
     "globus-sdk>=3.35.0,<4",
-    "globus-compute-common==0.4.0",
+    "globus-compute-common==0.4.1",
     # 'websockets' is used for the client-side websocket listener
     "websockets==10.3",
     # dill is an extension of `pickle` to a wider array of native python types


### PR DESCRIPTION
# Description

Version `0.4.1` of `globus-compute-common` extends the Pydantic version range in its `setup.cfg` file to include V2, avoiding dependency conflicts with consuming packages.


[sc-26075]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
