### PR TITLE
Use default path for search warning

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1187,13 +1187,15 @@ class EndpointManager:
             exit_code += 1
 
             # some Q&D verification for admin debugging purposes
-            if not shutil.which(proc_args[0], path=env["PATH"]):
+            if not shutil.which(proc_args[0]):
                 log.warning(
                     "Unable to find executable."
                     f"\n  Executable (not found): {proc_args[0]}"
-                    f'\n  Path: "{env["PATH"]}"'
+                    f'\n  Path: "{os.environ.get("PATH")}"'
                     f"\n\n  Will attempt exec anyway -- WARNING - it will likely fail."
                     f"\n  (pid: {pid}, user: {uname}, {ep_name})"
+                    f"\n\nA common reason for this error is permissions; is the virtual"
+                    " environment in a root-only accessible location, like /root/?"
                 )
 
             log.debug("Changing directory to '%s'", wd)

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -1831,6 +1831,8 @@ def test_warns_if_executable_not_found(
     assert "Unable to find executable" in a[0], "Expected precise problem in warning"
     assert "(not found):" in a[0]
     assert "globus-compute-endpoint" in a[0], "Share the precise thing not-found"
+    assert "common reason for this error" in a[0], "Expect suggested core reason"
+    assert "root-only accessible location" in a[0], "Expect suggested core reason"
     assert expected_env["PATH"] in a[0]
 
     assert mock_log.error.called


### PR DESCRIPTION
There is no functional difference -- `env` _is_ `os.environ`, per 797451caf426da93774ad96af597c985190d42f9 / sc-43531 -- but since we now set up the child environment variables much earlier, go ahead and use them in good faith in this `shutil.which()` call.

Meanwhile, per a number of user interactions, add a pointer in the log as to the likely culprit (permissions and `/root/` installed venvs).

## Type of change

- Code maintenance/cleanup