### PR TITLE
Refactor how the base directory (default being ~/.globus_compute) is configured

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -54,7 +54,7 @@ from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.whoami import print_whoami_info
 from globus_compute_sdk.sdk.batch import create_user_runtime
-from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir, get_compute_dir
 from globus_compute_sdk.sdk.utils.gare import gare_handler
 from globus_sdk import MISSING, AuthClient, GlobusAPIError, MissingType, NetworkError
 
@@ -91,7 +91,6 @@ _AUTH_POLICY_DEFAULT_DESC = "This policy was created automatically by Globus Com
 
 class CommandState:
     def __init__(self):
-        self.endpoint_config_dir: pathlib.Path = init_config_dir()
         self.debug = False
         self.no_color = False
         self.log_to_console = False
@@ -104,16 +103,13 @@ class CommandState:
         return click.get_current_context().ensure_object(CommandState)
 
 
-def init_config_dir() -> pathlib.Path:
+def config_dir_callback(ctx, param, value) -> pathlib.Path:
     try:
+        if value:
+            os.environ["GLOBUS_COMPUTE_USER_DIR"] = value
         return ensure_compute_dir()
     except (FileExistsError, PermissionError) as e:
         raise ClickException(str(e))
-
-
-def get_config_dir() -> pathlib.Path:
-    state = CommandState.ensure()
-    return state.endpoint_config_dir
 
 
 def get_cli_endpoint(conf: UserEndpointConfig) -> Endpoint:
@@ -206,7 +202,7 @@ def get_ep_dir_by_name_or_uuid(ctx, param, value, require_local: bool = True):
         ctx.params["ep_dir"] = None
         return
 
-    conf_dir = get_config_dir()
+    conf_dir = get_compute_dir()
     try:
         uuid.UUID(value)
     except ValueError:
@@ -292,23 +288,16 @@ def name_arg(f):
     )(f)
 
 
-def config_dir_callback(ctx, param, value):
-    if value is None or ctx.resilient_parsing:
-        return
-    state = CommandState.ensure()
-    state.endpoint_config_dir = pathlib.Path(value)
-
-
 @click.group("globus-compute-endpoint")
 @click.option(
     "-c",
     "--config-dir",
-    default=None,
+    type=str,
     help="override default config dir",
     callback=config_dir_callback,
     expose_value=False,
 )
-def app():
+def app(*, config_dir: str | None = None):
     # the main command group body runs on every command, so the block below will always
     # execute
     setup_logging()  # Until we parse the CLI flags, just setup default logging
@@ -563,7 +552,7 @@ def configure_endpoint(
             require_mfa=auth_policy_mfa_required or MISSING,
         )
 
