### PR TITLE
Retain default EP config field order

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -115,7 +115,7 @@ class Endpoint:
         if subscription_id:
             config_dict["subscription_id"] = subscription_id
 
-        config_text = yaml.safe_dump(config_dict)
+        config_text = yaml.safe_dump(config_dict, sort_keys=False)
         target_path.write_text(config_text)
 
     @staticmethod

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -828,3 +828,23 @@ def test_delete_endpoint_with_uuid_errors(
 
     assert pyt_exc.value.code == exit_code
     assert log_msg in mock_log.warning.call_args[0][0]
+
+
+def test_update_config_file_retains_order(fs):
+    target_path = pathlib.Path("target_config.yaml")
+    original_path = pathlib.Path("original_config.yaml")
+
+    original_config = "z: first\na: second\n"
+    original_path.write_text(original_config)
+    Endpoint.update_config_file(
+        original_path,
+        target_path,
+        multi_user=False,
+        high_assurance=False,
+        display_name=None,
+        auth_policy=None,
+        subscription_id=None,
+    )
+
+    target_config = target_path.read_text()
+    assert original_config == target_config


### PR DESCRIPTION
# Description

The `Endpoint.update_config_file` method sorts the config fields when it calls `yaml.dumps`, which has `sort_keys` set to `True` by default. To retain the deliberate layout in `default_config.yaml`, we no longer sort the fields.

## Type of change

- Code maintenance/cleanup
