### PR TITLE
add du -sh to diagnostic

### DIFF
--- a/changelog.d/20251010_125114_lei_add_quota_compute_usage_sc_45659.rst
+++ b/changelog.d/20251010_125114_lei_add_quota_compute_usage_sc_45659.rst
@@ -1,0 +1,5 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``globus-compute-diagnostic`` command now also include a summary of disk usage
+  for each endpoint in the Globus Compute home directory (default ``~/.globus_compute``)

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -72,6 +72,7 @@ def mock_general_reports(mocker, mock_gc_home, mock_endpoint_config_dir_data):
         [
             "whoami",
             "uname -a",
+            f"du -sh {home_dir}/*",
             cat(
                 [
                     f"{home_dir}/*/*.yaml",
@@ -84,6 +85,7 @@ def mock_general_reports(mocker, mock_gc_home, mock_endpoint_config_dir_data):
         [
             ["whoami", getpass.getuser()],
             ["uname", platform.uname()[0]],
+            [["du", "-sh", ""], ""],
             [["cat", "/config.yaml", "/endpoint.log"], ""],
         ],
     ]


### PR DESCRIPTION
# Description

A recent ticket involved disk quota issues that may be informative in all diagnostic output.  In particular, if any endpoint directory uses a significant amount of disk space, it may be a flag to look at it more closely to see if it's a long running endpoint (compare to tasks sent in psql), or if there's much more disk usage than expected.

Also, added a common user quota command that should work on a large percentage of systems, until we add more variations later if necessary.

Also modified the diagnostic command handling slightly to more easily add a display name for a diagnostic that is simply a str to be sent to the process to execute, by merely providing a tuple of `(cmd_str, display_name)` in addition to just  `cmd_str`

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
