### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: "Test SDK on py${{ matrix.python-version }} x ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -80,7 +80,7 @@ jobs:
         options: --health-cmd "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_virtual_hosts && rabbitmq-diagnostics -q check_port_connectivity" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: "Test Endpoint on py${{ matrix.python-version }} x ${{ matrix.os }} "
     steps:
       - uses: actions/checkout@v6

--- a/changelog.d/20251031_131637_kevin_drop_support_for_py39.rst
+++ b/changelog.d/20251031_131637_kevin_drop_support_for_py39.rst
@@ -1,0 +1,12 @@
+Removed
+^^^^^^^
+
+- Drop support for `Python 3.9 <https://peps.python.org/pep-0596/>`_, which
+  reached `end of life on 31 Oct 2025
+  <https://devguide.python.org/versions/>`_.
+
+Changed
+^^^^^^^
+
+- Update binary packages (DEB/RPM) to build against Python 3.13.  This will
+  create a new virtual environment directory in ``/opt/globus-compute-agent/``.

--- a/compute_endpoint/packaging/JenkinsFile
+++ b/compute_endpoint/packaging/JenkinsFile
@@ -17,7 +17,7 @@ pipeline {
     }
     stages {
         stage ("Prep source") {
-            agent {label "package_creator"}
+            agent {label "package_creator_py313"}
             steps {
                 script {
 
@@ -68,13 +68,15 @@ pipeline {
                                 env.SOURCE_STASH_NAME,
                                 env.PKG_TARBALL,
                                 require_gcs5_repo: true,
+                                epic: getClubhouseEpic(),
                                 extra_tarball_map: extra_tarball_map
                             )
                         }, "rpm": {
                             env.RPM_ARTIFACTS_STASH = buildMock(
                                 env.SOURCE_STASH_NAME,
                                 env.PKG_TARBALL,
-                                true
+                                true,
+                                getClubhouseEpic()
                             )
                         }, "failFast": false
                     }

--- a/compute_endpoint/packaging/Makefile
+++ b/compute_endpoint/packaging/Makefile
@@ -9,7 +9,7 @@ PY_MAJOR_VERSION := $(shell echo -n $(PY_FULL_VERSION) | cut -d . -f1 )
 PY_MINOR_VERSION := $(shell echo -n $(PY_FULL_VERSION) | cut -d . -f2 )
 PY_VERSION := $(PY_MAJOR_VERSION)$(PY_MINOR_VERSION)
 
-VIRTUALENV := venv-$(PY_VERSION)
+VIRTUALENV := venv-py$(PY_VERSION)
 VENV_PIP := $(VIRTUALENV)/bin/pip
 VENV_PY := $(shell pwd)/$(VIRTUALENV)/bin/python
 
@@ -103,8 +103,8 @@ _build_needs:
 
 .PHONY: $(VENV_PY)
 $(VENV_PY): _build_needs
-	@if [ "$(PY_MAJOR_VERSION)" -ne 3 ] || [ "$(PY_MINOR_VERSION)" -lt 9 ]; then \
-		echo "Unsupported python version $(PY_FULL_VERSION). At least 3.9 is required."; \
+	@if [ "$(PY_MAJOR_VERSION)" -ne 3 ] || [ "$(PY_MINOR_VERSION)" -lt 10 ]; then \
+		echo "Unsupported python version $(PY_FULL_VERSION). At least 3.10 is required."; \
 		echo "To override python path, use the following"; \
 		echo "    make PYTHON3=/path/to/python"; \
 		exit 1; \
@@ -113,6 +113,7 @@ $(VENV_PY): _build_needs
 	ln -sf "$(VIRTUALENV)" venv
 	. venv/bin/activate
 	@"$(VENV_PY)" -m pip install -U pip -U setuptools -U build
+	rm -f "$(VENV_PY)"/.gitignore  # Python 3.13 now adds this to new venvs!  :facepalm:
 
 $(PKG_WHEEL): $(VENV_PY)
 	(   rm -rf build/ \
@@ -174,6 +175,7 @@ _setup_dist_for_deb:
 	    -e "s/@PACKAGE_NAME@/$(PKG_NAME)/g" \
 	    -e "s/@PACKAGE_VERSION@/$(PKG_VERSION)/g" \
 	    -e "s/@PIP_NAME@/$(PIP_NAME_D)/g" \
+	    -e "s/@VIRTUALENV@/$(VIRTUALENV)/g" \
 	)
 
 setup_dist_for_deb: dist _setup_dist_for_deb  ##-Place Debian-build required files in dist/
@@ -183,7 +185,7 @@ deb_build_needs:  ##-Check that necessary executables are available before start
 	@dpkg-checkbuilddeps
 
 _deb:
-	(   cd dist/ \
+	(   cd dist/; \
 	 sed -i debian/changelog.in -e "s/@distro@/$(OS_CODENAME)/g" \
 	 && mv debian/changelog.in debian/changelog \
 	 && rm -rf debbuild/ \

--- a/compute_endpoint/packaging/debian/control
+++ b/compute_endpoint/packaging/debian/control
@@ -2,13 +2,13 @@ Source: @PACKAGE_NAME@
 Priority: optional
 Section: contrib/science
 Maintainer: Globus Toolkit <support@globus.org>
-Build-Depends: debhelper (>= 12), globus-python (>= 3.9), dh-exec, dh-python
+Build-Depends: debhelper (>= 12), globus-python (>= 3.13), globus-python (<< 3.14), dh-exec, dh-python
 Standards-Version: 4.6.0
 Homepage: https://globus-compute.readthedocs.io/
 
 Package: @PACKAGE_NAME@
 Architecture: amd64
-Depends: ${misc:Depends}, globus-python (>= 3.9)
+Depends: ${misc:Depends}, globus-python (>= 3.13), globus-python (<< 3.14)
 Provides: @PACKAGE_NAME@
 Description: agent to receive tasks as sent from the Globus Compute SDK
  This module is intended for system administrators; end-users will most-likely

--- a/compute_endpoint/packaging/debian/rules
+++ b/compute_endpoint/packaging/debian/rules
@@ -16,7 +16,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 name := @PACKAGE_NAME@
 package_executable := @PIP_NAME@
-VIRTUAL_ENV := /opt/$(name)/venv-py39
+VIRTUAL_ENV := /opt/$(name)/@VIRTUALENV@
 TMP_BUILD_DIR := debian/$(name)-tmp
 TMP_VIRTUAL_ENV := $(TMP_BUILD_DIR)$(VIRTUAL_ENV)
 DEST_ROOT := debian/$(name)
@@ -29,7 +29,8 @@ _unitdir=/lib/systemd/system
 
 .PHONY: override_dh_auto_configure
 override_dh_auto_configure:
-	$(PYTHON3) -mvenv $${PWD}/$(TMP_VIRTUAL_ENV)
+	$(PYTHON3) -mvenv "$${PWD}/$(TMP_VIRTUAL_ENV)"
+	rm -f "$${PWD}/$(TMP_VIRTUAL_ENV)/.gitignore"  # "Lovely" Python 3.13 addition
 	. "$${PWD}/$(TMP_VIRTUAL_ENV)/bin/activate"; \
 	set -x; \
 	python -mpip install --no-index --no-cache-dir -I --compile -U prereqs/pip-*.whl; \
@@ -45,8 +46,10 @@ override_dh_shlibdeps:    # empty == we're ignoring it for our purposes.
 .PHONY: override_dh_auto_install
 override_dh_auto_install:
 	set -ex; \
+	$(PYTHON3) -mvenv "$${PWD}/$(TMP_VIRTUAL_ENV)"
+	rm -f "$${PWD}/$(TMP_VIRTUAL_ENV)/.gitignore"  # "Lovely" Python 3.13 addition
+	set -ex; \
 	. "$(TMP_VIRTUAL_ENV)/bin/activate"; \
-	$(PYTHON3) -mvenv $${PWD}/$(TMP_VIRTUAL_ENV) ; \
 	install -d -m 755 \
 	  "$(DEST_VIRTUAL_ENV)" \
 	  "$(DEST_ROOT)$(_sbindir)" \

--- a/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
+++ b/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
@@ -1,13 +1,14 @@
 Name:           @PACKAGE_NAME@
-%define         _build_id_links         none
-%global         debug_package           %{nil}
-%global         version                 @PACKAGE_VERSION@
-%global         pythonversion           py39
-%global         VIRTUAL_ENV             /opt/%{name}/venv-%{pythonversion}
-%global         src_dir                 %{_sourcedir}/%{name}
-%global         package_executable      @PIP_NAME@
-%global         globus_python3_version  3.9
-%global         __python                /opt/globus-python/bin/python3
+%define         _build_id_links              none
+%global         debug_package                %{nil}
+%global         version                      @PACKAGE_VERSION@
+%global         pythonversion                py313
+%global         VIRTUAL_ENV                  /opt/%{name}/venv-%{pythonversion}
+%global         src_dir                      %{_sourcedir}/%{name}
+%global         package_executable           @PIP_NAME@
+%global         globus_python3_version       3.13
+%global         globus_python3_version_next  3.14
+%global         __python                     /opt/globus-python/bin/python3
 
 # We don't put our bits in the standard locations, so python_provides generation
 # is not useful (and super slow anyway!)
@@ -27,7 +28,7 @@ Vendor:         %{?vendor}%{!?vendor:Unknown}
 Summary:        Globus Compute Endpoint agent for system-level installs
 
 Conflicts:      %{name} < %{version}
-Requires:       globus-python >= %{globus_python3_version}
+Requires:       globus-python >= %{globus_python3_version}, globus-python < %{globus_python3_version_next}
 Requires(pre):  /usr/sbin/useradd, /usr/bin/getent
 Requires(postun): /usr/sbin/userdel
 
@@ -54,6 +55,7 @@ want to install the `@PIP_NAME@` directly from PyPI.
 
 rm -rf "%{DEST_VIRTUAL_ENV}"
 %__python -mvenv "%{DEST_VIRTUAL_ENV}"
+rm -f "%{DEST_VIRTUAL_ENV}/.gitignore"  # Python 3.13 adds this to new venvs (!!!)
 
 %build
 . "%{DEST_VIRTUAL_ENV}/bin/activate"

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -73,7 +73,7 @@ setup(
     extras_require={
         "test": TEST_REQUIRES,
     },
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/compute_endpoint/tox.ini
+++ b/compute_endpoint/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313,312,311,310,39}
+envlist = py{313,312,311,310}
 skip_missing_interpreters = true
 
 [testenv]

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -81,7 +81,7 @@ setup(
         "test": TEST_REQUIRES,
         "docs": DOCS_REQUIRES,
     },
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/compute_sdk/tox.ini
+++ b/compute_sdk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313,312,311,310,39}
+envlist = py{313,312,311,310}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Globus will be releasing their build of `globus-python` at 3.13.  Consequently, we can now drop our support of Python 3.9 and build the binary packages based off of Python 3.13.

[sc-46164]

## Type of change

- Code maintenance/cleanup
