### PR TITLE
Allow build to use unreleased sdk

### DIFF
--- a/compute_endpoint/packaging/Makefile
+++ b/compute_endpoint/packaging/Makefile
@@ -120,7 +120,7 @@ $(PKG_WHEEL): $(VENV_PY)
 wheel: $(PKG_WHEEL)  ##-Make the wheel (note that this does *not* include dependencies)
 
 $(PREREQS_TARBALL_NAME): $(VENV_PY) $(PKG_WHEEL)
-	PYTHON_BIN="$(VENV_PY)" bash create-prereqs-tarball.sh ./build/compute_endpoint/ > "$(PREREQS_TARBALL_NAME)"
+	PYTHON_BIN="$(VENV_PY)" bash create-prereqs-tarball.sh ./build/compute_endpoint/ ./build/compute_sdk/ > "$(PREREQS_TARBALL_NAME)"
 
 prereq_tarball: $(PREREQS_TARBALL_NAME)  ##-Make a tarball of wheel dependencies
 


### PR DESCRIPTION
The previous iteration relied (unintentionally!) on the SDK having already been released to PyPI.  For packaging and testing, that's a problem.  Teach the build scripts to use the _local_ `compute_sdk` when creating the prerequisites tarball.

## Type of change

- Bug fix (non-breaking change that fixes an issue) [for build system; users never had this "bug"]