### PR TITLE
Adding `GlobusMPIEngine` and documentation for `MPIFunction`s

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/engines/__init__.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/__init__.py
@@ -1,10 +1,12 @@
 from .globus_compute import GlobusComputeEngine
+from .globus_mpi import GlobusMPIEngine
 from .high_throughput.engine import HighThroughputEngine
 from .process_pool import ProcessPoolEngine
 from .thread_pool import ThreadPoolEngine
 
 __all__ = (
     "GlobusComputeEngine",
+    "GlobusMPIEngine",
     "ProcessPoolEngine",
     "ThreadPoolEngine",
     "HighThroughputEngine",

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -1,0 +1,100 @@
+import os
+import typing as t
+
+from globus_compute_endpoint.engines.globus_compute import (
+    VALID_CONTAINER_TYPES,
+    GlobusComputeEngine,
+    JobStatusPollerKwargs,
+)
+from parsl.executors import MPIExecutor
+
+
+class GlobusMPIEngine(GlobusComputeEngine):
+
+    def __init__(
+        self,
+        *args,
+        label: str = "GlobusMPIEngine",
+        max_retries_on_system_failure: int = 0,
+        executor: t.Optional[MPIExecutor] = None,
+        container_type: t.Literal[VALID_CONTAINER_TYPES] = None,  # type: ignore
+        container_uri: t.Optional[str] = None,
+        container_cmd_options: t.Optional[str] = None,
+        encrypted: bool = True,
+        strategy: str | None = None,
+        job_status_kwargs: t.Optional[JobStatusPollerKwargs] = None,
+        working_dir: str | os.PathLike = "tasks_working_dir",
+        run_in_sandbox: bool = False,
+        **kwargs,
+    ):
+        """``GlobusMPIEngine`` is a shim over `Parsl's MPIExecutor
+        <parslmpiex_>`_, almost all of arguments are passed along, unfettered.
+        Consequently, please reference `Parsl's MPIExecutor <parslmpiex_>`_
+        documentation for a complete list of arguments; we list below only the
+        arguments specific to the ``GlobusMPIEngine``.
+
+        .. _parslmpiex: https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.MPIExecutor.html
+        .. _parslstrategy: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.strategy.Strategy.html
+        .. _parsljobstatuspoller: https://parsl.readthedocs.io/en/stable/stubs/parsl.jobs.job_status_poller.JobStatusPoller.html
+
+        Parameters
+        ----------
+
+        label: str
+           Label used to name engine log directories and batch jobs
+           default: "GlobusComputeEngine"
+
+        max_retries_on_system_failure: int
+           Set the number of retries for functions that fail due to
+           system failures such as node failure/loss. Since functions
+           can fail after partial runs, consider additional cleanup
+           logic before enabling this functionality
+           default: 0
+
+        strategy: str | None
+            Specify which scaling strategy to use; this is eventually given to
+            `Parsl's Strategy <parslstrategy_>`_.  [Deprecated; use
+            ``job_status_kwargs``]
+
+        job_status_kwargs: dict | None
+            Keyword arguments to be passed through to `Parsl's JobStatusPoller
+            <parsljobstatuspoller_>`_ class that drives strategy to do auto-scaling.
+
+        encrypted: bool
+            Flag to enable/disable encryption (CurveZMQ). Default is True.
+
+        working_dir: str | os.PathLike
+            Directory within which functions should execute, defaults to
+            (~/.globus_compute/<endpoint_name>/tasks_working_dir)
+            If a relative path is supplied, the working dir is set relative
+            to the endpoint.run_dir. If an absolute path is supplied, it is
+            used as is.
+
+        run_in_sandbox: bool
+            Functions will run in a sandbox directory under the working_dir
+            if this option is enabled. Default: False
+
+        """  # noqa: E501
+
+        if executor:
+            assert isinstance(executor, MPIExecutor)
+        else:
+            executor = MPIExecutor(  # type: ignore
+                *args,
+                label=label,
+                encrypted=encrypted,
+                **kwargs,
+            )
+        super().__init__(
+            label=label,
+            max_retries_on_system_failure=max_retries_on_system_failure,
+            executor=executor,
+            container_type=container_type,
+            container_uri=container_uri,
+            container_cmd_options=container_cmd_options,
+            encrypted=encrypted,
+            strategy=strategy,
+            job_status_kwargs=job_status_kwargs,
+            working_dir=working_dir,
+            run_in_sandbox=run_in_sandbox,
+        )

--- a/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gceenging_bash_functions.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/high_throughput/test_gceenging_bash_functions.py
@@ -1,0 +1,171 @@
+import logging
+import uuid
+from queue import Queue
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_endpoint.engines import GlobusComputeEngine
+from globus_compute_sdk.sdk.bash_function import BashFunction
+from globus_compute_sdk.serialize import ComputeSerializer
+from parsl.providers import LocalProvider
+from tests.utils import ez_pack_function
+
+
+@pytest.fixture
+def gc_engine(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        heartbeat_period=1,
+        heartbeat_threshold=1,
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=0,
+            max_blocks=1,
+        ),
+    )
+    engine._status_report_thread.reporting_period = 1
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
+    yield engine
+    engine.shutdown()
+
+
+@pytest.fixture
+def gc_engine_with_sandbox(tmp_path):
+    ep_id = uuid.uuid4()
+    engine = GlobusComputeEngine(
+        address="127.0.0.1",
+        max_workers=1,
+        heartbeat_period=1,
+        heartbeat_threshold=1,
+        working_dir=tmp_path,
+        run_in_sandbox=True,
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=0,
+            max_blocks=1,
+        ),
+    )
+    engine._status_report_thread.reporting_period = 1
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
+    yield engine
+    engine.shutdown()
+
+
+def test_bash_function(gc_engine, tmp_path):
+    """Test running BashFunction with GCE: Happy path"""
+    engine = gc_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    bash_func = BashFunction("pwd")
+    task_body = ez_pack_function(serializer, bash_func, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message, resource_specification={})
+
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result_obj = serializer.deserialize(result.data)
+
+            assert "pwd" == result_obj.cmd
+            assert result_obj.returncode == 0
+            assert tmp_path.name in result_obj.stdout
+            assert not result_obj.stderr
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"
+
+
+@pytest.mark.parametrize(
+    "cmd, error_str, returncode",
+    [
+        ("sleep 5", "", 124),
+        ("cat /NONEXISTENT", "No such file or directory", 1),
+        ("echo 'very bad' 1>&2; exit 3", "very bad", 3),
+        ("fake_command", "command not found", 127),
+        ("touch foo; ./foo", "Permission denied", 126),
+    ],
+)
+def test_fail_bash_function(gc_engine, tmp_path, cmd, error_str, returncode):
+    """Test running BashFunction with GCE: Happy path"""
+    engine = gc_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    bash_func = BashFunction(cmd, walltime=0.1)
+    task_body = ez_pack_function(serializer, bash_func, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message, resource_specification={})
+
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            logging.warning(f"Got {result.data=}")
+
+            assert result.task_id == task_id
+            assert not result.error_details
+
+            result_obj = serializer.deserialize(result.data)
+
+            assert error_str in result_obj.stderr
+            assert result_obj.returncode == returncode
+
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"
+
+
+def test_no_sandbox(gc_engine, tmp_path):
+    """Test running BashFunction with GCE: Happy path"""
+    engine = gc_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    bash_func = BashFunction("pwd", run_in_sandbox=False)
+    task_body = ez_pack_function(serializer, bash_func, (), {})
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message, resource_specification={})
+
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result_obj = serializer.deserialize(result.data)
+
+            assert "pwd" == result_obj.cmd
+            assert result_obj.returncode == 0
+            assert f"{engine.run_dir}/tasks_working_dir" == result_obj.stdout.strip()
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"

