### PR TITLE
Ensure interchange AMQP threads stop at quiesce

### DIFF
--- a/changelog.d/20251103_110111_kevin_ensure_ix_amqp_threads_stop.rst
+++ b/changelog.d/20251103_110111_kevin_ensure_ix_amqp_threads_stop.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address a shutdown bug where the UEP process could take a long time to
+  shutdown, long after it had stated it had shutdown in the logs.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/result_publisher.py
@@ -104,6 +104,18 @@ class ResultPublisher(threading.Thread):
             self._total_published,
         )
 
+    def __enter__(self):
+        if self._stop_event.is_set():
+            raise RuntimeError(f"{self!r} Already stopped; cannot start again.")
+
+        if not self.is_alive():
+            self.start()
+
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.stop(block=False)
+
     def run(self) -> None:
         log.debug("%r thread begins", self)
         self._thread_id = threading.get_ident()

--- a/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/rabbit_mq/task_queue_subscriber.py
@@ -104,6 +104,18 @@ class TaskQueueSubscriber(threading.Thread):
 
         logger.debug("Init done")
 
+    def __enter__(self):
+        if self._stop_event.is_set():
+            raise RuntimeError(f"{self!r} Already stopped; cannot start again.")
+
+        if not self.is_alive():
+            self.start()
+
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.stop()
+
     def run(self):
         logger.debug("%s AMQP thread begins", self)
         idle_for_s = 0.0

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -62,7 +62,7 @@ def mock_conf(mock_engine):
 def mock_rp():
     pub_f = Future()
     pub_f.set_result(None)
-    m = mock.Mock(spec=ResultPublisher)
+    m = mock.MagicMock(spec=ResultPublisher)
     m.publish.return_value = pub_f
     with mock.patch(f"{_MOCK_BASE}ResultPublisher", return_value=m):
         yield m
@@ -70,7 +70,7 @@ def mock_rp():
 
 @pytest.fixture
 def mock_tqs():
-    m = mock.Mock(spec=TaskQueueSubscriber)
+    m = mock.MagicMock(spec=TaskQueueSubscriber)
     with mock.patch(f"{_MOCK_BASE}TaskQueueSubscriber", return_value=m):
         yield m
 
@@ -238,7 +238,7 @@ def test_soft_idle_honored(
 
     shut_down_s = f"{(idle_limit - 1) * mock_conf.heartbeat_period:,}"
     idle_msg = next(m for m in log_args if "In idle state" in m)
-    assert "due to" in idle_msg, "expected to find reason"
+    assert "no task or result movement" in idle_msg, "expected to find reason"
     assert "idle_heartbeats_soft" in idle_msg, "expected to find setting name"
     assert f" shut down in {shut_down_s}" in idle_msg, "expected to find timeout time"
 
@@ -280,7 +280,7 @@ def test_hard_idle_honored(
     shut_down_s = f"{(idle_limit - idle_soft_limit - 1) * mock_conf.heartbeat_period:,}"
     idle_msg = next(m for m in log_args if "Possibly idle" in m)
     assert "idle_heartbeats_hard" in idle_msg, "expected to find setting name"
-    assert f" shut down in {shut_down_s}" in idle_msg, "expected to find timeout time"
+    assert f" Shutting down in {shut_down_s}" in idle_msg, "expected timeout time"
 
     idle_msg = mock_log.warning.call_args[0][0]
     assert "Shutting down" in idle_msg, "expected to find action taken"

--- a/compute_endpoint/tests/unit/test_task_queue_subscriber.py
+++ b/compute_endpoint/tests/unit/test_task_queue_subscriber.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import queue
+from unittest import mock
+
+import pytest
+from globus_compute_endpoint.endpoint.rabbit_mq import TaskQueueSubscriber
+from tests.utils import try_assert
+
+_MOCK_BASE = "globus_compute_endpoint.endpoint.rabbit_mq.task_queue_subscriber."
+q_info = {"queue_publish_kwargs": {"exchange": "results"}, "exchange": "results"}
+
+
+@pytest.fixture
+def mock_log():
+    with mock.patch(f"{_MOCK_BASE}log", autospec=True) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_pika():
+    with mock.patch(f"{_MOCK_BASE}pika", autospec=True) as m:
+        yield m
+
+
+def test_tqs_as_contextmanager(randomstring, mock_pika):
+    queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
+    with TaskQueueSubscriber(
+        queue_info=queue_info,
+        pending_task_queue=queue.SimpleQueue(),
+    ) as tqs:
+        try_assert(tqs.is_alive, "Context manager starts thread")
+
+    try_assert(lambda: not tqs.is_alive(), "Context manager stops thread")
+
+
+def test_tqs_callbacks_hooked_up(randomstring, mock_pika):
+    queue_info = {"queue": randomstring(), **q_info, "connection_url": "amqp:///"}
+    tqs = TaskQueueSubscriber(
+        queue_info=queue_info,
+        pending_task_queue=queue.SimpleQueue(),
+    )
+    tqs._connect()
+
+    assert mock_pika.SelectConnection.called
+
+    _a, k = mock_pika.SelectConnection.call_args
+    assert "on_open_callback" in k, "Verify successful connection open handled"
+    assert "on_close_callback" in k, "Verify connection close handled"
+    assert "on_open_error_callback" in k, "Verify connection error handled"


### PR DESCRIPTION
If the case of an unhandled exception the endpoint would quiesce and eventually shutdown.  However, since the background AMQP threads are not daemonized, they would linger.  At each quiesce, there were more AMQP threads active because they were not shutdown (due the unhandled exception).  This became visible in the logs only with `debug: true`, or at shutdown, there were multiple `Thread-..s` records corresponding to the AMQP threads that had not been shutdown at each quiesce.  More directly noticeable, at shutdown, the main thread would shutdown, but as non-daemon threads were still alive, the process would appear to hang.  It would *eventually* stop, of course, after the 7200 attempts were exhausted.

The diff is largely whitespace, but the key changes are the addition of enter and exit dunder methods in the `result_publisher.py` and `task_queue_subscriber.py` files, the `ExitStack()` in `interchange.py`, and subsequent use of the stack:

    stk.enter_context(...)

A legitimate, if unlikely, bug.  It "shouldn't" happen, but that's the reason for the exit stack in the case of reality.

[sc-46183]

## Type of change

- Bug fix (non-breaking change that fixes an issue)