### PR TITLE
pin cryptography to avoid warning from parsl import

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -44,6 +44,9 @@ REQUIRES = [
     "jsonschema>=4.19.0,<4.20",
     "cachetools>=5.3.1",
     "types-cachetools>=5.3.0.6",
+    # Pin to 42.0.0 to avoid CryptographyDeprecationWarning, to be fixed in parsl
+    # See https://funcx.slack.com/archives/C016JMYST9C/p1723232785192439
+    "cryptography==42.0.0",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
The latest globus-compute-endpoint, which upgraded to a more recent version of parsl, started generating this error message on endpoint CLI commands:

```
/opt/globus-compute-agent/venv-py39/lib/python3.9/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES a
nd will be removed from this module in 48.0.0.                                                                                                                                                               
  "cipher": algorithms.TripleDES,                                                                                                                                                                            
/opt/globus-compute-agent/venv-py39/lib/python3.9/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.Triple
DES and will be removed from this module in 48.0.0.                                                                                                                                                          
  "class": algorithms.TripleDES,                                                                                                                                                                             
Created multi-user profile for endpoint named <some-endpoint-name>  
```

This was observed with 3.9, 3.12, and some environments of 3.10.

See slack thread with more context: https://funcx.slack.com/archives/C016JMYST9C/p1723232785192439

The temporary solution is to pin cryptography to a lower version until the [parsl issue](https://github.com/Parsl/parsl/issues/3515) with PR  [parsl #3569](https://github.com/Parsl/parsl/pull/3569) is deployed and Compute updates our parsl version to it. 

***Update***
42.0.0 triggered a pip-audit security warning, so maybe better to wait for parsl to deploy the fix above and bump parsl version in Compute instead.