### PR TITLE
tweak release script to handle git tag error better

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -27,13 +27,14 @@ if ! grep '^globus\-compute\-sdk \& globus\-compute\-endpoint v'"$VERSION"'$' do
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     [[ $0 = $BASH_SOURCE ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
   else
-    echo "\n  Releasing globus-compute-sdk and globus-compute-endpoint without changelog updates for v$VERSION"
+    echo -e "\n  Releasing globus-compute-sdk and globus-compute-endpoint without changelog updates for v$VERSION"
   fi
 fi
 
 echo "releasing v$VERSION"
-TAG_STDERR="$(git tag -s -m v$VERSION $VERSION 2>&1 > /dev/null)"
-if [[ $? == 0 ]]; then
+TAG_ERR=
+TAG_STDERR="$(git tag -s -m v$VERSION $VERSION 2>&1 > /dev/null)" || TAG_ERR=$?
+if [[ -z $TAG_ERR ]]; then
   echo "Git tagged $VERSION"
   git push origin "$VERSION"
 elif [[ "$TAG_STDERR" =~ "already exists" ]]; then


### PR DESCRIPTION
# Description

If the git tag already exists (for example from a prior failed partial release), the git tag triggers script termination due to the -e flag instead of actually being handled via the following lines.

Adding a ``|| echo`` ensures continuation while adding a custom string to search for (instead of || true)

Additionally, the echo "\n..." doesn't linebreak properly following the read -p, echo && echo... formats better

## Type of change

- Bug fix (non-breaking change that fixes an issue)