--- a/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_mpiengine.py
@@ -1,0 +1,125 @@
+import random
+import uuid
+from queue import Queue
+
+import pytest
+from globus_compute_common import messagepack
+from globus_compute_endpoint.engines import GlobusMPIEngine
+from globus_compute_sdk.sdk.bash_function import BashResult
+from globus_compute_sdk.sdk.mpi_function import MPIFunction
+from globus_compute_sdk.serialize import ComputeSerializer
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
+from tests.utils import ez_pack_function, get_env_vars
+
+
+@pytest.fixture
+def nodeslist(num=100):
+    limit = random.randint(1, num)
+    yield [f"NODE{node_i}" for node_i in range(1, limit)]
+
+
+@pytest.fixture
+def mpi_engine(tmp_path, nodeslist):
+    ep_id = uuid.uuid4()
+
+    nodefile_path = tmp_path / "pbs_nodefile"
+    nodes_string = "\n".join(nodeslist)
+    worker_init = f"""
+    echo -e "{nodes_string}" > {nodefile_path} ;
+    export PBS_NODEFILE={nodefile_path}
+    """
+
+    engine = GlobusMPIEngine(
+        address="127.0.0.1",
+        heartbeat_period=1,
+        heartbeat_threshold=1,
+        max_retries_on_system_failure=0,
+        mpi_launcher="mpiexec",
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=1,
+            max_blocks=1,
+            worker_init=worker_init,
+            launcher=SimpleLauncher(),
+        ),
+    )
+    engine._status_report_thread.reporting_period = 1
+    queue = Queue()
+    engine.start(endpoint_id=ep_id, run_dir=tmp_path, results_passthrough=queue)
+    yield engine, nodeslist
+    engine.shutdown()
+
+
+def test_mpi_function(mpi_engine, tmp_path):
+    """Test for the right cmd being generated"""
+    engine, nodeslist = mpi_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+
+    num_nodes = random.randint(1, len(nodeslist))
+    resource_spec = {"num_nodes": num_nodes, "num_ranks": random.randint(1, 4)}
+
+    mpi_func = MPIFunction("pwd", resource_specification=resource_spec)
+    task_body = ez_pack_function(
+        serializer, mpi_func, (), {"resource_specification": resource_spec}
+    )
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    engine.submit(task_id, task_message, resource_specification=resource_spec)
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result = serializer.deserialize(result.data)
+
+            assert isinstance(result, BashResult)
+            assert result.cmd == "$PARSL_MPI_PREFIX pwd"
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"
+
+
+def test_env_vars(mpi_engine, tmp_path):
+    engine, nodeslist = mpi_engine
+    queue = engine.results_passthrough
+    task_id = uuid.uuid1()
+    serializer = ComputeSerializer()
+    task_body = ez_pack_function(serializer, get_env_vars, (), {})
+
+    task_message = messagepack.pack(
+        messagepack.message_types.Task(task_id=task_id, task_buffer=task_body)
+    )
+    num_nodes = random.randint(1, len(nodeslist))
+    engine.submit(
+        task_id,
+        task_message,
+        resource_specification={"num_nodes": num_nodes, "num_ranks": 2},
+    )
+
+    flag = False
+    for _i in range(20):
+        q_msg = queue.get(timeout=10)
+        assert isinstance(q_msg, dict)
+
+        packed_result_q = q_msg["message"]
+        result = messagepack.unpack(packed_result_q)
+        if isinstance(result, messagepack.message_types.Result):
+            assert result.task_id == task_id
+            assert result.error_details is None
+            result = serializer.deserialize(result.data)
+            assert result["PARSL_NUM_NODES"] == str(num_nodes)
+            assert result["PARSL_MPI_PREFIX"].startswith("mpiexec")
+            flag = True
+            break
+
+    assert flag, "Expected result packet, but none received"

