### PR TITLE
Use length delimiters for combo strategies

### DIFF
--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -56,17 +56,11 @@ class JSONData(SerializationStrategy):
     def serialize(self, data: t.Any) -> str:
         ":meta private:"
         dumped = json.dumps(data)
-        encoded = codecs.encode(dumped.encode(), "base64").decode()
-        return self.identifier + encoded
+        return self.identifier + dumped
 
     def deserialize(self, payload: str) -> t.Any:
         ":meta private:"
         chomped = self.chomp(payload)
-        try:
-            chomped = codecs.decode(chomped.encode(), "base64").decode()
-        except Exception:
-            # Older versions do not use bas64 encoding
-            pass
         data = json.loads(chomped)
         return data
 

--- a/compute_sdk/globus_compute_sdk/serialize/facade.py
+++ b/compute_sdk/globus_compute_sdk/serialize/facade.py
@@ -20,6 +20,7 @@ from globus_compute_sdk.serialize.concretes import (
     DEFAULT_STRATEGY_DATA,
     SELECTABLE_STRATEGIES,
 )
+from globus_compute_sdk.serialize.utils import pack_buffers, unpack_buffers
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -249,12 +250,7 @@ class ComputeSerializer:
 
         :param buffers: A list of serialized buffers, as produced by :func:`serialize`.
         """
-        packed = ""
-        for buf in buffers:
-            s_length = str(len(buf)) + "\n"
-            packed += s_length + buf
-
-        return packed
+        return pack_buffers(buffers)
 
     @staticmethod
     def unpack_buffers(packed_buffer: str) -> list[str]:
@@ -265,14 +261,7 @@ class ComputeSerializer:
         :param packed_buffer: A packed buffer string as produced by
             :func:`pack_buffers`.
         """
-        unpacked = []
-        while packed_buffer:
-            s_length, buf = packed_buffer.split("\n", 1)
-            i_length = int(s_length)
-            current, packed_buffer = buf[:i_length], buf[i_length:]
-            unpacked.extend([current])
-
-        return unpacked
+        return unpack_buffers(packed_buffer)
 
     def unpack_and_deserialize(self, packed_buffer: str) -> list[t.Any]:
         """

--- a/compute_sdk/globus_compute_sdk/serialize/utils.py
+++ b/compute_sdk/globus_compute_sdk/serialize/utils.py
@@ -1,0 +1,48 @@
+def pack_buffers(buffers: list[str]) -> str:
+    """
+    Combines a list of Compute-serialized buffers into a single string format.
+
+    Each buffer is prefixed with its length in bytes followed by a newline,
+    allowing unambiguous reconstruction of the original buffers.
+
+    Parameters
+    ----------
+    buffers
+        A list of serialized buffers
+    """
+    return "".join([f"{len(b)}\n{b}" for b in buffers])
+
+
+def unpack_buffers(packed_buffer: str) -> list[str]:
+    """
+    Splits a packed buffer string into its constituent buffers.
+
+    Parameters
+    ----------
+    packed_buffer
+        A packed buffer string as produced by :func:`pack_buffers`.
+    """
+    unpacked = []
+    while packed_buffer:
+        try:
+            delimiter, buffer = packed_buffer.split("\n", 1)
+        except ValueError as e:
+            raise ValueError("Missing newline delimiter") from e
+
+        try:
+            buf_len = int(delimiter)
+        except ValueError as e:
+            raise ValueError(f"Invalid length delimiter: {delimiter}") from e
+
+        if buf_len < 0:
+            raise ValueError(f"Length delimiter must be non-negative: {buf_len}")
+
+        if len(buffer) < buf_len:
+            raise ValueError(
+                f"Truncated buffer: expected {buf_len} characters, but only"
+                f" {len(buffer)} characters remain"
+            )
+
+        current, packed_buffer = buffer[:buf_len], buffer[buf_len:]
+        unpacked.append(current)
+    return unpacked


### PR DESCRIPTION
# Description

To avoid delimiter conflicts and eliminate the need for sub-strategies to base64-encode their data, the `ComboSerializationStrategy` methods will use length delimiters rather than pipe characters.

Note that this is not a breaking change because `ComboSerializationStrategy` has not been released.

[sc-44734](https://app.shortcut.com/globus/story/44734/create-new-combo-serialization-strategies)

## Type of change

- New feature (non-breaking change that adds functionality)
