### PR TITLE
Update RTD build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 python:
   install:


### PR DESCRIPTION
ReadTheDocs kindly emailed project owners that they are deprecating the 20.04 base image.  Updating to 24.04 per[1].

[1] https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

## Type of change

- Code maintenance/cleanup