### PR TITLE
Leave an empty file comment in generated no-content yaml instead of {}

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -121,7 +121,11 @@ class Endpoint:
         if subscription_id:
             config_dict["subscription_id"] = subscription_id
 
-        config_text = yaml.safe_dump(config_dict, sort_keys=False)
+        # Empty file yields '{}' which is valid but may be unclear as to format
+        config_text = "# The generated config file is currently empty\n"
+        if config_dict:
+            config_text = yaml.safe_dump(config_dict, sort_keys=False)
+
         target_path.write_text(config_text)
 
     @staticmethod

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -870,6 +870,27 @@ def test_update_config_file_retains_order(fs):
     assert original_config == target_config
 
 
+def test_update_config_file_empty_comment(fs):
+    target_path = pathlib.Path("target_config.yaml")
+    original_path = pathlib.Path("original_config.yaml")
+
+    original_config = "engine:\n  abc: 123\n"
+    original_path.write_text(original_config)
+    Endpoint.update_config_file(
+        original_path,
+        target_path,
+        id_mapping=False,
+        high_assurance=False,
+        display_name=None,
+        auth_policy=None,
+        subscription_id=None,
+    )
+
+    target_config = target_path.read_text().strip()
+    assert target_config.startswith("#")
+    assert "is currently empty" in target_config
+
+
 @pytest.mark.parametrize(
     "config_keys",
     (


### PR DESCRIPTION
When we generate a new ``config.yaml`` that is empty, the default yaml dump method generates a '{}' instead of an empty file.

This may confuse some who will start to use JSON e.g. {} and [] format, instead of indentation-based yaml formats.  Leave a no-content yaml file but with a comment may be more clear to the user.

