### PR TITLE
change check_news to also allow changelog itself

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,11 +16,11 @@ jobs:
           fetch-depth: 0
       - name: check PR adds a news file
         run: |
-          news_files="$(git diff --name-only "$(git merge-base origin/main "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.rst)"
+          news_files="$(git diff --name-only "$(git merge-base origin/main "$GITHUB_SHA")" "$GITHUB_SHA" -- docs/changelog.rst changelog.d/*.rst)"
           if [ -n "$news_files" ]; then
             echo "Saw new files. changelog.d:"
             echo "$news_files"
           else
-            echo "No news files seen"
+            echo "No news files or changelog.rst modification seen"
             exit 1
           fi


### PR DESCRIPTION
# Description

When we create a bump release PR that deletes changelog.d/*.rst and modifies docs/changelog.rst,it fails the ``changelog`` GH action, because it does not include a changelog fragment itself.

This isn't correct, as modifying docs/changelog.rst itself is the end goal, so it should also satisfy the requirements as adding individual .rst in the changelog.d directory should.

Done by adding docs/changelog.rst to the compare list so it also counts as a changelog modification.  

## Type of change

- Bug fix (non-breaking change that fixes an issue)