--- a/compute_sdk/globus_compute_sdk/__init__.py
+++ b/compute_sdk/globus_compute_sdk/__init__.py
@@ -7,8 +7,17 @@ from globus_compute_sdk.version import __version__ as _version
 __author__ = "The Globus Compute Team"
 __version__ = _version
 
+from globus_compute_sdk.sdk.bash_function import BashFunction, BashResult
 from globus_compute_sdk.sdk.client import Client
 from globus_compute_sdk.sdk.container_spec import ContainerSpec
 from globus_compute_sdk.sdk.executor import Executor
+from globus_compute_sdk.sdk.mpi_function import MPIFunction
 
-__all__ = ("Executor", "Client", "ContainerSpec")
+__all__ = (
+    "Executor",
+    "Client",
+    "ContainerSpec",
+    "BashFunction",
+    "MPIFunction",
+    "BashResult",
+)

--- a/compute_sdk/globus_compute_sdk/sdk/bash_function.py
+++ b/compute_sdk/globus_compute_sdk/sdk/bash_function.py
@@ -1,0 +1,254 @@
+import tempfile
+import typing as t
+
+
+class BashResult:
+
+    def __init__(
+        self,
+        cmd: str,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        exception_name: t.Optional[str] = None,
+    ):
+        """
+
+        Parameters
+        ----------
+        cmd: str
+            formatted command line string that was executed on the endpoint
+
+        stdout: str
+            multiline (default 1K) snippet of stdout
+
+        stderr: str
+            multiline (default 1K) snippet of stderr
+
+        returncode: int
+            Return code from command execution
+
+        exception_name
+        """
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+        self.exception_name = exception_name
+
+    def __str__(self):
+        return f"Command {self.cmd} returned with exit status: {self.returncode}"
+
+
+class BashFunction:
+
+    def __init__(
+        self,
+        cmd: str,
+        stdout: t.Optional[str] = None,
+        stderr: t.Optional[str] = None,
+        walltime: t.Optional[float] = None,
+        # This could be a os.Pathlike, but check windows->unix transition
+        rundir: t.Optional[str] = None,
+        run_in_sandbox: bool = True,
+        resource_specification: t.Optional[t.Dict[str, t.Any]] = None,
+        snippet_lines=1000,
+    ):
+        """Initialize a BashFunction
+
+        Parameters
+        ----------
+        cmd: str
+             formattable command line to execute. For e.g:
+             "lammps -in {input_file}" where {input_file} is formatted
+             with kwargs passed at call time.
+
+        stdout: str | None
+            file path to which stdout should be captured
+
+        stderr: str | None
+            file path to which stderr should be captures
+
+        walltime: float | None
+            duration in seconds after which the command should be interrupted
+
+        rundir: str | None
+            directory within which the command should be executed
+
+        run_in_sandbox: bool
+            when set, the command will execute within a directory matching
+            the task UUID
+            default=True
+
+        resource_specification: dict | None
+            resources required for command execution
+
+        snippet_lines: int
+            Number of lines of stdout/err to capture,
+            default=1000
+
+        """
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+        self.walltime = walltime
+        self.rundir = rundir
+        self.run_in_sandbox = run_in_sandbox
+        self.resource_specification = resource_specification
+        self.snippet_lines = snippet_lines
+
+    @property
+    def __name__(self):
+        # This is required for function registration
+        return self.cmd
+
+    def open_std_fd(self, fname, mode: str = "a+"):
+        import os
+
+        # fname is 'stdout' or 'stderr'
+        if fname is None:
+            return None
+
+        if os.path.dirname(fname):
+            os.makedirs(os.path.dirname(fname), exist_ok=True)
+        fd = open(fname, mode)
+        return fd
+
+    def get_snippet(self, file_obj) -> str:
+        file_obj.seek(0, 0)
+        last_n_lines = file_obj.readlines()[-self.snippet_lines :]
+        return "".join(last_n_lines)
+
+    def get_and_close_streams(self, stdout, stderr) -> t.Tuple[str, str]:
+        stdout_snippet = self.get_snippet(stdout)
+        stderr_snippet = self.get_snippet(stderr)
+        stdout.close()
+        stderr.close()
+        return stdout_snippet, stderr_snippet
+
+    def execute_cmd_line(
+        self,
+        cmd: str,
+        stdout: t.Optional[str] = None,
+        stderr: t.Optional[str] = None,
+        rundir: t.Optional[str] = None,
+    ) -> BashResult:
+        import os
+        import subprocess
+
+        run_dir = rundir or self.rundir
+
+        if not run_dir:
+            # run_dir takes priority over sandboxing
+            if os.environ.get("GC_TASK_SANDBOX_DIR"):
+                run_dir = os.environ["GC_TASK_SANDBOX_DIR"]
+            else:
+                if self.run_in_sandbox and os.environ.get("GC_TASK_UUID"):
+                    run_dir = os.environ["GC_TASK_UUID"]
+                    os.environ["GC_TASK_SANDBOX_DIR"] = os.path.join(
+                        os.getcwd(), run_dir
+                    )
+
+        if run_dir:
+            os.makedirs(run_dir, exist_ok=True)
+            os.chdir(run_dir)
+
+        stdout = (
+            stdout or self.stdout or tempfile.NamedTemporaryFile(dir=os.getcwd()).name
+        )
+        stderr = (
+            stderr or self.stdout or tempfile.NamedTemporaryFile(dir=os.getcwd()).name
+        )
+
+        std_out = self.open_std_fd(stdout)
+        std_err = self.open_std_fd(stderr)
+        exception_name = None
+
+        """
+        if std_err is not None:
+            print(
+                f"--> executable follows <--\n{cmd}\n--> end executable <--",
+                file=std_err,
+                flush=True,
+            )
+       """
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=std_out,
+                stderr=std_err,
+                shell=True,
+                executable="/bin/bash",
+                close_fds=False,
+            )
+            proc.wait(timeout=self.walltime)
+            returncode = proc.returncode
+            if returncode != 0:
+                exception_name = "subprocess.CalledProcessError"
+
+        except subprocess.TimeoutExpired:
+            # Returncode to match behavior of timeout bash command
+            # https://man7.org/linux/man-pages/man1/timeout.1.html
+            returncode = 124
+            exception_name = "subprocess.TimeoutExpired"
+
+        stdout_snippet, stderr_snippet = self.get_and_close_streams(std_out, std_err)
+
+        return BashResult(
+            cmd,
+            stdout_snippet,
+            stderr_snippet,
+            returncode,
+            exception_name=exception_name,
+        )
+
+    def __call__(
+        self,
+        stdout: t.Optional[str] = None,
+        stderr: t.Optional[str] = None,
+        rundir: t.Optional[str] = None,
+        **kwargs,
+    ) -> BashResult:
+        """This method is passed from an executor to an endpoint to execute the
+        BashFunction :
+
+        .. code-block:: python
+
+            bf = BashFunction("echo 'Hello'")
+            future = executor.submit(bf)  # Invokes this method on an endpoint
+            future.result()               # returns a BashResult
+
+        Parameters
+        ----------
+        stdout: str|None
+           file path to which stdout should be captured
+           overrides stdout set at BashFunction declaration
+
+        stderr: str|None
+           file path to which stderr should be captures
+           overrides stdout set at BashFunction declaration
+
+        rundir: str|None
+           directory within which the command should be executed
+           overrides stdout set at BashFunction declaration
+
+        **kwargs:
+           arbitrary keyword args will be used to format the `cmd` string
+           before execution
+
+        Returns
+        -------
+        BashResult: BashResult
+           Bash result object that encapsulates outputs from
+           command execution
+        """
+        import copy
+
+        # Copy to avoid mutating the class vars
+        format_args = copy.copy(vars(self))
+        format_args.update(kwargs)
+        cmd_line = self.cmd.format(**format_args)
+        return self.execute_cmd_line(
+            cmd_line, stdout=stdout, stderr=stderr, rundir=rundir
+        )

