### PR TITLE
Add deprecation warning to container method docs

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -672,7 +672,13 @@ class Client:
 
     @_client_gares_handler
     def get_container(self, container_uuid, container_type):
-        """Get the details of a container for staging it locally.
+        """
+        .. warning::
+
+            Deprecated since version 3.8.0. Container functionality has moved to
+            the endpoint configuration.
+
+        Get the details of a container for staging it locally.
 
         Parameters
         ----------
@@ -839,7 +845,13 @@ class Client:
 
     @_client_gares_handler
     def register_container(self, location, container_type, name="", description=""):
-        """Register a container with the Globus Compute service.
+        """
+        .. warning::
+
+            Deprecated since version 3.8.0. Container functionality has moved to
+            the endpoint configuration.
+
+        Register a container with the Globus Compute service.
 
         Parameters
         ----------
@@ -874,6 +886,11 @@ class Client:
     @_client_gares_handler
     def build_container(self, container_spec):
         """
+        .. warning::
+
+            Deprecated since version 3.8.0. Container functionality has moved to
+            the endpoint configuration.
+
         Submit a request to build a docker image based on a container spec. This
         container build service is based on repo2docker, so the spec reflects features
         supported by it.
@@ -906,6 +923,24 @@ class Client:
 
     @_client_gares_handler
     def get_container_build_status(self, container_id):
+        """
+        .. warning::
+
+            Deprecated since version 3.8.0. Container functionality has moved to
+            the endpoint configuration.
+
+        Get the status of a container build.
+
+        Parameters
+        ----------
+        container_id : str
+            UUID of the container in question
+
+        Returns
+        -------
+        str
+            The status of the container build
+        """
         self._raise_container_deprecation_warning("get_container_build_status")
         with self._request_lock:
             r = self._compute_web_client.v2.get(f"/v2/containers/build/{container_id}")

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -394,6 +394,11 @@ class Executor(concurrent.futures.Executor):
     @property
     def container_id(self) -> uuid.UUID | None:
         """
+        .. warning::
+
+            Deprecated since version 3.8.0. Container functionality has moved to
+            the endpoint configuration.
+
         The container id with which this Executor instance is currently associated.
         Tasks submitted after this is set will use this container.
 


### PR DESCRIPTION
# Description

This should have been done in https://github.com/globus/globus-compute/pull/1883.

[sc-34263](https://app.shortcut.com/globus/story/34263/add-containerization-documentation-and-tutorial)

## Type of change

- Documentation update
