### PR TITLE
Revert "Remove obsolete close file loop"

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -1260,6 +1260,14 @@ class EndpointManager:
             stdin_data = json.dumps(stdin_data_dict, separators=(",", ":"))
             exit_code += 1
 
+            # Reminder: this is *os*.open, not *open*.  Descriptors will not be closed
+            # unless we explicitly do so, so `null_fd =` in loop will work.
+            null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
+            while null_fd < 3:  # reminder 0/1/2 == std in/out/err, so ...
+                # ... overkill, but "just in case": don't step on them
+                null_fd = os.open(os.devnull, os.O_WRONLY, mode=0o200)
+            exit_code += 1
+
             log.debug("Setting up process stdin")
             read_handle, write_handle = os.pipe()
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -53,7 +53,7 @@ else:
 
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
-_GOOD_EC = 87  # SPoA for "good/happy-path" exit code
+_GOOD_EC = 88  # SPoA for "good/happy-path" exit code
 
 _mock_rootuser_rec = pwd.struct_passwd(
     ("root", "", 0, 0, "Mock Root User", "/mock_root", "/bin/false")
@@ -2085,7 +2085,7 @@ def test_run_as_same_user_does_not_change_uid(successful_exec_from_mocked_root):
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
 
-    assert pyexc.value.code == 83, "Q&D: verify we exec'ed, but no privilege drop"
+    assert pyexc.value.code == 84, "Q&D: verify we exec'ed, but no privilege drop"
 
     assert not mock_os.initgroups.called
     assert not mock_os.setresuid.called

--- a/compute_endpoint/tests/unit/test_mep_audit_log.py
+++ b/compute_endpoint/tests/unit/test_mep_audit_log.py
@@ -16,7 +16,7 @@ from globus_compute_endpoint.endpoint.endpoint_manager import (
 from tests.utils import try_assert
 
 _MOCK_BASE = "globus_compute_endpoint.endpoint.endpoint_manager."
-_GOOD_UNPRIVILEGED_EC = 83
+_GOOD_UNPRIVILEGED_EC = 84
 
 
 @pytest.fixture(autouse=True, scope="module")


### PR DESCRIPTION
This reverts commit 4e8ba5d81cc30f60836490512f6c395dcdcbdca8

The 'apparently unused' section of code was actually making a difference.

A followup will likely add a test for this, but for now, reverting addresses the ``BrokenPipeError``

For context see https://globus.slack.com/archives/C0896RYMBGX/p1762194306014709

## Type of change

- Bug fix (non-breaking change that fixes an issue)