--- a/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
+++ b/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
@@ -1,0 +1,29 @@
+import typing as t
+
+from .bash_function import BashFunction
+
+
+class MPIFunction(BashFunction):
+
+    def __call__(
+        self,
+        stdout: t.Optional[str] = None,
+        stderr: t.Optional[str] = None,
+        rundir: t.Optional[str] = None,
+        resource_specification: t.Optional[t.Dict[str, t.Any]] = None,
+        **kwargs,
+    ):
+        assert (
+            resource_specification
+        ), "MPIFunction requires kwarg:resource_specification"
+        import copy
+
+        self.stdout = stdout or self.stdout
+        self.stderr = stderr or self.stderr
+        self.rundir = rundir or self.rundir
+
+        # Copy to avoid mutating the class vars
+        format_args = copy.copy(vars(self))
+        format_args.update(kwargs)
+        cmd_line = "$PARSL_MPI_PREFIX " + self.cmd.format(**format_args)
+        return self.execute_cmd_line(cmd_line)

--- a/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
+++ b/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
@@ -4,6 +4,9 @@ from .bash_function import BashFunction
 
 
 class MPIFunction(BashFunction):
+    """MPIFunction extends BashFunction, as a thin wrapper that adds an
+    MPI launcher prefix to the BashFunction command.
+    """
 
     def __call__(
         self,

--- a/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
+++ b/compute_sdk/globus_compute_sdk/sdk/mpi_function.py
@@ -10,12 +10,8 @@ class MPIFunction(BashFunction):
         stdout: t.Optional[str] = None,
         stderr: t.Optional[str] = None,
         rundir: t.Optional[str] = None,
-        resource_specification: t.Optional[t.Dict[str, t.Any]] = None,
         **kwargs,
     ):
