### PR TITLE
Update license classifers per build warning

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -77,7 +77,6 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
@@ -92,7 +91,7 @@ setup(
     include_package_data=True,
     author="Globus Compute Team",
     author_email="support@globus.org",
-    license="Apache License, Version 2.0",
+    license="Apache-2.0",
     url="https://github.com/globus/globus-compute",
     project_urls={
         "Changelog": "https://globus-compute.readthedocs.io/en/latest/changelog.html",  # noqa: E501

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -85,7 +85,6 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
@@ -94,7 +93,7 @@ setup(
     keywords=["Globus Compute", "FaaS", "Function Serving"],
     author="Globus Compute Team",
     author_email="support@globus.org",
-    license="Apache License, Version 2.0",
+    license="Apache-2.0",
     url="https://github.com/globus/globus-compute",
     project_urls={
         "Changelog": "https://globus-compute.readthedocs.io/en/latest/changelog.html",  # noqa: E501


### PR DESCRIPTION
Motivated by the following deprecation warning while building:

    SetuptoolsDeprecationWarning: License classifiers are deprecated.

## Type of change

- Code maintenance/cleanup