-    compute_dir = get_config_dir()
+    compute_dir = get_compute_dir()
     ep_dir = compute_dir / name
     Endpoint.configure_endpoint(
         conf_dir=ep_dir,
@@ -658,7 +647,7 @@ def _do_login(force: bool) -> None:
 
 def _do_logout_endpoints(force: bool) -> None:
     """Logout from all endpoints and remove cached authentication credentials"""
-    compute_dir = get_config_dir()
+    compute_dir = get_compute_dir()
     running_endpoints = Endpoint.get_running_endpoints(compute_dir)
 
     if running_endpoints and not force:
@@ -1000,7 +989,7 @@ def restart_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
 @common_options
 def list_endpoints():
     """List all available endpoints"""
-    compute_dir = get_config_dir()
+    compute_dir = get_compute_dir()
     Endpoint.print_endpoint_table(compute_dir)
 
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -32,8 +32,8 @@ from globus_compute_endpoint.cli import (
     _do_logout_endpoints,
     _do_render_user_config,
     app,
+    config_dir_callback,
     create_or_choose_auth_project,
-    init_config_dir,
 )
 from globus_compute_endpoint.endpoint.config import (
     ManagerEndpointConfig,
@@ -62,8 +62,18 @@ def reset_umask():
 
 
 @pytest.fixture
-def gc_dir(tmp_path):
-    yield tmp_path / ".globus_compute"
+def mock_user_dir_env(tmp_path):
+    with mock.patch.dict(
+        os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(tmp_path.resolve())}
+    ):
+        yield tmp_path
+
+
+@pytest.fixture
+def gc_dir(mock_user_dir_env):
+    with mock.patch("globus_compute_sdk.sdk.compute_dir.get_compute_dir") as m:
+        m.return_value = pathlib.Path(mock_user_dir_env)
+        yield m.return_value
 
 
 @pytest.fixture
@@ -90,7 +100,6 @@ def mock_auth_client(mock_app):
 def mock_command_ensure(gc_dir):
     with mock.patch(f"{_MOCK_BASE}CommandState.ensure") as m:
         m.return_value = m
-        m.endpoint_config_dir = gc_dir
         m.detach = False  # since a Mock would be truthy
 
         yield m
@@ -208,9 +217,9 @@ def mock__do_register_endpoint(ep_uuid):
 
 
 @pytest.fixture
-def make_endpoint_dir(mock_command_ensure, ep_name):
+def make_endpoint_dir(gc_dir, ep_name):
     def func(name=ep_name, ep_uuid=None):
-        ep_dir = mock_command_ensure.endpoint_config_dir / name
+        ep_dir = gc_dir / name
         ep_dir.mkdir(parents=True, exist_ok=True)
         if ep_uuid is not None:
             ep_json = ep_dir / "endpoint.json"
@@ -227,9 +236,9 @@ engine:
 
 
 @pytest.fixture
-def make_manager_endpoint_dir(mock_command_ensure, ep_name):
+def make_manager_endpoint_dir(gc_dir, ep_name):
     def func(name=ep_name, ep_uuid=None):
-        ep_dir = mock_command_ensure.endpoint_config_dir / name
+        ep_dir = gc_dir / name
         ep_dir.mkdir(parents=True, exist_ok=True)
         if ep_uuid is not None:
             ep_json = ep_dir / "endpoint.json"
@@ -311,9 +320,9 @@ def test_init_config_dir(fs, dir_exists, user_dir):
         with mock.patch.dict(
             os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(config_dirname)}
         ):
-            dirname = init_config_dir()
+            dirname = ensure_compute_dir()
     else:
-        dirname = init_config_dir()
+        dirname = ensure_compute_dir()
 
     assert dirname == config_dirname
 
@@ -323,7 +332,7 @@ def test_init_config_dir_file_conflict(fs):
     fs.create_file(filename)
 
     with pytest.raises(ClickException) as exc:
-        init_config_dir()
+        config_dir_callback(None, None, None)
 
     assert "Error creating directory" in str(exc)
 
@@ -339,7 +348,7 @@ def test_init_config_dir_permission_error(fs):
         with mock.patch.dict(
             os.environ, {"GLOBUS_COMPUTE_USER_DIR": str(config_dirname)}
         ):
-            init_config_dir()
+            config_dir_callback(None, None, str(config_dirname))
 
     assert "Permission denied" in str(exc)
 
@@ -356,21 +365,20 @@ def test_start_endpoint_existing_ep(
     mock_mep,
     make_manager_endpoint_dir,
     ep_name,
-    mock_send_endpoint_startup_failure_to_amqp,
-    mock__do_register_endpoint,
     mock_client,
 ):
-    make_manager_endpoint_dir()
+    make_manager_endpoint_dir(ep_name)
     run_line(f"start {ep_name}")
     mock_mep.start.assert_called_once()
 
 
 def test_start_endpoint_already_running(
+    mock_command_ensure,
+    gc_dir,
     make_manager_endpoint_dir,
     mock_client,
     ep_name,
     mock_send_endpoint_startup_failure_to_amqp,
-    mock__do_register_endpoint,
 ):
     """Check to ensure endpoint already active message prints to console"""
     ep_dir = make_manager_endpoint_dir()