-        assert (
-            resource_specification
-        ), "MPIFunction requires kwarg:resource_specification"
         import copy
 
         self.stdout = stdout or self.stdout

--- a/compute_sdk/tests/unit/test_bash_functions.py
+++ b/compute_sdk/tests/unit/test_bash_functions.py
@@ -1,0 +1,141 @@
+import os
+import uuid
+
+import pytest
+from globus_compute_sdk.sdk.bash_function import BashFunction, BashResult
+
+
+@pytest.fixture
+def run_in_tmp_dir(tmp_path):
+    os.chdir(tmp_path)
+    return tmp_path
+
+
+def test_bash_function_no_stdfile(run_in_tmp_dir):
+    """Confirm that stdout/err snippet is reported after successful run"""
+
+    bf = BashFunction("echo 'Hello'")
+    bf_result = bf()
+
+    assert isinstance(bf_result, BashResult)
+
+    assert "Hello" in bf_result.stdout
+    assert not bf_result.stderr
+    assert "returned with exit status: 0" in str(bf_result)
+
+
+def test_repeated_invocation(run_in_tmp_dir):
+    """Confirm that stdout/err snippet is reported after successful run"""
+
+    os.environ["GC_TASK_ID"] = str(uuid.uuid4())
+    cmd = "pwd; echo 'Hello {target}'; echo 'Bye {target}' 1>&2"
+    bf = BashFunction(cmd, run_in_sandbox=True)
+
+    prev = "world_0"
+
+    for i in range(1, 3):
+        target = f"world_{i}"
+        result = bf(target=target, sandbox=True)
+
+        assert f"Hello {target}" in result.stdout
+        assert f"Bye {target}" == result.stderr.strip()
+        assert result.cmd == cmd.format(target=target)
+
+        assert prev not in result.stdout, "Output from previous invocation present"
+        prev = target
+
+
+def test_timeout(run_in_tmp_dir):
+    """Test for timeout returning correct returncode"""
+    bf = BashFunction("sleep 5; echo Fail", walltime=0.1)
+
+    result_obj = bf()
+    assert isinstance(result_obj, BashResult)
+    assert result_obj.returncode == 124
+    assert "Fail" not in result_obj.stdout
+
+
+def test_snippet_capture_on_walltime_fail(run_in_tmp_dir):
+    """Confirm that stdout/err snippet is reported after successful run"""
+    cmd = "echo 'Hello'; sleep 5"
+    bf = BashFunction(cmd, walltime=0.1)
+
+    result = bf()
+
+    assert result.returncode == 124
+    assert "Hello" in result.stdout
+    assert not result.stderr
+
+
+def test_fail(run_in_tmp_dir):
+    """Confirm failed cmd behavior"""
+    cmd = "echo 'hi'; cat /non_existent"
+    bf = BashFunction(cmd, walltime=0.1)
+
+    result = bf()
+
+    assert result.returncode == 1
+    assert "hi" in result.stdout
+    assert result.cmd == cmd
+    assert "No such file or directory" in result.stderr
+
+
+def test_default_run_dir(run_in_tmp_dir):
+    """BF should run in CWD if a run_dir is not set"""
+    bf = BashFunction("pwd")
+    result = bf()
+
+    assert str(os.getcwd()) in result.stdout
+    assert not result.stderr
+
+
+def test_run_dir(tmp_path):
+    """BF should run in tmp_path and not in the PWD"""
+    assert os.getcwd() != tmp_path
+
+    bf = BashFunction("echo [$PWD]", rundir=tmp_path)
+    result = bf()
+
+    assert f"[{tmp_path}]" in result.stdout
+
+
+def test_bad_run_dir():
+    """Confirm that stdout/err snippet is reported after successful run"""
+    bf = BashFunction("pwd", rundir="/NONEXISTENT")
+
+    with pytest.raises(OSError):
+        bf()
+
+
+def test_sandbox_run_dir(run_in_tmp_dir):
+    """Confirm that cmd is executed in a sandbox dir based on task_id"""
+    task_id = str(uuid.uuid4())
+    os.environ["GC_TASK_UUID"] = task_id
+    bf = BashFunction("pwd", run_in_sandbox=True)
+
+    result = bf()
+    assert os.path.join(run_in_tmp_dir, task_id) == result.stdout.strip()
+
+
+def test_no_sandbox_run_dir(run_in_tmp_dir):
+    """Confirm that cmd is executed in a sandbox dir based on task_id"""
+    task_id = str(uuid.uuid4())
+    os.environ["GC_TASK_UUID"] = task_id
+    os.environ.pop("GC_TASK_SANDBOX_DIR")
+    bf = BashFunction("pwd", run_in_sandbox=False)
+
+    result = bf()
+    assert str(run_in_tmp_dir) == result.stdout.strip()
+
+
+def test_skip_redundant_sandbox(run_in_tmp_dir):
+    """Confirm that sandbox is not created if executor is set to create sandbox"""
+    task_id = str(uuid.uuid4())
+
+    os.environ["GC_TASK_SANDBOX_DIR"] = run_in_tmp_dir.name
+    os.environ["GC_TASK_UUID"] = task_id
+    bf = BashFunction("pwd", run_in_sandbox=True)
+
+    result = bf()
+    assert os.path.join(run_in_tmp_dir, task_id) not in result.stdout
+    assert run_in_tmp_dir.name in result.stdout

