### PR TITLE
remove deprecated slack notify block in GH Actions for daily + hourly

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -32,24 +32,3 @@ jobs:
         source .venv/bin/activate
         cd smoke_tests
         make staging
-
-  slack-notify:
-    needs:
-      - smoke-test-staging
-    if: always()
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '${{ env.TARGET_PYTHON_VERSION }}'
-      - run: python -m pip install --upgrade requests
-      - name: notify slack
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#commits'
-          SLACK_MESSAGE_TITLE: 'Daily Smoke Tests on Staging'
-          SLACK_FAILURE_MESSAGE: 'Daily test failed on staging'
-        run: ./.github/_support/github-slack-notify.py ${{ needs.smoke-test-staging.result }}

--- a/.github/workflows/hourly.yaml
+++ b/.github/workflows/hourly.yaml
@@ -29,13 +29,3 @@ jobs:
       run: |
         cd smoke_tests
         make prod
-
-  slack-notify:
-    needs: [smoke-test]
-    if: always()
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-      - run: python -m pip install -U requests


### PR DESCRIPTION
# Description

Our daily builds have been failing as it was still trying to use SLACK_WEBHOOK_URL to post to slack, and the underlying .py has already been removed.  We fixed the hourly some weeks ago in [PR-1929](https://github.com/globus/globus-compute/pull/1929) but didn't remove the daily variation (or the setup steps).

There is a slack app already set up for compute-commits, so using GH Actions is no longer necessary.

## Type of change

- Bug fix (non-breaking change that fixes an issue)