### PR TITLE
catch WorkerLost exceptions and inject message to TaskExecutionFailed

### DIFF
--- a/compute_sdk/globus_compute_sdk/errors/error_types.py
+++ b/compute_sdk/globus_compute_sdk/errors/error_types.py
@@ -94,12 +94,27 @@ For more information, see:
 """
 
 
+WORKER_LOST_MESSAGE = """*****
+ One common cause of WorkerLost exceptions is Python version mismatch
+ between the submitting Globus Compute SDK and the Endpoint, as
+ serialization is typically not compatible across differing major
+ Python versions.
+*****
+"""
+
+
 class TaskExecutionFailed(Exception):
     """
     Error result from the remote end, wrapped as an exception object
     """
 
     SERDE_REGEX = re.compile("dill|pickle|serializ", re.IGNORECASE)
+
+    # Looking for this specific Exception stack trace.  Can be rendered
+    #   out-of-date if parsl refactors WorkerLost by moving/renaming it
+    # This is currently
+    #   parsl.executors.......errors.WorkerLost: Task failure due to...
+    WORKER_LOST_REGEX = re.compile(r"\s*parsl\.\S+\.WorkerLost:")
 
     def __init__(
         self,
@@ -115,6 +130,10 @@ class TaskExecutionFailed(Exception):
     def __str__(self) -> str:
         remote_data = textwrap.indent(self.remote_data, " ")
         message = "\n" + remote_data
-        if re.search(TaskExecutionFailed.SERDE_REGEX, remote_data):
+        serial_err = TaskExecutionFailed.SERDE_REGEX.search(remote_data)
+        worker_err = TaskExecutionFailed.WORKER_LOST_REGEX.search(remote_data)
+        if serial_err or worker_err:
             message += SERDE_TASK_EXECUTION_FAILED_HELP_MESSAGE
+        if worker_err:
+            message += WORKER_LOST_MESSAGE
         return message

--- a/compute_sdk/tests/unit/conftest.py
+++ b/compute_sdk/tests/unit/conftest.py
@@ -57,3 +57,27 @@ def mock_gc_home_other(tmp_path):
             return ensure_compute_dir().absolute()
 
     yield _mock_base_dir
+
+
+@pytest.fixture
+def mock_worker_lost_task():
+    return {
+        "task_id": "259a07a4-f218-4ed2-8aa6-1234567890ab",
+        "status": "failed",
+        "completion_t": "1773080793.4360487",
+        "exception": (
+            "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+            "Traceback (most recent call last):\n"
+            '  File "/home/ubuntu/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n'  # noqa E501
+            "    raise self._exception\n"
+            '  File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/executors/high_throughput/executor.py", line 538, in _result_queue_worker\n'  # noqa E501
+            "    s.reraise()\n"
+            '  File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/app/errors.py", line 114, in reraise\n'  # noqa E501
+            "    raise v\n"
+            '  File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/executors/high_throughput/process_worker_pool.py", line 452, in worker_watchdog\n'  # noqa E501
+            "    raise WorkerLost(worker_id, platform.node())\n"
+            "    ^^^^^^^^^^^^^^^^^\n"
+            "parsl.executors.high_throughput.errors.WorkerLost: Task failure due to loss of worker 0 on host ip-172-31-16-75\n"  # noqa E501
+            "--------------------------------------------------------------------"
+        ),
+    }

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -1002,7 +1002,7 @@ def test_ha_register_and_submit_warning_deduplication(gcc, mocker):
         for _ in range(10):
             gcc.batch_run("endpoint_id", batch=mocker.Mock())
 
-    assert len(record) == 11, "Verify always checked for an HA warning"
+    assert len(record) > 10, "Verify always checked for an HA warning"
 
     with warnings.catch_warnings(record=True) as records:
         for _ in range(10):
@@ -1023,3 +1023,19 @@ def test_get_endpoints_with_role(gcc, role):
 
     gcc.get_endpoints(role=role)
     gcc._compute_web_client.v2.get_endpoints.assert_called_with(role=role)
+
+
+def test_worker_lost_warn_serialization(gcc, mock_worker_lost_task):
+    tid = mock_worker_lost_task["task_id"]
+
+    mock_v2_get_task = mock.MagicMock()
+    mock_v2_get_task.text = mock_worker_lost_task
+
+    gcc._task_status_table[tid] = mock_worker_lost_task
+    gcc._compute_web_client = mock.MagicMock()
+    gcc._compute_web_client.v2.get_task.return_value = mock_v2_get_task
+
+    with pytest.raises(TaskExecutionFailed) as e:
+        gcc.get_task(tid)
+
+    assert "One common cause of WorkerLost exceptions" in str(e.value)


### PR DESCRIPTION
This looks for WorkerLost exceptions in any exceptions returned by the Client and appends a message about possible version conflicts in addition to the exception's stacktrace.

It avoids mentioning serialization as that word triggers another wrapper to add serialization remedies which won't apply when there's a version mismatch.

Note that this applies only to the Client, not the Executor, which is a bit more complex and will be in a follow-up PR.

Sample new message output:
```
...
 loss of worker 0 on host ip-172-31-16-75\n--------------------------------------------------------------------"
}
  ERROR! Task 32d831c0-0cee-4b00-be9c-d90904ba50fc failed unexpectedly:
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Traceback (most recent call last):
   File "/home/ubuntu/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
     raise self._exception
   File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/executors/high_throughput/executor.py", line 538, in _result_queue_worker
     s.reraise()
   File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/app/errors.py", line 114, in reraise
     raise v
   File "/home/ubuntu/p3.12.7/lib/python3.12/site-packages/parsl/executors/high_throughput/process_worker_pool.py", line 452, in worker_watchdog
     raise WorkerLost(worker_id, platform.node())
     ^^^^^^^^^^^^^^^^^
 parsl.executors.high_throughput.errors.WorkerLost: Task failure due to loss of worker 0 on host ip-172-31-16-75
 --------------------------------------------------------------------
 *****
   One common cause of WorkerLost exceptions is Python version mismatch between the submitting Globus Compute SDK and the Endpoint.
 *****
 ```