### PR TITLE
Reset retry counter after 2 HBs

### DIFF
--- a/changelog.d/20240328_144808_kevin_address_fail_counter_race_condition_reset.rst
+++ b/changelog.d/20240328_144808_kevin_address_fail_counter_race_condition_reset.rst
@@ -1,0 +1,8 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address a race-condition in detecting Endpoint stability.  Previously, the EP
+  could keep resetting an internal fail counter, potentially allowing the EP to
+  stay up indefinitely in a half-working state.  The EP logic now more
+  faithfully detects an unrecoverable error and will shutdown rather than
+  giving an appearance of being alive.

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -1,4 +1,6 @@
 import random
+import uuid
+from multiprocessing.synchronize import Event as EventType
 from unittest import mock
 
 import pytest
@@ -43,7 +45,8 @@ def test_main_exception_always_quiesces(mocker, fs, randomstring, reset_signals)
 
 @pytest.mark.parametrize("reconnect_attempt_limit", [-1, 0, 1, 2, 3, 5, 10])
 def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_signals):
-    num_iterations = reconnect_attempt_limit * 2 + 5  # overkill "just to be sure"
+    expected_reconnect_limit = max(1, reconnect_attempt_limit)  # checking boundary
+    num_iterations = expected_reconnect_limit * 2 + 5  # overkill "just to be sure"
     excepts_left = num_iterations
 
     def _mock_start_threads(*a, **k):
@@ -65,10 +68,40 @@ def test_reconnect_attempt_limit(mocker, fs, reconnect_attempt_limit, reset_sign
     ei._start_threads_and_main.side_effect = _mock_start_threads
     ei.start()
 
-    reconnect_attempt_limit = max(1, reconnect_attempt_limit)  # checking boundary
-    assert ei._start_threads_and_main.call_count == reconnect_attempt_limit
+    assert ei._start_threads_and_main.call_count == expected_reconnect_limit
 
-    expected_msg = f"Failed {reconnect_attempt_limit} consecutive"
+    expected_msg = f"Failed {expected_reconnect_limit} consecutive"
     assert mock_log.critical.called
     assert expected_msg in mock_log.critical.call_args[0][0]
     assert excepts_left > 0, "expect reconnect limit to stop loop, not test backup"
+
+
+def test_reset_reconnect_attempt_limit_when_stable(mocker, fs):
+    mocker.patch(f"{_mock_base}ResultPublisher")
+    mocker.patch(f"{_mock_base}threading.Thread")
+    mocker.patch(f"{_mock_base}multiprocessing")
+    ei = EndpointInterchange(
+        config=Config(executors=[mocker.Mock()]),
+        endpoint_id=str(uuid.uuid4()),
+        reg_info={"task_queue_info": {}, "result_queue_info": {}},
+    )
+    ei._quiesce_event = mock.Mock(spec=EventType)
+
+    ei._quiesce_event.wait.side_effect = (False, True)  # iterate once
+    ei._reconnect_fail_counter = 1  # simulate that we've failed once
+    ei._main_loop()
+    assert ei._reconnect_fail_counter == 1, "Expect single iteration to not reset value"
+    assert ei._quiesce_event.wait.call_count == 2, "Verify loop iterations"
+
+    # nothing changes about the logic by *just* running again
+    ei._quiesce_event.wait.reset_mock()
+    ei._quiesce_event.wait.side_effect = (False, True)  # iterate once
+    ei._main_loop()
+    assert ei._reconnect_fail_counter == 1, "Expect single iteration to not reset value"
+    assert ei._quiesce_event.wait.call_count == 2, "Verify loop iterations"
+
+    ei._quiesce_event.wait.reset_mock()
+    ei._quiesce_event.wait.side_effect = (False, False, True)
+    ei._main_loop()
+    assert ei._reconnect_fail_counter == 0, "Expect stable determination after 2 HBs"
+    assert ei._quiesce_event.wait.call_count == 3, "Verify loop iterations"


### PR DESCRIPTION
The EP world roughly revolves around heartbeats, an "I'm alive" notification that goes out, by default, every 30s.  In the interchange, we also use this interval to determine whether our connection is stable.  Unfortunately, if we only detect that our connection is stable _when we attempt to send a heartbeat_, then it's anyone's guess which thread wins: "successfully alive for a HB, mark as stable" vs "quiesce because we're clearly not stable."

This manifests as an EP staying up for much longer than the settings would otherwise attempt to enforce -- in the motivating case, almost an hour before the race condition finally caught up to the settings which wanted the EP to shutdown in roughly 2m, preventing the fix to the larger errant condition.

Work around this for now by bumping the heuristic of "still alive ==> stable", to "alive for 2 HBs ==> stable".  That should give plenty of time for an actual "integration test" (of sorts) to verify that all the pipes are in working order.

[sc-31352]

## Type of change

- Bug fix (non-breaking change that fixes an issue)