### PR TITLE
Remove obsolete close file loop

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1264,14 +1264,6 @@ class EndpointManager:
             stdin_data = json.dumps(stdin_data_dict, separators=(",", ":"))
             exit_code += 1
 
-            # Reminder: this is *os*.open, not *open*.  Descriptors will not be closed
-            # unless we explicitly do so, so `null_fd =` in loop will work.
-            null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
-            while null_fd < 3:  # reminder 0/1/2 == std in/out/err, so ...
-                # ... overkill, but "just in case": don't step on them
-                null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
-            exit_code += 1
-
             log.debug("Setting up process stdin")
             read_handle, write_handle = os.pipe()
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -53,7 +53,7 @@ else:
 
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
-_GOOD_EC = 88  # SPoA for "good/happy-path" exit code
+_GOOD_EC = 87  # SPoA for "good/happy-path" exit code
 
 _mock_rootuser_rec = pwd.struct_passwd(
     ("root", "", 0, 0, "Mock Root User", "/mock_root", "/bin/false")
@@ -2090,7 +2090,7 @@ def test_run_as_same_user_does_not_change_uid(successful_exec_from_mocked_root):
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
 
-    assert pyexc.value.code == 84, "Q&D: verify we exec'ed, but no privilege drop"
+    assert pyexc.value.code == 83, "Q&D: verify we exec'ed, but no privilege drop"
 
     assert not mock_os.initgroups.called
     assert not mock_os.setresuid.called

--- a/compute_endpoint/tests/unit/test_mep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_mep_audit_log.py
@@ -16,7 +16,7 @@ from globus_compute_endpoint.endpoint.endpoint_manager import (
 from tests.utils import try_assert
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
-_GOOD_UNPRIVILEGED_EC = 84
+_GOOD_UNPRIVILEGED_EC = 83
 
 
 @pytest.fixture(autouse=True, scope="module")


### PR DESCRIPTION
This loop was rendered obsolete when we redirected the std* streams to the `endpoint.log` in 9ac0f9d7b1a0211d80e158f8a979f951316dae2c.  Additionally, all files are closed prior to even dropping privileges.

## Type of change

- Code maintenance/cleanup