### PR TITLE
Add render-user-config command

### DIFF
--- a/changelog.d/20251023_132912_chris_render_tool_sc_43535.rst
+++ b/changelog.d/20251023_132912_chris_render_tool_sc_43535.rst
@@ -1,0 +1,7 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- Added the ``render-user-config`` command to the endpoint CLI, which renders a given
+    endpoint's user config template to stdout. This allows admins to validate
+    configuration templates without needing to restart or interact with running
+    endpoint processes.

--- a/compute_sdk/globus_compute_sdk/sdk/batch.py
+++ b/compute_sdk/globus_compute_sdk/sdk/batch.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import platform
+import sys
 import typing as t
 import uuid
 from collections import defaultdict
@@ -11,6 +13,8 @@ from globus_compute_sdk.sdk.utils.uuid_like import (
     as_uuid,
 )
 from globus_compute_sdk.serialize import ComputeSerializer
+from globus_compute_sdk.version import __version__
+from globus_sdk.version import __version__ as __version_globus__
 
 _default_serde = ComputeSerializer()
 
@@ -95,6 +99,29 @@ class UserRuntime:
         release: str
 
     platform: PlatformInfo
+
+
+def create_user_runtime() -> UserRuntime:
+    return UserRuntime(
+        globus_compute_sdk_version=__version__,
+        globus_sdk_version=__version_globus__,
+        python_version=sys.version,
+        python=UserRuntime.PythonInfo(
+            version=platform.python_version(),
+            version_tuple=sys.version_info[:3],
+            version_info=tuple(sys.version_info),  # type: ignore[arg-type]
+            compiler=platform.python_compiler(),
+            implementation=platform.python_implementation(),
+        ),
+        platform=UserRuntime.PlatformInfo(
+            architecture=platform.architecture(),
+            machine=platform.machine(),
+            node=platform.node(),
+            platform=platform.platform(),
+            processor=platform.processor(),
+            release=platform.release(),
+        ),
+    )
 
 
 class Batch:

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -4,7 +4,6 @@ import functools
 import json
 import logging
 import platform
-import sys
 import threading
 import typing as t
 import warnings
@@ -32,11 +31,10 @@ from globus_compute_sdk.serialize import (
 )
 from globus_compute_sdk.version import __version__, compare_versions
 from globus_sdk.gare import GlobusAuthorizationParameters
-from globus_sdk.version import __version__ as __version_globus__
 
 from .auth.auth_client import ComputeAuthClient
 from .auth.globus_app import get_globus_app
-from .batch import Batch, UserRuntime
+from .batch import Batch, create_user_runtime
 from .login_manager import LoginManagerProtocol
 from .utils import get_env_var_with_deprecation
 from .web_client import WebClient
@@ -548,26 +546,7 @@ class Client:
             create_websocket_queue,
             result_serializers=result_serializers,
             serializer=self.fx_serializer,
-            user_runtime=UserRuntime(
-                globus_compute_sdk_version=__version__,
-                globus_sdk_version=__version_globus__,
-                python_version=sys.version,
-                python=UserRuntime.PythonInfo(
-                    version=platform.python_version(),
-                    version_tuple=sys.version_info[:3],
-                    version_info=tuple(sys.version_info),  # type: ignore[arg-type]
-                    compiler=platform.python_compiler(),
-                    implementation=platform.python_implementation(),
-                ),
-                platform=UserRuntime.PlatformInfo(
-                    architecture=platform.architecture(),
-                    machine=platform.machine(),
-                    node=platform.node(),
-                    platform=platform.platform(),
-                    processor=platform.processor(),
-                    release=platform.release(),
-                ),
-            ),
+            user_runtime=create_user_runtime(),
         )
 
     @_client_gares_handler

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -601,6 +601,12 @@ pulling out the configuration from the logs:
    $ sed -n "/Begin Compute/,/End Compute/p" ~/.globus_compute/uep.[...]/endpoint.log | less
 
 
+Testing Templates
+-----------------
+
+Iterating on template changes by restarting the endpoint and submitting a task can be very slow. As a result, the Compute Endpoint CLI includes a :ref:`tool for rendering config templates offline, without touching the endpoint lifecycle at all. <testing-templates>`
+
+
 Client Identities
 =================
 


### PR DESCRIPTION
# Description

Adds the `render-user-config` command to the endpoint CLI for quick iteration on user config templates.

[[sc-43535]](https://app.shortcut.com/globus/story/43535/implement-tool-to-test-user-config-templates)

## Type of change

- New feature (non-breaking change that adds functionality)