--- a/compute_sdk/tests/unit/test_mpi_functions.py
+++ b/compute_sdk/tests/unit/test_mpi_functions.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+from globus_compute_sdk.sdk.mpi_function import MPIFunction
+
+
+@pytest.fixture
+def run_in_tmp_dir(tmp_path):
+    os.chdir(tmp_path)
+    return tmp_path
+
+
+def test_mpi_function(run_in_tmp_dir):
+
+    mpi_func = MPIFunction("hostname", resource_specification={"num_ranks": 2})
+    bash_result = mpi_func(resource_specification={"num_ranks": 4})
+
+    assert "$PARSL_MPI_PREFIX hostname" in bash_result.stderr
+
+
+def test_missing_resource_spec(run_in_tmp_dir):
+
+    mpi_func = MPIFunction("hostname")
+
+    with pytest.raises(AssertionError):
+        mpi_func()

--- a/compute_sdk/tests/unit/test_mpi_functions.py
+++ b/compute_sdk/tests/unit/test_mpi_functions.py
@@ -15,7 +15,7 @@ def test_mpi_function(run_in_tmp_dir):
     mpi_func = MPIFunction("hostname", resource_specification={"num_ranks": 2})
     bash_result = mpi_func(resource_specification={"num_ranks": 4})
 
