### PR TITLE
remove mention of macos, add flag to pipx

### DIFF
--- a/docs/endpoints/installation.rst
+++ b/docs/endpoints/installation.rst
@@ -7,10 +7,8 @@ package (DEB and RPM).
 Operating System Support
 ========================
 
-Currently, the Globus Compute Endpoint is only supported on Linux.  While some
-have reported success running Compute endpoints on macOS, we do not currently
-support it.  If running on a non-Linux host OS is necessary, consider doing so
-in a container running Linux.
+Currently, the Globus Compute Endpoint is only supported on Linux. If running on
+a non-Linux host OS is necessary, consider doing so in a container running Linux.
 
 .. note::
 
@@ -34,7 +32,7 @@ library isolation|_:
 
 .. code-block:: console
 
-   $ python3 -m pipx install globus-compute-endpoint
+   $ python3 -m pipx install --include-deps globus-compute-endpoint
 
 
 .. _repo-based-installation:


### PR DESCRIPTION
# Description

Remove mention of macos being usable, as V4 templatable EPs no longer start on darwin.

Also add --include-deps to pipix as we had forgotten to do so previously from https://app.shortcut.com/globus/story/32417/update-readthedocs-with-globus-compute-endpoint-installation-methods-pipx-venv-conda-deb-rpm

## Type of change

- Documentation update

This will update readthedocs as it's merged to main, so no need to associate with v4.0.0 necessarily.
