### PR TITLE
Allow template-endpoints to have no config

### DIFF
--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -200,14 +200,6 @@ def test_init_config_dir_permission_error(fs):
     assert "Permission denied" in str(exc)
 
 
-def test_start_ep_corrupt(run_line, mock_command_ensure, make_endpoint_dir, ep_name):
-    make_endpoint_dir()
-    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
-    conf.unlink()
-    res = run_line(f"start {ep_name}", assert_exit_code=1)
-    assert "corrupted?" in res.stderr
-
-
 def test_start_endpoint_no_such_ep(run_line, mock_ep, ep_name):
     res = run_line(f"start {ep_name}", assert_exit_code=1)
     mock_ep.start_endpoint.assert_not_called()


### PR DESCRIPTION
In the advent of all endpoints being template-capable, there's no longer a strict need for a `config.yaml` file -- it's utility is now optional (e.g., `display_name`, `identity_mapping_config_path`, `audit_log_path`).  Allow empty or no `config.yaml`, treating as an empty string, or "no optional configuration."

[sc-46071]

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup