### PR TITLE
Pin dill version to 0.3.9 for all python versions

### DIFF
--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -12,8 +12,7 @@ REQUIRES = [
     # dill is an extension of `pickle` to a wider array of native python types
     # pin to the latest version, as 'dill' is not at 1.0 and does not have a clear
     # versioning and compatibility policy
-    'dill==0.3.5.1;python_version<"3.11"',
-    'dill==0.3.9;python_version>="3.11"',
+    "dill==0.3.9",
     # typing_extensions, so we can use Protocol and other typing features on python3.7
     'typing_extensions>=4.0;python_version<"3.8"',
     # packaging, allowing version parsing


### PR DESCRIPTION
# Description

Pin dill version to be consistent (and with Conda Forge meta.xml), as discussed during backlog grooming

## Type of change

- Code maintenance/cleanup
