### PR TITLE
Shutdown engines at test close

### DIFF
--- a/compute_endpoint/tests/unit/engine/test_globuscompute.py
+++ b/compute_endpoint/tests/unit/engine/test_globuscompute.py
@@ -168,3 +168,4 @@ def test_sets_task_id(tmp_path, mock_htex, endpoint_uuid, task_uuid):
     f = GCFuture(task_uuid)
     eng.submit(f, b"bytes", {})
     assert f.executor_task_id is not None
+    eng.shutdown()

--- a/compute_endpoint/tests/unit/engine/test_globusmpi.py
+++ b/compute_endpoint/tests/unit/engine/test_globusmpi.py
@@ -9,3 +9,4 @@ def test_sets_task_id(tmp_path, mock_mpiex, endpoint_uuid, task_uuid):
     f = GCFuture(task_uuid)
     eng.submit(f, b"bytes", {})
     assert f.executor_task_id is not None
+    eng.shutdown()

--- a/compute_endpoint/tests/unit/engine/test_processpool.py
+++ b/compute_endpoint/tests/unit/engine/test_processpool.py
@@ -12,3 +12,4 @@ def test_sets_task_id(endpoint_uuid, task_uuid):
         f = GCFuture(task_uuid)
         eng.submit(f, b"bytes", {})
         assert f.executor_task_id is not None
+        eng.shutdown()

--- a/compute_endpoint/tests/unit/engine/test_threadpool.py
+++ b/compute_endpoint/tests/unit/engine/test_threadpool.py
@@ -12,3 +12,4 @@ def test_sets_task_id(endpoint_uuid, task_uuid):
         f = GCFuture(task_uuid)
         eng.submit(f, b"bytes", {})
         assert f.executor_task_id is not None
+        eng.shutdown()


### PR DESCRIPTION
Remove a source of spurious test noise by shutting down the resources when finished.  An oversight from initial implementation.

## Type of change

- Code maintenance/cleanup