### PR TITLE
Fix wording in configure command output

### DIFF
--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -59,7 +59,7 @@ via the ``configure`` subcommand:
 .. code-block:: console
 
    $ globus-compute-endpoint configure my_endpoint
-   Created multi-user profile for endpoint named <my_endpoint>
+   Created profile for endpoint named <my_endpoint>
 
        Configuration file: /home/user/.globus_compute/my_endpoint/config.yaml
 

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -144,7 +144,7 @@ properly generate the :ref:`multi-user-config-yaml` and
 .. code-block:: console
 
    # globus-compute-endpoint configure my_mu_ep
-   Created multi-user profile for endpoint named <my_mu_ep>
+   Created profile for endpoint named <my_mu_ep>
 
        Configuration file: /root/.globus_compute/my_mu_ep/config.yaml
 


### PR DESCRIPTION
The `configure` subcommand output no longer includes the "multi-user" term.

# Description

The `configure` subcommand output no longer includes the "multi-user" term.

## Type of change

- Documentation update
