### PR TITLE
Don't break list on invalid endpoint.json files

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -835,9 +835,17 @@ class Endpoint:
         ep_statuses = {}
 
         for ep_path in Endpoint._get_ep_dirs(pathlib.Path(funcx_conf_dir)):
+            try:
+                ep_id = Endpoint.get_endpoint_id(ep_path)
+            except Exception as e:
+                t = type(e).__name__
+                log.warning(f"Failed to read endpoint id: [{t}] {e} ({ep_path})")
+                del t, e
+                ep_id = "[failed to read endpoint id]"
+
             ep_status = {
                 "status": "Initialized",
-                "id": Endpoint.get_endpoint_id(ep_path),
+                "id": ep_id,
             }
             ep_statuses[ep_path.name] = ep_status
             if not ep_status["id"]:


### PR DESCRIPTION
This is a fairly specific "robustification" to the print list function, but if there's an error in other contexts (e.g., `gce start EP_NAME`), we still want it to break loudly.  This allows corrupted EP files to still be read and utilized by the diagnostic.

[sc-45652]

## Type of change

- Bug fix (non-breaking change that fixes an issue)