### PR TITLE
Revert CombinedCode bugfix from #1944

### DIFF
--- a/changelog.d/20251016_114115_30907815+rjmello_revert_combined_code_fix.rst
+++ b/changelog.d/20251016_114115_30907815+rjmello_revert_combined_code_fix.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Reverted changes to multiple serialization strategies that caused backward compatibility
+  issues with endpoints running versions prior to `3.16.0
+  <https://github.com/globus/globus-compute/releases/tag/3.16.0>`_.

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import codecs
 import functools
 import json
 import logging
@@ -921,8 +920,7 @@ class Client:
         # Simulate PureSourceTextInspect strategy
         serde_iden = PureSourceTextInspect.identifier
         serde_sep = PureSourceTextInspect._separator
-        source_data = f"{function_name}{serde_sep}{source}"
-        serialized = serde_iden + codecs.encode(source_data.encode(), "base64").decode()
+        serialized = f"{serde_iden}{function_name}{serde_sep}{source}"
         packed = ComputeSerializer.pack_buffers([serialized])
 
         if metadata:

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -239,17 +239,11 @@ class PureSourceTextInspect(SerializationStrategy):
         name: str = data.__name__
         body = inspect.getsource(data)
         x = name + self._separator + body
-        x = codecs.encode(x.encode(), "base64").decode()
         return self.identifier + x
 
     def deserialize(self, payload: str):
         ":meta private:"
         chomped = self.chomp(payload)
-        try:
-            chomped = codecs.decode(chomped.encode(), "base64").decode()
-        except Exception:
-            # Older versions do not use bas64 encoding
-            pass
         name, body = chomped.split(self._separator, 1)
         exec_ns: dict = {}
         exec(body, exec_ns)
@@ -286,17 +280,11 @@ class PureSourceDill(SerializationStrategy):
         name: str = data.__name__
         body = dill.source.getsource(data, lstrip=True)
         x = name + self._separator + body
-        x = codecs.encode(x.encode(), "base64").decode()
         return self.identifier + x
 
     def deserialize(self, payload: str):
         ":meta private:"
         chomped = self.chomp(payload)
-        try:
-            chomped = codecs.decode(chomped.encode(), "base64").decode()
-        except Exception:
-            # Older versions do not use bas64 encoding
-            pass
         name, body = chomped.split(self._separator, 1)
         exec_ns: dict = {}
         exec(body, exec_ns)


### PR DESCRIPTION
# Description

PR https://github.com/globus/globus-compute/pull/1944 attempted to fix a delimiter conflict bug with the `CombinedCode` serialization strategy by adding a base64-encoding step to two sub-strategies: `PureSourceTextInspect` and `PureSourceDill`. This did fix the bug and maintained backward compatibility with functions registered using older SDK versions, but introduced backward compatibility issues with executing newly registered functions on older endpoint versions.

We've rolled back these changes and will introduce a replacement for `CombinedCode` in a subsequent release.

[sc-45849](https://app.shortcut.com/globus/story/45849/3-16-0-serialization-bug)

## Type of change

- Bug fix (non-breaking change that fixes an issue)
