### PR TITLE
Conditionally emit not-template-capable warning

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -751,15 +751,18 @@ def _do_start_endpoint(
         else:
             assert isinstance(ep_config, UserEndpointConfig)
 
-            print(
-                "This endpoint is not template capable. To add that capability, run:"
-                f"\n\n\t$ globus-compute-endpoint migrate-to-template-capable {ep_dir.name}\n"  # noqa: E501
-            )
-
             if die_with_parent:
                 # The endpoint cannot die with its parent if it doesn't have one :)
                 ep_config.detach_endpoint = False
                 log.debug("The --die-with-parent flag has set detach_endpoint to False")
+            else:
+                bname = os.path.basename(sys.argv[0])
+                print(
+                    "\nThis endpoint is not template capable.  To add that capability,"
+                    " run:\n\n"
+                    f"    $ {bname} migrate-to-template-capable {ep_dir.name}\n",
+                    flush=True,
+                )
 
             get_cli_endpoint(ep_config).start_endpoint(
                 ep_dir,

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -11,7 +11,7 @@ import sys
 import time
 import typing as t
 import uuid
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
 import globus_sdk
@@ -253,6 +253,18 @@ def test_start_endpoint_stale(mock_ep, make_endpoint_dir, ep_name):
     assert "Previous endpoint instance" in serr, "Expect 'who' in warning"
     assert "failed to shutdown cleanly" in serr, "Expect 'what' in warning"
     assert "Removing PID file" in serr, "Expect action taken in warning"
+
+
+@pytest.mark.parametrize("is_uep", (False, True))
+def test_start_non_template_emits_upgrade_message(mock_ep, make_endpoint_dir, is_uep):
+    ep_dir = make_endpoint_dir()
+    f = io.StringIO()
+    with redirect_stdout(f):
+        cli._do_start_endpoint(
+            ep_dir=ep_dir, endpoint_uuid=None, die_with_parent=is_uep
+        )
+
+    assert ("migrate-to-template-capable" in f.getvalue()) is not is_uep
 
 
 @pytest.mark.parametrize("cli_cmd", ["configure"])


### PR DESCRIPTION
It is expected that a UEP is not template capable -- that is, templating is the purview of the MEP.  The warning should only occur if a UEP is not started from a template-context.  The MEP-UEP interface does not currently share the parent-child relationship explicitly (e.g., by passing in a flag, parent-process pid, or parent uuid on stdin), but does imply it via the use of the `--die-with-parent` command line flag.  Until such time as we update the interface, re-use that flag implication and only conditionally warn about a non-template-capable endpoint.

[sc-46051]

## Type of change

- Bug fix (non-breaking change that fixes an issue)