@@ -393,12 +401,7 @@ def test_start_endpoint_already_running(
 
 
 def test_start_endpoint_stale(
-    mock_mep,
-    make_manager_endpoint_dir,
-    ep_name,
-    mock_client,
-    mock_send_endpoint_startup_failure_to_amqp,
-    mock__do_register_endpoint,
+    mock_mep, mock_command_ensure, make_manager_endpoint_dir, ep_name, mock_client
 ):
     ep_dir = make_manager_endpoint_dir()
     pid_path = Endpoint.pid_path(ep_dir)
@@ -415,7 +418,10 @@ def test_start_endpoint_stale(
     assert "Removing PID file" in serr, "Expect action taken in warning"
 
 
-def test_cannot_start_sep(mock_ep, make_endpoint_dir, mock_client):
+@pytest.mark.parametrize("is_uep", (False, True))
+def test_cannot_start_sep(
+    mock_ep, mock_command_ensure, gc_dir, make_endpoint_dir, is_uep, mock_client
+):
     ep_dir = make_endpoint_dir()
     with pytest.raises(ClickException) as pyt_e:
         cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
@@ -738,10 +744,10 @@ def test__do_register_endpoint_handles_network_error_scriptably(
 
 @mock.patch(f"{_MOCK_BASE}setup_logging")
 def test_debug_configurable(
-    mock_setup_log, run_line, mock_ep, mock_command_ensure, ep_name
+    mock_setup_log, run_line, mock_ep, mock_command_ensure, gc_dir, ep_name
 ):
     mock_command_ensure.debug = False
-    ep_dir = mock_command_ensure.endpoint_config_dir / ep_name
+    ep_dir = gc_dir / ep_name
     ep_dir.mkdir(parents=True)
     config = {"debug": False, "engine": {"type": "ThreadPoolEngine"}}
     data = {"config": yaml.safe_dump(config)}
@@ -767,10 +773,10 @@ def test_debug_configurable(
 
 @mock.patch(f"{_MOCK_BASE}setup_logging")
 def test_cli_debug_overrides_config(
-    mock_setup_log, run_line, mock_ep, mock_command_ensure, ep_name
+    mock_setup_log, run_line, mock_ep, mock_command_ensure, ep_name, gc_dir
 ):
     mock_command_ensure.debug = True
-    ep_dir = mock_command_ensure.endpoint_config_dir / ep_name
+    ep_dir = gc_dir / ep_name
     ep_dir.mkdir(parents=True)
     config = {"debug": False, "engine": {"type": "ThreadPoolEngine"}}
     data = {"config": yaml.safe_dump(config)}
@@ -783,9 +789,8 @@ def test_cli_debug_overrides_config(
     assert k["debug"] is True, "Expect --debug flag overrides config"
 
 
-def test_configure_validates_name(mock_command_ensure, run_line):
-    compute_dir = mock_command_ensure.endpoint_config_dir
-    compute_dir.mkdir(parents=True, exist_ok=True)
+def test_configure_validates_name(mock_command_ensure, run_line, gc_dir):
+    gc_dir.mkdir(parents=True, exist_ok=True)
 
     run_line("configure ValidName")
     run_line("configure 'Invalid name with spaces'", assert_exit_code=1)
@@ -799,15 +804,19 @@ def test_configure_validates_name(mock_command_ensure, run_line):
         ["ep2", "abc 😎 /.great"],
     ],
 )
-def test_start_ep_display_name_in_config(run_line, mock_command_ensure, display_test):
+def test_start_ep_display_name_in_config(
+    run_line, gc_dir, make_endpoint_dir, display_test
+):
     dir_name, display_name = display_test
 
-    conf = mock_command_ensure.endpoint_config_dir / dir_name / "config.yaml"
+    conf = gc_dir / dir_name / "config.yaml"
+    open("/tmp/err.txt", "a").write(f"XXX {conf=}\n")
     configure_arg = ""
     if display_name is not None:
         configure_arg = f" --display-name '{display_name}'"
     run_line(f"configure {dir_name}{configure_arg}")
 
+    open("/tmp/err.txt", "a").write(f"YYY {dir_name=} {conf=}")
     with open(conf) as f:
         conf_dict = yaml.safe_load(f)
 
@@ -823,9 +832,9 @@ def test_start_ep_display_name_in_config(run_line, mock_command_ensure, display_
     ),
 )
 def test_start_ep_high_assurance_in_config(
-    run_line, mock_command_ensure, ep_name, set_ha
+    run_line, gc_dir, make_endpoint_dir, ep_name, set_ha
 ):
-    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+    conf = gc_dir / ep_name / "config.yaml"
     configure_arg = ""
     auth_policy = str(uuid.uuid4())
     sub_id = str(uuid.uuid4())
@@ -845,10 +854,10 @@ def test_start_ep_high_assurance_in_config(
         assert conf_dict.get("high_assurance", False) is False
 
 
-def test_configure_ep_auth_policy_in_config(run_line, mock_command_ensure):
+def test_configure_ep_auth_policy_in_config(run_line, gc_dir, make_endpoint_dir):
     ep_name = "my-ep"
     auth_policy = str(uuid.uuid4())
-    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+    conf = gc_dir / ep_name / "config.yaml"
 
     run_line(f"configure {ep_name} --auth-policy {auth_policy}")
 
@@ -858,10 +867,10 @@ def test_configure_ep_auth_policy_in_config(run_line, mock_command_ensure):
     assert conf_dict["authentication_policy"] == auth_policy
 
 
-def test_configure_ep_subscription_id_in_config(run_line, mock_command_ensure):
+def test_configure_ep_subscription_id_in_config(run_line, gc_dir, make_endpoint_dir):
     ep_name = "my-ep"
     subscription_id = str(uuid.uuid4())
-    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+    conf = gc_dir / ep_name / "config.yaml"
 
     run_line(f"configure {ep_name} --subscription-id {subscription_id}")
 
@@ -973,10 +982,10 @@ def test_configure_ep_errors_on_id_mapping_config_without_multiuser(
 
 
 @pytest.mark.parametrize("display_name", [None, "None"])
-def test_config_yaml_display_none(run_line, mock_command_ensure, display_name):
+def test_config_yaml_display_none(run_line, gc_dir, display_name):
     ep_name = "test_display_none"
 
-    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+    conf = gc_dir / ep_name / "config.yaml"
 
     config_cmd = f"configure {ep_name}"
     if display_name is not None:
@@ -1170,7 +1179,7 @@ def test_name_or_uuid_decorator(tmp_path, mocker, run_line, name, uuid):
 def test_get_endpoint_by_name_or_uuid_error_message(tmp_path, run_line, data):
     value, error = data
 
-    with mock.patch(f"{_MOCK_BASE}get_config_dir", return_value=tmp_path):
+    with mock.patch(f"{_MOCK_BASE}get_compute_dir", return_value=tmp_path):
         result = run_line(f"start {value}", assert_exit_code=1)
 
     assert error in result.stderr
@@ -1691,6 +1700,8 @@ def test_delete_endpoint_no_local_config(
 def test_render_user_config_happy_path(
     run_line,
     mock_render_config_user_template,
+    gc_dir,
+    mock_command_ensure,
     make_manager_endpoint_dir,
     ep_name,
     randomstring,

--- a/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
+++ b/compute_sdk/globus_compute_sdk/sdk/compute_dir.py
@@ -1,24 +1,39 @@
 from __future__ import annotations
 
 import os
-import pathlib
+from pathlib import Path
 
 
-def ensure_compute_dir() -> pathlib.Path:
-    dirname = pathlib.Path.home() / ".globus_compute"
+def get_compute_dir() -> Path:
+    """
+    Gets the base Compute directory.
+      Note this merely returns the expected path and does not create
+      the directory if it doesn't exist or set env var, unlike ensure_compute_dir
+    """
+    # This is either set by the user via GLOBUS_COMPUTE_USER_DIR
+    #  or by the cli argument --config-dir via overriding the env var
+    if env_dir := os.environ.get("GLOBUS_COMPUTE_USER_DIR"):
+        return Path(env_dir)
+    else:
+        return Path.home() / ".globus_compute"
 
-    user_dir = os.getenv("GLOBUS_COMPUTE_USER_DIR")
-    if user_dir:
-        dirname = pathlib.Path(user_dir)
 
-    if dirname.is_dir():
-        pass
-    elif dirname.is_file():
+def ensure_compute_dir() -> Path:
+    """
+    Creates the base Compute directory if it doesn't already exist.
+
+    This differs from get_compute_dir() in that it creates the
+    directory if it doesn't exist, where get_ is read-only,
+    returning what the path should be.
+    """
+
+    compute_dir = get_compute_dir()
+    if compute_dir.is_file():
         raise FileExistsError(
-            f"Error creating directory {dirname}, "
+            f"Error creating directory {compute_dir}, "
             "please remove or rename the conflicting file"
         )
-    else:
-        dirname.mkdir(mode=0o700, parents=True, exist_ok=True)
+    elif not compute_dir.exists():
+        compute_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
-    return dirname
+    return compute_dir

--- a/compute_sdk/tests/unit/test_compute_dir.py
+++ b/compute_sdk/tests/unit/test_compute_dir.py
@@ -9,28 +9,32 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 
 
 @pytest.mark.parametrize("dir_exists", [True, False])
-@pytest.mark.parametrize("user_dir", ["/my/dir", None, ""])
+@pytest.mark.parametrize("env_dir", ["/my/dir", "", None])
 def test_ensure_compute_dir(
     dir_exists: bool,
-    user_dir: str | None,
+    env_dir: str | None,
     fs: FakeFilesystem,
     monkeypatch: pytest.MonkeyPatch,
 ):
     home = pathlib.Path.home()
 
-    dirname = home / ".globus_compute"
+    expected_dirname = home / ".globus_compute"
 
     if dir_exists:
-        fs.create_dir(dirname)
+        fs.create_dir(expected_dirname)
 
-    if user_dir is not None:
-        dirname = pathlib.Path(user_dir)
+    if env_dir is not None:
+        # Override ~/.globus_compute if env var is set
+        dirname = pathlib.Path(env_dir)
         monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(dirname))
+        expected_dirname = pathlib.Path(env_dir)
+    else:
+        monkeypatch.delenv("GLOBUS_COMPUTE_USER_DIR", raising=False)
 
-    compute_dirname = ensure_compute_dir()
+    actual_compute_dir = ensure_compute_dir()
 
-    assert compute_dirname.is_dir()
-    assert compute_dirname == dirname
+    assert actual_compute_dir.is_dir()
+    assert actual_compute_dir.resolve() == expected_dirname.resolve()
 
 
 @pytest.mark.parametrize("user_dir_defined", [True, False])
@@ -43,6 +47,8 @@ def test_conflicting_compute_file(
     with pytest.raises(FileExistsError) as exc:
         if user_dir_defined:
             monkeypatch.setenv("GLOBUS_COMPUTE_USER_DIR", str(filename))
+        else:
+            monkeypatch.delenv("GLOBUS_COMPUTE_USER_DIR", raising=False)
         ensure_compute_dir()
 
     assert "Error creating directory" in str(exc)


### PR DESCRIPTION
Previously, using `--config-dir` didn't always set the appropriate base directory for Compute, depending on what CLI command was used and if `GLOBUS_COMPUTE_USER_DIR` env variable was set.

This removes the `endpoint_config_dir` attribute from `CommandState()` and centralizes the logic via `get_compute_dir()` which checks `GLOBUS_COMPUTE_USER_DIR`.  `--config-dir` also sets the environment variable, so the env var will be the single source of truth for all situations.

Much of the effort went into fixing the tests that work with test endpoint config directories/files.

There may still be a failing test but it is not directly related to the config dir logic, and will be addressed momentarily (and this sentence removed)