### PR TITLE
Refactor endpoint unit test fixtures

### DIFF
--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -88,15 +88,20 @@ def mock_ep_data(fs, conf):
 
 
 @pytest.fixture
-def mock_ep_buf():
+def table_buf():
     buf = io.StringIO()
-    Endpoint.get_endpoints = mock.Mock()
-    Endpoint.get_endpoints.return_value = {}
-
-    Endpoint.print_endpoint_table = functools.partial(
+    partial_print = functools.partial(
         Endpoint.print_endpoint_table, conf_dir="unused", ofile=buf
     )
-    yield buf
+    with mock.patch.object(Endpoint, "print_endpoint_table", partial_print):
+        yield buf
+
+
+@pytest.fixture
+def mock_ep_get():
+    with mock.patch.object(Endpoint, "get_endpoints") as m:
+        m.return_value = {}
+        yield m
 
 
 @pytest.fixture
@@ -333,30 +338,26 @@ def test_register_endpoint_blocked(
         assert pytexc.value.http_status == status_code
 
 
-def test_list_endpoints_none_configured(mock_ep_buf):
-    buf = mock_ep_buf
+def test_list_endpoints_none_configured(mock_ep_get, table_buf):
     Endpoint.print_endpoint_table()
-    assert "No endpoints configured" in buf.getvalue()
-    assert "Hint:" in buf.getvalue()
-    assert "globus-compute-endpoint configure" in buf.getvalue()
+    assert "No endpoints configured" in table_buf.getvalue()
+    assert "Hint:" in table_buf.getvalue()
+    assert "globus-compute-endpoint configure" in table_buf.getvalue()
 
 
-def test_list_endpoints_no_id_yet(mock_ep_buf, randomstring):
-    buf = mock_ep_buf
-    expected_col_length = random.randint(2, 30)
-    Endpoint.get_endpoints.return_value = {
-        "default": {"status": randomstring(length=expected_col_length), "id": None}
-    }
+def test_list_endpoints_no_id_yet(mock_ep_get, table_buf, randomstring):
+    col_length = random.randint(2, 30)
+    get_data = {"default": {"status": randomstring(length=col_length), "id": None}}
+    mock_ep_get.return_value = get_data
     Endpoint.print_endpoint_table()
-    assert Endpoint.get_endpoints.return_value["default"]["status"] in buf.getvalue()
-    assert "| Endpoint ID |" in buf.getvalue(), "Expecting column shrinks to size"
+    assert get_data["default"]["status"] in table_buf.getvalue()
+    assert "| Endpoint ID |" in table_buf.getvalue(), "Expect col shrinks to size"
 
 
 @pytest.mark.parametrize("term_size", ((30, 5), (50, 5), (67, 5), (72, 5), (120, 5)))
 def test_list_endpoints_long_names_wrapped(
-    mock_ep_buf, mocker, term_size, randomstring
+    mock_ep_get, table_buf, mocker, term_size, randomstring
 ):
-    buf = mock_ep_buf
     tsize = namedtuple("terminal_size", ["columns", "lines"])(*term_size)
     mock_shutil = mocker.patch("globus_compute_endpoint.endpoint.endpoint.shutil")
     mock_shutil.get_terminal_size.return_value = tsize
@@ -376,9 +377,9 @@ def test_list_endpoints_long_names_wrapped(
     Endpoint.print_endpoint_table()
 
     for ep_name, ep in expected_data.items():
-        assert ep["status"] in buf.getvalue(), "expected no wrapping of status"
-        assert str(ep["id"]) in buf.getvalue(), "expected no wrapping of id"
-        assert ep_name not in buf.getvalue(), "expected only name column is wrapped"
+        assert ep["status"] in table_buf.getvalue(), "expect status not wrapped"
+        assert str(ep["id"]) in table_buf.getvalue(), "expect id not wrapped"
+        assert ep_name not in table_buf.getvalue(), "expect only name column wrapped"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Same tests, but a little smarter about setup and teardown.  The functional change is not leaking test state when each test is done:

```diff
- Endpoint.function = ...
+ with mock.patch.object(Endpoint, "function", ...
```

Also split the `print_endpoint_table` and `get_endpoints` mocks into different fixtures -- not strictly necessary, but clarifies an upcoming PR.

## Type of change

- Code maintenance/cleanup