### PR TITLE
Revert changes to default serialization strategies

### DIFF
--- a/changelog.d/20251006_153442_30907815+rjmello_combo_strategies_sc_44734.rst
+++ b/changelog.d/20251006_153442_30907815+rjmello_combo_strategies_sc_44734.rst
@@ -25,10 +25,3 @@ Deprecated
   - :class:`~globus_compute_sdk.serialize.CombinedCode` - Replaced by
     :class:`~globus_compute_sdk.serialize.AllCodeStrategies`, which does not include
     the deprecated strategies above.
-
-Changed
-^^^^^^^
-
-- Changed the default code serialization strategy to
-  :class:`~globus_compute_sdk.serialize.AllCodeStrategies` and the default data
-  serialization strategy to :class:`~globus_compute_sdk.serialize.AllDataStrategies`.

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -487,7 +487,7 @@ SELECTABLE_STRATEGIES = [
 
 #: The *code* serialization strategy used by :class:`ComputeSerializer`
 #: when one is not specified.
-DEFAULT_STRATEGY_CODE = SerializationStrategy.get_cached_by_class(AllCodeStrategies)
+DEFAULT_STRATEGY_CODE = SerializationStrategy.get_cached_by_class(DillCode)
 #: The *data* serialization strategy used by :class:`ComputeSerializer`
 #: when one is not specified.
-DEFAULT_STRATEGY_DATA = SerializationStrategy.get_cached_by_class(AllDataStrategies)
+DEFAULT_STRATEGY_DATA = SerializationStrategy.get_cached_by_class(DillDataBase64)

--- a/docs/sdk/executor_user_guide.rst
+++ b/docs/sdk/executor_user_guide.rst
@@ -344,10 +344,9 @@ sent over the wire. Internally, :class:`~globus_compute_sdk.serialize.ComputeSer
 and arguments to strings) and deserializing (converting well-formatted strings back into
 function code and arguments).
 
-The default strategies are :class:`~globus_compute_sdk.serialize.AllCodeStrategies` for function code and
-:class:`~globus_compute_sdk.serialize.AllDataStrategies` for function ``*args`` and ``**kwargs``, which combine the results
-from multiple sub-strategies into a single payload. To select a specific, non-combination strategy, use the ``serializer``
-attribute of the Compute :class:`~globus_compute_sdk.Executor`:
+The default strategies are :class:`~globus_compute_sdk.serialize.DillCode` for function code and
+:class:`~globus_compute_sdk.serialize.DillDataBase64` for function ``*args`` and ``**kwargs``, which are both wrappers around
+|dill|_. To choose another serializer, use the ``serializer`` member of the Compute :class:`~globus_compute_sdk.Executor`:
 
 .. code:: python
 


### PR DESCRIPTION
# Description

Since the new `AllCodeStrategies` and `AllDataStrategies` serialization strategies do not exist in older versions of the SDK and endpoint, upgrading the client's SDK will require an upgrade to the endpoint. To avoid this sudden breaking change, we will keep the same default serde strategies in place for a reasonable amount of time, then make the change in a subsequent major release.

#1950 implemented the original change.

[sc-44734](https://app.shortcut.com/globus/story/44734/change-default-serializer-to-minimize-serialization-errors)

## Type of change

- Code maintenance/cleanup