-    assert "$PARSL_MPI_PREFIX hostname" in bash_result.stderr
+    assert "$PARSL_MPI_PREFIX hostname" in bash_result.cmd
 
 
 def test_missing_resource_spec(run_in_tmp_dir):

--- a/docs/bash_functions.rst
+++ b/docs/bash_functions.rst
@@ -95,8 +95,63 @@ Here's an example:
    124
 
 
+MPIFunctions
+------------
+
+|MPIFunction|_ extends |BashFunction|_ to support launching MPI applications. Similar
+to the |BashFunction|_ interface, |MPIFunction|_ accepts a command string which it
+launches using the appropriate MPI launcher as configured on a target endpoint configured
+with |GlobusMPIEngine|_. This allows |MPIFunction|_ definitions to be agnostic to the
+MPI environment on any of the endpoints it may be sent to. An |MPIFunction|_
+
+Here's an example:
+
+.. code-block:: python
+
+   mpi_func = MPIFunction("lmp_mpi -in {input_file}")
+
+   executor.resource_specification = {"num_nodes" : 2, "num_ranks": 4}
+
+   future = executor.submit(mpi_func, input_file="/path/to/input_1")
+
+
+Resource Specification
+^^^^^^^^^^^^^^^^^^^^^^
+
+Globus Compute allows for dynamically requesting MPI resources on a per-function basis
+by updating the `resource_specification` attribute on the executor. `resource_specification`
+takes these fields `num_nodes`, `num_ranks`, and `ranks_per_node`. Please refer to the
+`resource specification docs from Parsl <https://parsl.readthedocs.io/en/stable/userguide/mpi_apps.html#writing-an-mpi-app>`_
+for more details.
+
+Here's an example of dynamically changing the resources requested:
+
+.. code-block:: python
+
+   mpi_func = MPIFunction("lmp_mpi -in {input_file}")
+
+   all_futures = []
+   for nodes in range(1,5):
+      executor.resource_specification = {"num_nodes" : nodes,
+                                         "num_ranks": nodes * 4}
+      future = executor.submit(mpi_func, input_file="/path/to/input_file")
+      all_futures.append(future)
+
+   # Wait for all the MPI runs
+   [future.result() for future in all_futures]
+
+
+
+
+
 .. |BashFunction| replace:: ``BashFunction``
 .. _BashFunction: reference/bash_function.html
 
 .. |BashResult| replace:: ``BashResult``
 .. _BashResult: reference/bash_function.html#globus_compute_sdk.sdk.bash_function.BashResult
+
+.. |MPIFunction| replace:: ``MPIFunction``
+.. _MPIFunction: reference/mpi_function.html
+
+.. |GlobusMPIEngine| replace:: ``GlobusMPIEngine``
+.. _GlobusMPIEngine: reference/mpi_engine.html

