### PR TITLE
Use Parsl HTEX submit_payload

### DIFF
--- a/changelog.d/20251007_150417_kevin_custom_execute_task.rst
+++ b/changelog.d/20251007_150417_kevin_custom_execute_task.rst
@@ -2,5 +2,5 @@ Changed
 ^^^^^^^
 
 - Bumped ``parsl`` dependency version from `2025.9.15
-  <https://pypi.org/project/parsl/2025.9.15/>`_ to `2025.10.27
-  <https://pypi.org/project/parsl/2025.10.27/>`_
+  <https://pypi.org/project/parsl/2025.9.15/>`_ to `2025.12.01
+  <https://pypi.org/project/parsl/2025.12.01/>`_

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_mpi.py
@@ -1,9 +1,4 @@
-from __future__ import annotations
-
-import typing as t
-
 import parsl.executors
-from globus_compute_endpoint.engines.base import GCExecutorFuture
 from globus_compute_endpoint.engines.globus_compute import GlobusComputeEngine
 
 
@@ -27,18 +22,3 @@ class GlobusMPIEngine(GlobusComputeEngine):
         """  # noqa: E501
 
         super().__init__(*args, **kwargs)
-
-    def _submit(
-        self,
-        func: t.Callable,
-        resource_specification: t.Dict,
-        *args: t.Any,
-        **kwargs: t.Any,
-    ) -> GCExecutorFuture:
-        # override submit since super rejects resource_specification
-        f = t.cast(
-            GCExecutorFuture,
-            self.executor.submit(func, resource_specification, *args, **kwargs),
-        )
-        f.executor_task_id = f.parsl_executor_task_id  # type: ignore[attr-defined]
-        return f

--- a/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/thread_pool.py
@@ -87,15 +87,21 @@ class ThreadPoolEngine(GlobusComputeEngineBase):
 
     def _submit(
         self,
-        func: t.Callable,
         resource_specification: t.Dict,
-        *args: t.Any,
-        **kwargs: t.Any,
+        func: t.Callable,
+        packed_task: bytes,
+        args: tuple[t.Any, ...] = (),
+        kwargs: dict | None = None,
     ) -> GCExecutorFuture:
-        """``resource_specification`` is not applicable to the ThreadPoolEngine"""
+        if resource_specification:
+            raise ValueError(
+                f"resource_specification is not supported on {type(self).__name__}."
+                "  For MPI apps, use GlobusMPIEngine."
+            )
 
         self._task_counter += 1
-        f = t.cast(GCExecutorFuture, self.executor.submit(func, *args, **kwargs))
+        _f = self.executor.submit(func, packed_task, *args, **(kwargs or {}))
+        f = t.cast(GCExecutorFuture, _f)
         f.executor_task_id = self._task_counter
         return f
 

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2025.11.03",
+    "parsl==2025.12.01",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_gcengine_strategy.py
@@ -68,7 +68,7 @@ def test_engine_submit_init_0(gc_engine_scaling):
     # Run a function to trigger scale_out and confirm via breakdown
     param = random.randint(1, 100)
     resource_spec = {}
-    future = engine._submit(double, resource_spec, param)
+    future = engine._submit(resource_spec, double, param)
     assert isinstance(future, concurrent.futures.Future)
     assert future.result() == param * 2
 
@@ -94,7 +94,7 @@ def test_engine_no_scaling(gc_engine_non_scaling):
     # Run a function to trigger scale_out and confirm via breakdown
     param = random.randint(1, 100)
     resource_spec = {}
-    future = engine._submit(double, resource_spec, param)
+    future = engine._submit(resource_spec, double, param)
     assert isinstance(future, concurrent.futures.Future)
     assert future.result() == param * 2
 

--- a/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
+++ b/compute_endpoint/tests/integration/endpoint/executors/test_engines.py
@@ -48,7 +48,7 @@ def test_engine_submit(engine_type: GlobusComputeEngineBase, engine_runner):
 
     param = random.randint(1, 100)
     resource_spec: dict = {}
-    future = engine._submit(double, resource_spec, param)
+    future = engine._submit(resource_spec, double, param)
     assert isinstance(future, concurrent.futures.Future)
 
     # 5-seconds is nominally "overkill," but gc on CI appears to need (at least) >1s

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -103,7 +103,7 @@ def get_random_of_datatype():
 
 @pytest.fixture
 def execute_task_runner(task_uuid, tmp_path):
-    return functools.partial(execute_task, task_uuid, run_dir=tmp_path)
+    return functools.partial(execute_task, task_id=task_uuid, run_dir=tmp_path)
 
 
 @pytest.fixture

--- a/compute_endpoint/tests/unit/engine/test_base.py
+++ b/compute_endpoint/tests/unit/engine/test_base.py
@@ -1,4 +1,15 @@
+import functools
+import random
+from unittest import mock
+
+import pytest
 from globus_compute_endpoint.engines import GCFuture, ThreadPoolEngine
+from globus_compute_endpoint.engines.helper import execute_task
+from globus_compute_sdk.serialize import ComputeSerializer
+from globus_compute_sdk.serialize.concretes import (
+    SELECTABLE_CODE_STRATEGIES,
+    SELECTABLE_DATA_STRATEGIES,
+)
 from tests.utils import double
 
 
@@ -13,12 +24,16 @@ class _Dict(dict):
         return val
 
 
-def test_tasks_cleared_when_complete(ez_pack_task, endpoint_uuid, task_uuid):
+@pytest.fixture()
+def task_bytes(ez_pack_task):
+    return ez_pack_task(double, 1)
+
+
+def test_tasks_cleared_when_complete(task_bytes, endpoint_uuid, task_uuid):
     # important for memory that we clean up each task
     eng = ThreadPoolEngine()
     eng.start(endpoint_id=endpoint_uuid)
     eng._task_id_map = _Dict()
-    task_bytes = ez_pack_task(double, 1)
     f = GCFuture(task_uuid)
 
     eng.submit(f, task_bytes, {})
@@ -28,3 +43,74 @@ def test_tasks_cleared_when_complete(ez_pack_task, endpoint_uuid, task_uuid):
     ex_tid, ex_fut = eng._task_id_map.deleted_items[-1]
     assert ex_tid == f.executor_task_id
     assert ex_fut is f
+
+
+@pytest.fixture
+def mock_eng(endpoint_uuid):
+    eng = ThreadPoolEngine()
+    eng.start(endpoint_id=endpoint_uuid)
+
+    a, k = [], {}
+
+    def mock_invoke(_task_f, f_partial: functools.partial, *_a, **_k):
+        a.extend(f_partial.args)
+        k.update(f_partial.keywords)
+
+    with mock.patch.object(eng, "_invoke_submission", mock_invoke):
+        yield eng, a, k
+
+    eng.shutdown(block=True)
+
+
+def test_submit_uses_helper_execute(
+    randomstring, mock_eng, task_bytes, endpoint_uuid, task_uuid
+):
+    eng, a, k = mock_eng
+    f = GCFuture(task_uuid)
+
+    eng.submit(f, task_bytes, {"a": randomstring()})
+
+    assert execute_task in a, "Time to update this assumption?"
+    assert task_bytes in a
+
+
+def test_submit_sets_task_state(mock_eng, task_bytes, endpoint_uuid, task_uuid):
+    eng, a, k = mock_eng
+    f = GCFuture(task_uuid)
+
+    eng.submit(f, task_bytes, {})
+
+    args, kwargs = k["args"], k["kwargs"]
+    assert task_uuid in args, "top-level (user-visible) task id should be shared"
+    assert endpoint_uuid in args
+    assert kwargs["run_dir"] == eng.working_dir
+    assert kwargs["run_in_sandbox"] == eng.run_in_sandbox
+
+
+def test_submit_specifies_serializers(randomstring, mock_eng, task_bytes, task_uuid):
+    eng, _a, k = mock_eng
+    f = GCFuture(task_uuid)
+
+    res_serde = list(randomstring() for _ in range(random.randint(0, 10)))
+    eng.submit(f, task_bytes, {}, result_serializers=res_serde)
+
+    assert k["kwargs"]["result_serializers"] == res_serde
+
+
+def test_submit_specifies_deserializers(mock_eng, task_bytes, endpoint_uuid, task_uuid):
+    num_desers_code = random.randint(1, len(SELECTABLE_CODE_STRATEGIES))
+    num_desers_data = random.randint(1, len(SELECTABLE_DATA_STRATEGIES))
+    desers = random.choices(SELECTABLE_CODE_STRATEGIES, k=num_desers_code)
+    desers.extend(random.choices(SELECTABLE_DATA_STRATEGIES, k=num_desers_data))
+    exp_task_deser = {f"{c.__module__}.{c.__name__}" for c in desers}
+
+    eng, a, k = mock_eng
+    eng.serde = ComputeSerializer(allowed_deserializer_types=desers)
+
+    f = GCFuture(task_uuid)
+
+    eng.submit(f, task_bytes, {})
+
+    assert exp_task_deser == set(
+        k["kwargs"]["task_deserializers"]
+    ), eng.serde.allowed_deserializer_types

--- a/compute_endpoint/tests/unit/engine/test_globusmpi.py
+++ b/compute_endpoint/tests/unit/engine/test_globusmpi.py
@@ -1,3 +1,4 @@
+import parsl.executors
 from globus_compute_endpoint.engines import GCFuture, GlobusMPIEngine
 
 _MOCK_BASE = "globus_compute_endpoint.engines.globus_mpi."
@@ -10,3 +11,10 @@ def test_sets_task_id(tmp_path, mock_mpiex, endpoint_uuid, task_uuid):
     eng.submit(f, b"bytes", {})
     assert f.executor_task_id is not None
     eng.shutdown()
+
+
+def test_executor_class_is_mpi():
+    # At some point, it's plausible that the MPI functionality in Parsl will be
+    # subsumed entirely into HighThroughputExecutor; for now, though, verify
+    # the substantive (only!) difference from the parent class
+    assert GlobusMPIEngine._ExecutorClass is parsl.executors.MPIExecutor

--- a/compute_endpoint/tests/unit/engine/test_processpool.py
+++ b/compute_endpoint/tests/unit/engine/test_processpool.py
@@ -1,15 +1,33 @@
 from unittest import mock
 
+import pytest
+from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GCFuture, ProcessPoolEngine
 
 _MOCK_BASE = "globus_compute_endpoint.engines.process_pool."
 
 
-def test_sets_task_id(endpoint_uuid, task_uuid):
+@pytest.fixture
+def eng(endpoint_uuid):
     with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
-        eng = ProcessPoolEngine()
-        eng.start(endpoint_id=endpoint_uuid)
-        f = GCFuture(task_uuid)
-        eng.submit(f, b"bytes", {})
-        assert f.executor_task_id is not None
-        eng.shutdown()
+        ppe = ProcessPoolEngine()
+        ppe.start(endpoint_id=endpoint_uuid)
+        yield ppe
+        ppe.shutdown(block=True)
+
+
+def test_sets_task_id(eng, task_uuid):
+    f = GCFuture(task_uuid)
+    eng.submit(f, b"bytes", {})
+    assert f.executor_task_id is not None
+
+
+def test_rejects_resource_spec(eng, task_uuid):
+    f = GCFuture(task_uuid)
+    eng.submit(f, b"bytes", {"some": "resource_spec"})
+    raw = f.result()
+    res = messagepack.unpack(raw)
+
+    assert "resource_specification is not supported" in res.data, "Expect eplanation"
+    assert "For MPI apps, use GlobusMPIEngine" in res.data, "Expect suggestion"
+    assert res.error_details is not None

--- a/compute_endpoint/tests/unit/engine/test_threadpool.py
+++ b/compute_endpoint/tests/unit/engine/test_threadpool.py
@@ -1,15 +1,33 @@
 from unittest import mock
 
+import pytest
+from globus_compute_common import messagepack
 from globus_compute_endpoint.engines import GCFuture, ThreadPoolEngine
 
 _MOCK_BASE = "globus_compute_endpoint.engines.thread_pool."
 
 
-def test_sets_task_id(endpoint_uuid, task_uuid):
+@pytest.fixture
+def eng(endpoint_uuid):
     with mock.patch(f"{_MOCK_BASE}NativeExecutor"):
-        eng = ThreadPoolEngine()
-        eng.start(endpoint_id=endpoint_uuid)
-        f = GCFuture(task_uuid)
-        eng.submit(f, b"bytes", {})
-        assert f.executor_task_id is not None
-        eng.shutdown()
+        tpe = ThreadPoolEngine()
+        tpe.start(endpoint_id=endpoint_uuid)
+        yield tpe
+        tpe.shutdown(block=True)
+
+
+def test_sets_task_id(eng, task_uuid):
+    f = GCFuture(task_uuid)
+    eng.submit(f, b"bytes", {})
+    assert f.executor_task_id is not None
+
+
+def test_rejects_resource_spec(eng, task_uuid):
+    f = GCFuture(task_uuid)
+    eng.submit(f, b"bytes", {"some": "resource_spec"})
+    raw = f.result()
+    res = messagepack.unpack(raw)
+
+    assert "resource_specification is not supported" in res.data, "Expect eplanation"
+    assert "For MPI apps, use GlobusMPIEngine" in res.data, "Expect suggestion"
+    assert res.error_details is not None

--- a/compute_endpoint/tests/unit/test_working_dir.py
+++ b/compute_endpoint/tests/unit/test_working_dir.py
@@ -109,10 +109,10 @@ def test_submit_pass(tmp_path, task_uuid, mock_gcengine):
         task_f=GCFuture(task_uuid), packed_task=b"SomeBytes", resource_specification={}
     )
 
-    mock_gcengine.executor.submit.assert_called()
+    mock_gcengine.executor.submit_payload.assert_called()
     flag = False
-    for call in mock_gcengine.executor.submit.call_args_list:
-        args, kwargs = call
+    for (ctxt, _pld), _ in mock_gcengine.executor.submit_payload.call_args_list:
+        kwargs = ctxt["task_executor"]["k"]
         assert "run_dir" in kwargs
         assert kwargs["run_dir"] == os.path.join(tmp_path, "tasks_working_dir")
         flag = True
@@ -124,7 +124,7 @@ def test_execute_task_working_dir(
 ):
     assert os.getcwd() != str(tmp_path)
     task_bytes = ez_pack_task(get_cwd)
-    packed_result = execute_task(task_uuid, task_bytes, endpoint_uuid, run_dir=tmp_path)
+    packed_result = execute_task(task_bytes, task_uuid, endpoint_uuid, run_dir=tmp_path)
 
     message = messagepack.unpack(packed_result)
     assert message.task_id == task_uuid
@@ -140,8 +140,8 @@ def test_sandbox(tmp_path, reset_cwd, serde, endpoint_uuid, task_uuid, ez_pack_t
 
     task_bytes = ez_pack_task(get_cwd)
     packed_result = execute_task(
-        task_uuid,
         task_bytes,
+        task_uuid,
         endpoint_uuid,
         run_dir=tmp_path,
         run_in_sandbox=True,

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -466,6 +466,8 @@ SELECTABLE_STRATEGIES = [
     for t in SerializationStrategy._CACHE.values()
     if not getattr(t, "_DEPRECATED", False)
 ]
+SELECTABLE_CODE_STRATEGIES = [t for t in SELECTABLE_STRATEGIES if t.for_code]
+SELECTABLE_DATA_STRATEGIES = [t for t in SELECTABLE_STRATEGIES if not t.for_code]
 
 #: The *code* serialization strategy used by :class:`ComputeSerializer`
 #: when one is not specified.


### PR DESCRIPTION
# Description

Parsl has learned the ability to dynamically import an `execute_task()` function.  Use this capability to tell Parsl to use the installed endpoint's `execute_task()`.  This enables specification of the allowed serializers, per task.  They are currently dynamically specified per task based on the engine configuration.

The core change is "small" but with big impact in the tests.  The substantive changes are:

- `base.py` - `submit()` via `task_deserializers`, `args`, and `kwargs`

- `helper.py` - update `execute_task()` to instantiate a `ComputeSerializer()`,
  rather than attempting to marshal an instance via the arguments.  Relates to
  `task_deserializers` in `base.py`

  - Update logging to include a task_id prefix to each log record -- hopefully
    helpful to users (or us!) when tracking down issues.

- `globus_compute.py` - `_submit()` with `context` and `submit_payload`;
  requirements to use Parsl's dynamic import functionality

- `globus_mpi.py` - no need to duplicate parent's `_submit()`

[sc-35486]

## Type of change

- New feature (non-breaking change that adds functionality)