--- a/docs/bash_functions.rst
+++ b/docs/bash_functions.rst
@@ -1,0 +1,102 @@
+Bash Functions
+--------------
+
+|BashFunction|_ is the solution to executing commands remotely using Globus Compute.
+The |BashFunction|_ class allows for the specification of a command string, along with
+runtime details such as a run directory, per-task sandboxing, walltime, etc and returns a
+|BashResult|_. |BashResult|_ encapsulates the outputs from executing the command line string
+by wrapping the returnode and snippets from the standard streams (`stdout` and `stderr`).
+
+Here's a basic example that demonstrates specifying a |BashFunction|_ that is to be
+formatted with a list of values at launch time.
+
+.. code-block:: python
+
+   from globus_compute_sdk import BashFunction, Executor
+
+   ep_id = <SPECIFY_ENDPOINT_ID>
+   # The cmd will be formatted with kwargs at invocation time
+   bf = BashFunction("echo '{message}'")
+   with Executor(endpoint_id=ep_id) as ex:
+
+       for msg in ["hello", "hola", "bonjour"]:
+           future = ex.submit(bf, message=msg)
+           bash_result = future.result()  # BashFunctions return BashResults
+           print(bash_result.stdout)
+
+   # Executing the above prints:
+   hello
+
+   hola
+
+   bonjour
+
+
+The |BashResult|_ object captures outputs relevant to simplify debugging when execution
+failures. By default, |BashFunction|_ captures 1000 lines of stdout and stderr, but this
+can be changed via the `BashFunction(snippet_lines)` kwarg.
+
+Results
+^^^^^^^
+
+The output from a |BashFunction|_ is encapsulated in a |BashResult|_. Here are the various fields made
+available through the |BashResult|_:
+
+* `returncode`: The return code from the execution of the command supplied
+* `stdout`: A snippet of upto the last 1K lines captured from the stdout stream
+* `stderr`: A snippet of upto the last 1K lines captures form the stderr stream
+* `cmd`: The formatted command string executed on the endpoint
+
+.. note::
+   The number of lines captured from stdout/err can be modified by setting `BashFunction(snippet_lines: int)`.
+   Please keep in mind the result payload size limit of 10MB to which the snippet lines are counted.
+
+Working Directory
+^^^^^^^^^^^^^^^^^
+
+Since BashFunctions operate on files, overwriting files unintentionally is a possibility. To mitigate this,
+|BashFunction|_ enables sandboxing by default where each execution is set to a directory named after the task
+UUID. The working directory is: `~/.globus_compute/<ENDPOINT_NAME>/tasks_working_dir/<TASK_UUID>`.
+This functionality can be disabled by setting the `run_in_sandbox` keyword argument to `False`.
+Here's an example:
+
+.. code-block:: python
+
+   bf = BashFunction("pwd")
+   print(executor.submit(bf).result().stdout)
+
+   # Executing the above prints:
+   /Users/yadu/.globus_compute/test_endpoint/tasks_working_dir/70e53142-a391-4e27-a11d-582a786bf813
+
+   bf = BashFunction("pwd", run_in_sandbox=False)
+   print(executor.submit(bf).result().stdout)
+
+   # Executing the above prints:
+   /Users/yadu/.globus_compute/test_endpoint/tasks_working_dir
+
+Walltime
+^^^^^^^^
+
+The `walltime` keyword argument to |BashFunction|_ can be used to specify the maximum duration (in seconds)
+after which execution should be interrupted. If the execution was prematurely terminated due to reaching
+the walltime, the returcode will be set to `124`, which matches the behavior of the
+`timeout <https://ss64.com/bash/timeout.html>`_ command.
+
+Here's an example:
+
+.. code-block:: python
+
+   # Limit execution to 1s
+   bf = BashFunction("sleep 2", walltime=1)
+   future = executor.submit(bf)
+   print(future.returncode)
+
+   # Executing the above prints:
+   124
+
+
+.. |BashFunction| replace:: ``BashFunction``
+.. _BashFunction: reference/bash_function.html
+
+.. |BashResult| replace:: ``BashResult``
+.. _BashResult: reference/bash_function.html#globus_compute_sdk.sdk.bash_function.BashResult

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -328,6 +328,8 @@ processing:
         for f in concurrent.futures.as_completed(futs):
             print("Received:", f.result())
 
+.. include:: bash_functions.rst
+
 AMQP Port
 ---------
 

--- a/docs/reference/bash_function.rst
+++ b/docs/reference/bash_function.rst
@@ -1,0 +1,11 @@
+BashFunction
+============
+
+.. autoclass:: globus_compute_sdk.sdk.bash_function.BashFunction
+    :members:
+    :member-order: bysource
+    :special-members: __call__
+
+.. autoclass:: globus_compute_sdk.sdk.bash_function.BashResult
+    :members:
+    :member-order: bysource

--- a/docs/reference/engine.rst
+++ b/docs/reference/engine.rst
@@ -4,4 +4,3 @@ The Globus Compute Engine
 .. autoclass:: globus_compute_endpoint.engines.GlobusComputeEngine
     :members:
     :member-order: bysource
-

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,3 +9,5 @@ Globus Compute SDK
     executor
     client
     engine
+    bash_function
+    mpi_function

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,5 +9,6 @@ Globus Compute SDK
     executor
     client
     engine
+    mpi_engine
     bash_function
     mpi_function

--- a/docs/reference/mpi_engine.rst
+++ b/docs/reference/mpi_engine.rst
@@ -1,0 +1,6 @@
+The Globus MPI Engine
+===========================
+
+.. autoclass:: globus_compute_endpoint.engines.GlobusMPIEngine
+    :members:
+    :member-order: bysource

--- a/docs/reference/mpi_function.rst
+++ b/docs/reference/mpi_function.rst
@@ -1,0 +1,6 @@
+MPIFunction
+===========
+
+.. autoclass:: globus_compute_sdk.sdk.mpi_function.MPIFunction
+    :members:
+    :member-order: bysource


### PR DESCRIPTION
# Description

Parsl has added a new `MPIExecutor` that is a thin wrapper over `HighThroughputExecutor`. It makes sense to point users to this new executor and documentation when it comes to MPI applications. 

This PR adds a new `GlobusMPIEngine` that is a thin shim over our default `GlobusComputeEngine` in that it simply replaces the internal executor from HTEX to MPIExecutor. 

Fixes # (issue)

[sc-32391]
[sc-33956]
## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
