### PR TITLE
Remove deprecated single-user functionality

### DIFF
--- a/changelog.d/20260317_095046_chris_sc_42856.rst
+++ b/changelog.d/20260317_095046_chris_sc_42856.rst
@@ -1,0 +1,11 @@
+Removed
+^^^^^^^
+
+- Removed the ability to register and start endpoints without templating support.
+
+- Removed the following deprecated endpoint config options related to non-templatable
+  endpoints:
+
+  - ``multi_user``
+  - ``force_mu_allow_same_user``
+  - ``detach_endpoint``

--- a/compute_endpoint/globus_compute_endpoint/boot_persistence.py
+++ b/compute_endpoint/globus_compute_endpoint/boot_persistence.py
@@ -4,8 +4,6 @@ import shutil
 import textwrap
 
 from click import ClickException
-from globus_compute_endpoint.endpoint.config.config import UserEndpointConfig
-from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_sdk import GlobusApp
 
@@ -48,25 +46,6 @@ def enable_on_boot(ep_dir: pathlib.Path, app: GlobusApp):
         )
 
     ep_name = ep_dir.name
-
-    config = get_config(ep_dir)
-    if isinstance(config, UserEndpointConfig):  # aka: not a manager endpoint
-        if config.detach_endpoint:
-            # config.py takes priority if it exists
-            if (ep_dir / "config.py").is_file():
-                # can't give users a nice packaged command to run here; just tell them
-                msg = (
-                    "Persistent endpoints cannot run in detached mode.  Update"
-                    f" {ep_name} config to set `detach_endpoint=False` and try again."
-                )
-            else:
-                # _can_ give a nice packaged command if they use yaml, though
-                msg = (
-                    "Persistent endpoints cannot run in detached mode.  Run the"
-                    f" following command to update {ep_name}'s config:"
-                    f"\n\techo 'detach_endpoint: false' >> {ep_dir / 'config.yaml'}"
-                )
-            raise ClickException(msg)
 
     if Endpoint.check_pidfile(ep_dir)["active"]:
         raise ClickException(

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -27,7 +27,6 @@ from daemon.pidfile import PIDLockFile
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.boot_persistence import disable_on_boot, enable_on_boot
 from globus_compute_endpoint.endpoint.config import (
-    BaseConfig,
     ManagerEndpointConfig,
     UserEndpointConfig,
 )
@@ -749,7 +748,7 @@ def _pidfile(pid_path: pathlib.Path, stale_after_s: int | float):
 
 
 def _do_register_endpoint(
-    ep_dir: pathlib.Path, ep_config: BaseConfig, ep_uuid: str | None
+    ep_dir: pathlib.Path, ep_config: ManagerEndpointConfig, ep_uuid: str | None
 ) -> dict:
     gcc = Client(
         local_compute_services=ep_config.local_compute_services,
@@ -757,23 +756,13 @@ def _do_register_endpoint(
         app=get_globus_app_with_scopes(),
     )
 
-    if isinstance(ep_config, ManagerEndpointConfig):
-        metadata = EndpointManager.get_metadata(ep_dir, ep_config)
-        public = ep_config.public
-        multi_user = is_privileged()
-    else:
-        assert isinstance(ep_config, UserEndpointConfig)  # mypy
-        metadata = Endpoint.get_metadata(ep_config.source_content)
-        public = False
-        multi_user = False
-
     try:
         reg_info = gcc.register_endpoint(
             name=ep_dir.name,
             endpoint_id=ep_uuid or Endpoint.get_endpoint_id(ep_dir),
-            metadata=metadata,
-            public=public,
-            multi_user=multi_user,
+            metadata=EndpointManager.get_metadata(ep_dir, ep_config),
+            public=ep_config.public,
+            multi_user=is_privileged(),
             display_name=ep_config.display_name,
             allowed_functions=ep_config.allowed_functions,
             auth_policy=ep_config.authentication_policy,
@@ -908,7 +897,13 @@ def _do_start_endpoint(
             raise
 
         if not reg_info:
-            reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)
+            if isinstance(ep_config, ManagerEndpointConfig):
+                reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)
+            else:
+                raise ClickException(
+                    "This endpoint is not template capable and will not start."
+                    " (hint: globus-compute-endpoint migrate-to-template-capable)"
+                )
 
         # detach after reading config and registration so errors are still printed to
         # terminal, but otherwise as early as possible so any files created aren't lost
@@ -945,11 +940,7 @@ def _do_start_endpoint(
         else:
             assert isinstance(ep_config, UserEndpointConfig)
 
-            if die_with_parent:
-                # The endpoint cannot die with its parent if it doesn't have one :)
-                ep_config.detach_endpoint = False
-                log.debug("The --die-with-parent flag has set detach_endpoint to False")
-            else:
+            if not die_with_parent:
                 bname = os.path.basename(sys.argv[0])
                 print(
                     "\nThis endpoint is not template capable.  To add that capability,"
@@ -963,7 +954,6 @@ def _do_start_endpoint(
                 endpoint_uuid,
                 ep_config,
                 state.log_to_console,
-                state.no_color,
                 reg_info,
                 ep_info,
                 die_with_parent,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import typing as t
-import warnings
 
 from globus_compute_endpoint.engines.base import GlobusComputeEngineBase
 from globus_compute_sdk.sdk.utils.uuid_like import (
@@ -56,10 +55,6 @@ class BaseConfig:
     :param admins: A list of Globus Auth identity IDs that have administrative access
         to the endpoint, in addition to the owner. This field requires an active
         Globus subscription (i.e., ``subscription_id``).
-
-    :param multi_user: DEPRECATED - previously, this controlled whether an endpoint
-        would instantiate child endpoint processes.  The ``engine`` field is now used
-        for this purpose.
     """
 
     def __init__(
@@ -76,7 +71,6 @@ class BaseConfig:
         local_compute_services: bool = False,
         debug: bool = False,
         admins: t.Iterable[UUID_LIKE_T] | None = None,
-        multi_user: bool | None = None,
     ):
         # Misc
         self.display_name = display_name
@@ -98,24 +92,8 @@ class BaseConfig:
         # Used to store the raw content of the YAML or Python config file
         self.source_content: str | None = None
 
-        if multi_user is not None:
-            warnings.warn(
-                "`multi_user` is deprecated and will be removed in a future release."
-                " If you want this endpoint to spawn child processes, ensure there is"
-                " no `engine` field in its config.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
     def __repr__(self) -> str:
-        deprecated = {
-            # remove after Apr 2026
-            "multi_user",
-            # remove after Apr 2026
-            "force_mu_allow_same_user",
-            # remove after Jun 2026
-            "detach_endpoint",
-        }
+        deprecated: t.Set[str] = set()
 
         kwds: dict[str, t.Any] = {}
         for cls in type(self).__mro__:
@@ -231,10 +209,6 @@ class UserEndpointConfig(BaseConfig):
         equivalent to two days.  For example, if ``heartbeat_period`` is 30s, then
         suggest 5760.
 
-    :param detach_endpoint: DEPRECATED - Whether the endpoint daemon be run as a
-        detached process.  This is good for a real edge node, but an anti-pattern for
-        kubernetes pods
-
     :param endpoint_setup: Command(s) to be run during the endpoint initialization
         process
 
@@ -257,7 +231,6 @@ class UserEndpointConfig(BaseConfig):
         heartbeat_threshold: int = 120,
         idle_heartbeats_soft: int = 0,
         idle_heartbeats_hard: int = 5760,  # Two days, divided by `heartbeat_period`
-        detach_endpoint: bool | None = None,
         endpoint_setup: str | None = None,
         endpoint_teardown: str | None = None,
         # Logging info
@@ -274,17 +247,6 @@ class UserEndpointConfig(BaseConfig):
         self.heartbeat_threshold = heartbeat_threshold
         self.idle_heartbeats_soft = int(max(0, idle_heartbeats_soft))
         self.idle_heartbeats_hard = int(max(0, idle_heartbeats_hard))
-
-        if detach_endpoint is None:
-            self.detach_endpoint = True  # default to True for backwards compatibility
-        else:
-            warnings.warn(
-                "`detach_endpoint` is deprecated and will be removed in a future"
-                " release. Start the endpoint using the `--detach` flag instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.detach_endpoint = detach_endpoint
 
         self.endpoint_setup = endpoint_setup
         self.endpoint_teardown = endpoint_teardown
@@ -411,14 +373,6 @@ class ManagerEndpointConfig(BaseConfig):
         user-endpoint shuts down, the endpoint manager will hold on to the most recent
         start request for the user-endpoint for this grace period.
 
-    :param force_mu_allow_same_user:  DEPRECATED - previously, this overrode the
-        heuristic that determined whether the UID running a manager endpoint could
-        also run single-user endpoints.
-
-        Now, template capable endpoints run as the same user by default, unless an
-        identity mapping file is supplied. Note that privileged UIDs are still not
-        allowed to map to themselves.
-
     .. |BaseConfig| replace:: :class:`BaseConfig <globus_compute_endpoint.endpoint.config.config.BaseConfig>`
     .. |ManagerEndpointConfig| replace:: :class:`ManagerEndpointConfig <globus_compute_endpoint.endpoint.config.config.ManagerEndpointConfig>`
     .. |UserEndpointConfig| replace:: :class:`UserEndpointConfig <globus_compute_endpoint.endpoint.config.config.UserEndpointConfig>`
@@ -438,7 +392,6 @@ class ManagerEndpointConfig(BaseConfig):
         audit_log_path: os.PathLike | str | None = None,
         pam: PamConfiguration | None = None,
         mu_child_ep_grace_period_s: float = 30.0,
-        force_mu_allow_same_user: bool | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -460,16 +413,6 @@ class ManagerEndpointConfig(BaseConfig):
         self.audit_log_path = _tmp  # type: ignore[assignment]
 
         self.pam = pam or PamConfiguration(enable=False)
-
-        if force_mu_allow_same_user is not None:
-            warnings.warn(
-                "`force_mu_allow_same_user` is deprecated and will be removed in a"
-                " future release. Template-capable endpoints run as the same user by"
-                " default, unless an identity mapping file is supplied. Note that"
-                " privileged UIDs are still not allowed to map to themselves.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     @property
     def user_config_template_path(self) -> pathlib.Path | None:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/model.py
@@ -108,7 +108,6 @@ class EngineModel(BaseConfigModel):
 
 
 class BaseEndpointConfigModel(BaseModel):
-    multi_user: t.Optional[bool]
     display_name: t.Optional[str]
     allowed_functions: t.Optional[t.List[uuid.UUID]]
     admins: t.Optional[t.List[uuid.UUID]]
@@ -130,7 +129,6 @@ class UserEndpointConfigModel(BaseEndpointConfigModel):
     heartbeat_threshold: t.Optional[int]
     idle_heartbeats_soft: t.Optional[int]
     idle_heartbeats_hard: t.Optional[int]
-    detach_endpoint: t.Optional[bool]
     endpoint_setup: t.Optional[str]
     endpoint_teardown: t.Optional[str]
     log_dir: t.Optional[str]

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 import os
@@ -15,13 +14,12 @@ import sys
 import time
 import typing as t
 from datetime import datetime
-from http import HTTPStatus
 
-import daemon
 import psutil
 import setproctitle
 import texttable
 import yaml
+from click import ClickException
 from globus_compute_endpoint import __version__
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import (
@@ -33,7 +31,6 @@ from globus_compute_endpoint.endpoint.config.utils import get_config
 from globus_compute_endpoint.endpoint.interchange import EndpointInterchange
 from globus_compute_endpoint.endpoint.result_store import ResultStore
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds, update_url_port
-from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_sdk.sdk.client import Client
 from globus_sdk import AuthAPIError, GlobusAPIError, NetworkError
 
@@ -473,25 +470,11 @@ class Endpoint:
         endpoint_uuid,
         endpoint_config: UserEndpointConfig,
         log_to_console: bool,
-        no_color: bool,
         reg_info: dict,
         ep_info: dict,
         die_with_parent: bool = False,
         audit_fd: int | None = None,
     ):
-        # If we are running a full detached daemon then we will send the output to
-        # log files, otherwise we can piggy back on our stdout
-        if endpoint_config.detach_endpoint:
-            stdout: t.TextIO = open(
-                os.path.join(endpoint_dir, endpoint_config.stdout), "a+"
-            )
-            stderr: t.TextIO = open(
-                os.path.join(endpoint_dir, endpoint_config.stderr), "a+"
-            )
-        else:
-            stdout = sys.stdout
-            stderr = sys.stderr
-
         ostream = None
         if sys.stdout.isatty():
             ostream = sys.stdout
@@ -527,94 +510,7 @@ class Endpoint:
             raise
 
         try:
-            files_preserve = []
-            if audit_fd:
-                files_preserve.append(audit_fd)
-            context = daemon.DaemonContext(
-                working_directory=endpoint_dir,
-                umask=0o002,
-                stdout=stdout,
-                stderr=stderr,
-                detach_process=endpoint_config.detach_endpoint,
-                files_preserve=files_preserve,
-            )
-
-        except Exception:
-            log.exception(
-                "Caught exception while trying to setup endpoint context dirs"
-            )
-            exit(-1)
-
-        # place registration after everything else so that the endpoint will
-        # only be registered if everything else has been set up successfully
-        if not reg_info:
-            endpoint_uuid = Endpoint.get_endpoint_id(endpoint_dir) or endpoint_uuid
-            log.debug("Attempting registration; trying with eid: %s", endpoint_uuid)
-            try:
-                fx_client = Endpoint.get_funcx_client(endpoint_config)
-                reg_info = fx_client.register_endpoint(
-                    name=endpoint_dir.name,
-                    endpoint_id=endpoint_uuid,
-                    metadata=Endpoint.get_metadata(endpoint_config.source_content),
-                    multi_user=False,
-                    display_name=endpoint_config.display_name,
-                    allowed_functions=endpoint_config.allowed_functions,
-                    auth_policy=endpoint_config.authentication_policy,
-                    subscription_id=endpoint_config.subscription_id,
-                    high_assurance=endpoint_config.high_assurance,
-                    admins=endpoint_config.admins,
-                )
-
-            except GlobusAPIError as e:
-                blocked_msg = f"Endpoint registration blocked.  [{e.text}]"
-                log.warning(blocked_msg)
-                if ostream:
-                    print(blocked_msg, file=ostream)
-                if e.http_status in (
-                    HTTPStatus.CONFLICT,
-                    HTTPStatus.LOCKED,
-                    HTTPStatus.NOT_FOUND,
-                ):
-                    raise SystemExit(os.EX_UNAVAILABLE) from e
-                elif e.http_status in (
-                    HTTPStatus.BAD_REQUEST,
-                    HTTPStatus.UNPROCESSABLE_ENTITY,
-                ):
-                    raise SystemExit(os.EX_DATAERR) from e
-                raise
-
-            except NetworkError as e:
-                # the output of a NetworkError exception is huge and unhelpful, so
-                # it seems better to just stringify it here and get a concise error
-                log.exception(
-                    f"Caught exception while attempting endpoint registration: {e}"
-                )
-                msg = (
-                    "globus-compute-endpoint is unable to reach the Globus Compute "
-                    "service due to a network error.\n"
-                    "Please ensure the Globus Compute service address is reachable, "
-                    "then attempt restarting the endpoint."
-                )
-                log.critical(msg)
-                if ostream:
-                    print(msg, file=ostream)
-                exit(os.EX_TEMPFAIL)
-
-            ret_ep_uuid = reg_info.get("endpoint_id")
-            if endpoint_uuid and ret_ep_uuid != endpoint_uuid:
-                log.error(
-                    "Unexpected response from server: mismatched endpoint id."
-                    f"\n  Expected: {endpoint_uuid}, received: {ret_ep_uuid}"
-                )
-                exit(os.EX_SOFTWARE)
-
-        try:
-            endpoint_uuid = reg_info["endpoint_id"]
-        except KeyError:
-            log.error("Invalid credential structure")
-            exit(os.EX_DATAERR)
-
-        try:
+            ret_ep_uuid = reg_info["endpoint_id"]
             tq_info, rq_info, hbq_info = (
                 reg_info["task_queue_info"],
                 reg_info["result_queue_info"],
@@ -623,6 +519,15 @@ class Endpoint:
         except KeyError:
             log.error("Invalid credential structure")
             exit(os.EX_DATAERR)
+
+        if endpoint_uuid and ret_ep_uuid != endpoint_uuid:
+            log.error(
+                "Unexpected response from server: mismatched endpoint id."
+                f"\n  Expected: {endpoint_uuid}, received: {ret_ep_uuid}"
+            )
+            exit(os.EX_SOFTWARE)
+        else:
+            endpoint_uuid = ret_ep_uuid
 
         if endpoint_config.amqp_port is not None:
             for q_info in tq_info, rq_info, hbq_info:
@@ -648,23 +553,13 @@ class Endpoint:
         ptitle += f" [{setproctitle.getproctitle()}]"
         setproctitle.setproctitle(ptitle)
 
-        parent_pid = 0
         if die_with_parent:
             parent_pid = os.getppid()
-
-        log.debug("Launching endpoint daemon process")
-
-        # NOTE
-        # It's important that this log is emitted before we enter the daemon context
-        # because daemonization closes down everything, a log message inside the
-        # context won't write the currently configured loggers
-        logfile = endpoint_dir / "endpoint.log"
-        log.debug(
-            "Reconfiguring logging for daemonization. logfile: %s , debug: %s",
-            logfile,
-            self.debug,
-        )
-
+        else:
+            raise ClickException(
+                "This endpoint is not template capable and will not start. "
+                "(hint: globus-compute-endpoint migrate-to-template-capable)"
+            )
         if ostream:
             msg = f"Starting endpoint; registered ID: {endpoint_uuid}"
             if log_to_console:
@@ -672,63 +567,32 @@ class Endpoint:
                 msg = f"\n    {msg}\n"
             print(msg, file=ostream)
 
-        with contextlib.ExitStack() as stk:
-            stk.enter_context(context)
-            if endpoint_config.detach_endpoint:
-                # special case until daemon.DaemonContext logic removed
-                pid_path = Endpoint.pid_path(endpoint_dir)
-                pid_path.unlink(missing_ok=True)
+        now_tz = datetime.now().astimezone()
+        ep_info.update(
+            posix_username=pwd.getpwuid(os.getuid()).pw_name,
+            posix_uid=os.getuid(),
+            posix_gid=os.getgid(),
+            posix_groups=os.getgroups(),
+            posix_pid=os.getpid(),
+            posix_sid=os.getsid(os.getpid()),
+            config_raw=endpoint_config.source_content,
+            start_iso=now_tz.isoformat(),
+            start_unix=now_tz.timestamp(),
+        )
 
-                from globus_compute_endpoint.cli import _pidfile
-
-                pid_ctxt = _pidfile(pid_path, endpoint_config.heartbeat_period * 3)
-                stk.enter_context(pid_ctxt)
-
-            # Per DaemonContext implementation, and that we _don't_ pass stdin,
-            # fd 0 is already connected to devnull.  Unfortunately, there is an
-            # as-yet unknown interaction on Polaris (ALCF) that needs this
-            # connection setup *again*.  So, repeat what daemon context already
-            # did, and dup2 stdin from devnull to ... devnull.  (!@#$%^&*)
-            # On any other system, this should make no difference (same file!)
-            with open(os.devnull) as nullf:
-                if os.dup2(nullf.fileno(), 0) != 0:
-                    msg = "Unable to close stdin; endpoint will not start."
-                    log.critical(msg)
-                    raise Exception(msg)
-
-            setup_logging(
-                logfile=logfile,
-                debug=self.debug,
-                console_enabled=log_to_console,
-                no_color=no_color,
-            )
-
-            now_tz = datetime.now().astimezone()
-            ep_info.update(
-                posix_username=pwd.getpwuid(os.getuid()).pw_name,
-                posix_uid=os.getuid(),
-                posix_gid=os.getgid(),
-                posix_groups=os.getgroups(),
-                posix_pid=os.getpid(),
-                posix_sid=os.getsid(os.getpid()),
-                config_raw=endpoint_config.source_content,
-                start_iso=now_tz.isoformat(),
-                start_unix=now_tz.timestamp(),
-            )
-
-            Endpoint.daemon_launch(
-                endpoint_uuid,
-                endpoint_dir,
-                endpoint_config,
-                reg_info,
-                result_store,
-                parent_pid,
-                ep_info,
-                audit_fd,
-            )
+        Endpoint.start_interchange(
+            endpoint_uuid,
+            endpoint_dir,
+            endpoint_config,
+            reg_info,
+            result_store,
+            parent_pid,
+            ep_info,
+            audit_fd,
+        )
 
     @staticmethod
-    def daemon_launch(
+    def start_interchange(
         endpoint_uuid,
         endpoint_dir,
         endpoint_config: UserEndpointConfig,

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -1,9 +1,7 @@
-import json
 import os
 import pathlib
 import random
 import shutil
-import uuid
 from unittest import mock
 
 import pytest
@@ -69,67 +67,6 @@ def test_non_configured_endpoint(tmp_path):
         assert "no endpoint configuration" in result.stdout
 
 
-@pytest.mark.parametrize(
-    "display_name",
-    [
-        None,
-        "xyz",
-        "😎 Great display/.name",
-    ],
-)
-def test_start_endpoint_display_name(fs, display_name):
-    responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
-    )
-
-    ep = endpoint.Endpoint()
-    ep_conf = UserEndpointConfig(engine=mock.Mock())
-    ep_dir = pathlib.Path("/some/path/some_endpoint_name")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-    ep_conf.display_name = display_name
-
-    with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={}, ep_info={})
-    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
-
-    req = pyt_exc.value.__cause__._underlying_response.request
-    req_json = json.loads(req.body)
-    if display_name is not None:
-        assert display_name == req_json["display_name"]
-    else:
-        assert "display_name" not in req_json
-
-
-def test_start_endpoint_data_passthrough(fs):
-    responses.add(  # 404 == we are verifying the POST, not the response
-        responses.POST, _SVC_ADDY + "/v3/endpoints", json={}, status=404
-    )
-
-    ep = endpoint.Endpoint()
-    ep_conf = UserEndpointConfig(engine=mock.Mock())
-    ep_dir = pathlib.Path("/some/path/some_endpoint_name")
-    ep_dir.mkdir(parents=True, exist_ok=True)
-    ep_conf.allowed_functions = [uuid.uuid4() for _ in range(random.randint(1, 10))]
-    ep_conf.authentication_policy = str(uuid.uuid4())
-    ep_conf.subscription_id = str(uuid.uuid4())
-    ep_conf.admins = [uuid.uuid4() for _ in range(random.randint(1, 10))]
-    ep_conf.public = True
-
-    with pytest.raises(SystemExit) as pyt_exc:
-        ep.start_endpoint(ep_dir, None, ep_conf, False, True, reg_info={}, ep_info={})
-    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
-
-    req = pyt_exc.value.__cause__._underlying_response.request
-    req_json = json.loads(req.body)
-
-    assert len(req_json["allowed_functions"]) == len(ep_conf.allowed_functions)
-    assert req_json["allowed_functions"] == [str(f) for f in ep_conf.allowed_functions]
-    assert req_json["authentication_policy"] == str(ep_conf.authentication_policy)
-    assert req_json["subscription_uuid"] == str(ep_conf.subscription_id)
-    assert len(req_json["admins"]) == len(ep_conf.admins)
-    assert req_json["admins"] == [str(a) for a in ep_conf.admins]
-
-
 def test_stop_remote_endpoint(mocker):
     ep_uuid = "some-uuid"
     ep_dir = pathlib.Path("some_ep_dir") / "abc-endpoint"
@@ -163,10 +100,8 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
     endpoint_config = UserEndpointConfig(
         endpoint_setup=command,
         engine=mock.Mock(),
-        detach_endpoint=False,
     )
     log_to_console = False
-    no_color = True
     reg_info = {}
     ep_info = {}
 
@@ -178,7 +113,6 @@ def test_endpoint_setup_execution(mocker, tmp_path, randomstring):
                 endpoint_uuid,
                 endpoint_config,
                 log_to_console,
-                no_color,
                 reg_info,
                 ep_info,
             )

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -36,7 +36,6 @@ known_user_config_opts = {
     "heartbeat_threshold": int,
     "idle_heartbeats_soft": int,
     "idle_heartbeats_hard": int,
-    "detach_endpoint": False,
     "endpoint_setup": str,
     "endpoint_teardown": str,
     "log_dir": str,

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -3,7 +3,6 @@ import pathlib
 from unittest import mock
 
 import pytest
-import yaml
 from click import ClickException
 from globus_compute_endpoint.boot_persistence import (
     _systemd_service_name,
@@ -28,7 +27,6 @@ def fake_ep_dir(fs: fakefs.FakeFilesystem, ep_name) -> pathlib.Path:
     fs.create_dir(ep_dir)
     ep_config = Endpoint._config_file_path(ep_dir)
     ep_config.write_text("""
-detach_endpoint: false
 display_name: null
 engine:
     type: ThreadPoolEngine
@@ -68,19 +66,6 @@ def test_enable_on_boot_no_systemd(fake_ep_dir, mocker):
         enable_on_boot(fake_ep_dir, mock_app)
 
     assert "Systemd not found" in str(e)
-
-
-def test_enable_on_boot_detach_endpoint(fake_ep_dir, systemd_unit_dir):
-    mock_app = mock.Mock(spec=UserApp)
-    cfg_path = fake_ep_dir / "config.yaml"
-    cfg = yaml.safe_load(cfg_path.read_text())
-    del cfg["detach_endpoint"]
-    cfg_path.write_text(yaml.dump(cfg))
-
-    with pytest.raises(ClickException) as e:
-        enable_on_boot(fake_ep_dir, mock_app)
-
-    assert "cannot run in detached mode" in str(e)
 
 
 @pytest.mark.parametrize("exists", [True, False])

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -106,6 +106,13 @@ def mock_ep(gc_dir, ep_name):
 
 
 @pytest.fixture
+def mock_mep():
+    with mock.patch(f"{_MOCK_BASE}EndpointManager") as m:
+        m.return_value = m
+        yield m
+
+
+@pytest.fixture
 def mock_client():
     with mock.patch(f"{_MOCK_BASE}Client") as m:
         mock_client = mock.Mock(spec=Client)
@@ -130,6 +137,22 @@ def mock_get_config():
 
 
 @pytest.fixture
+def mock_load_config_yaml_mep():
+    conf = ManagerEndpointConfig()
+    with mock.patch(f"{_MOCK_BASE}load_config_yaml") as m:
+        m.return_value = conf
+        yield m
+
+
+@pytest.fixture
+def mock_get_config_mep():
+    conf = ManagerEndpointConfig()
+    with mock.patch(f"{_MOCK_BASE}get_config") as m:
+        m.return_value = conf
+        yield m
+
+
+@pytest.fixture
 def mock_render_config_user_template():
     with mock.patch(f"{_MOCK_BASE}render_config_user_template") as m:
         yield m
@@ -144,6 +167,42 @@ def mock_send_endpoint_startup_failure_to_amqp():
 @pytest.fixture
 def mock_daemon():
     with mock.patch(f"{_MOCK_BASE}daemon") as m:
+        yield m
+
+
+@pytest.fixture
+def mock__do_register_endpoint(ep_uuid):
+    with mock.patch(f"{_MOCK_BASE}_do_register_endpoint") as m:
+        m.return_value = {
+            "endpoint_id": ep_uuid,
+            "task_queue_info": {
+                "connection_url": "amqps://user:password@mq.fqdn",
+                "exchange": "some_exchange",
+                "queue": "some_queue",
+            },
+            "command_queue_info": {
+                "connection_url": "amqps://user:password@mq.fqdn",
+                "exchange": "some_exchange",
+                "queue": "some_queue",
+                "queue_publish_kwargs": {
+                    "exchange": "some_exchange",
+                    "routing_key": "some_key",
+                    "mandatory": True,
+                    "properties": {"delivery_mode": 2},
+                },
+            },
+            "heartbeat_queue_info": {
+                "connection_url": "amqps://user:password@mq.fqdn",
+                "exchange": "some_exchange",
+                "queue": "some_queue",
+                "queue_publish_kwargs": {
+                    "exchange": "some_exchange",
+                    "routing_key": "some_key",
+                    "mandatory": True,
+                    "properties": {"delivery_mode": 2},
+                },
+            },
+        }
         yield m
 
 
@@ -292,18 +351,28 @@ def test_start_endpoint_no_such_ep(run_line, mock_ep, ep_name):
 
 
 def test_start_endpoint_existing_ep(
-    run_line, mock_ep, make_endpoint_dir, ep_name, mock_client
+    run_line,
+    mock_mep,
+    make_manager_endpoint_dir,
+    ep_name,
+    mock_send_endpoint_startup_failure_to_amqp,
+    mock__do_register_endpoint,
+    mock_client,
 ):
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
     run_line(f"start {ep_name}")
-    mock_ep.start_endpoint.assert_called_once()
+    mock_mep.start.assert_called_once()
 
 
 def test_start_endpoint_already_running(
-    make_endpoint_dir, mock_client, ep_name, mock_send_endpoint_startup_failure_to_amqp
+    make_manager_endpoint_dir,
+    mock_client,
+    ep_name,
+    mock_send_endpoint_startup_failure_to_amqp,
+    mock__do_register_endpoint,
 ):
     """Check to ensure endpoint already active message prints to console"""
-    ep_dir = make_endpoint_dir()
+    ep_dir = make_manager_endpoint_dir()
     pid_path = Endpoint.pid_path(ep_dir)
     pid_path.write_text("12345")
     f = io.StringIO()
@@ -319,8 +388,15 @@ def test_start_endpoint_already_running(
     assert "remove the PID file" in serr, "Expect suggested action conveyed"
 
 
-def test_start_endpoint_stale(mock_ep, make_endpoint_dir, ep_name, mock_client):
-    ep_dir = make_endpoint_dir()
+def test_start_endpoint_stale(
+    mock_mep,
+    make_manager_endpoint_dir,
+    ep_name,
+    mock_client,
+    mock_send_endpoint_startup_failure_to_amqp,
+    mock__do_register_endpoint,
+):
+    ep_dir = make_manager_endpoint_dir()
     pid_path = Endpoint.pid_path(ep_dir)
     pid_path.write_text("12345")
     stale_time = time.time() - 95  # something larger than HB * 3
@@ -335,18 +411,13 @@ def test_start_endpoint_stale(mock_ep, make_endpoint_dir, ep_name, mock_client):
     assert "Removing PID file" in serr, "Expect action taken in warning"
 
 
-@pytest.mark.parametrize("is_uep", (False, True))
-def test_start_non_template_emits_upgrade_message(
-    mock_ep, make_endpoint_dir, is_uep, mock_client
-):
+def test_cannot_start_sep(mock_ep, make_endpoint_dir, mock_client):
     ep_dir = make_endpoint_dir()
-    f = io.StringIO()
-    with redirect_stdout(f):
-        cli._do_start_endpoint(
-            ep_dir=ep_dir, endpoint_uuid=None, die_with_parent=is_uep
-        )
+    with pytest.raises(ClickException) as pyt_e:
+        cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
 
-    assert ("migrate-to-template-capable" in f.getvalue()) is not is_uep
+    assert "not template capable" in str(pyt_e.value)
+    assert "will not start" in str(pyt_e.value)
 
 
 @pytest.mark.parametrize("cli_cmd", ["configure"])
@@ -362,16 +433,10 @@ def test_endpoint_uuid_name_not_supported(run_line, cli_cmd):
 @pytest.mark.parametrize(
     "stdin_data",
     [
-        (False, "..."),
-        (False, "()"),
-        (False, json.dumps([1, 2, 3])),
-        (False, json.dumps("abc")),
-        (True, "{}"),
-        (True, json.dumps({"amqp_creds": {}})),
-        (True, json.dumps({"config": "myconfig"})),
-        (True, json.dumps({"amqp_creds": {}, "config": ""})),
-        (True, json.dumps({"amqp_creds": {"a": 1}, "config": "myconfig"})),
-        (True, json.dumps({"amqp_creds": {}, "config": "myconfig", "audit_fd": 1})),
+        json.dumps({"amqp_creds": {"foo": "bar"}}),
+        json.dumps({"amqp_creds": {"baz": "qux"}, "config": ""}),
+        json.dumps({"amqp_creds": {"a": 1}, "config": "myconfig"}),
+        json.dumps({"amqp_creds": {"b": 2}, "config": "myconfig", "audit_fd": 1}),
     ],
 )
 def test_start_ep_reads_stdin(
@@ -382,10 +447,7 @@ def test_start_ep_reads_stdin(
     make_endpoint_dir,
     stdin_data,
     ep_name,
-    randomstring,
 ):
-    data_is_valid, data = stdin_data
-
     mock_load_conf = mocker.patch(f"{_MOCK_BASE}load_config_yaml")
     mock_load_conf.return_value = mock_get_config.return_value
 
@@ -393,39 +455,29 @@ def test_start_ep_reads_stdin(
     mock__do_register_endpoint = mocker.patch(f"{_MOCK_BASE}_do_register_endpoint")
     mock__do_register_endpoint.return_value = remote_register_endpoint_response
 
-    mock_log = mocker.patch(f"{_MOCK_BASE}log")
     mock_sys = mocker.patch(f"{_MOCK_BASE}sys")
     mock_sys.stdin.closed = False
     mock_sys.stdin.isatty.return_value = False
-    mock_sys.stdin.read.return_value = data
+    mock_sys.stdin.read.return_value = stdin_data
 
     make_endpoint_dir()
 
-    run_line(f"start {ep_name}")
+    run_line(f"start {ep_name} --die-with-parent")
     assert mock_ep.start_endpoint.called
     s_ep_a, _ = mock_ep.start_endpoint.call_args
-    reg_info_found = s_ep_a[5]
-    audit_fd_found = s_ep_a[8]
+    reg_info_found = s_ep_a[4]
+    audit_fd_found = s_ep_a[7]
 
-    if data_is_valid:
-        data_dict = json.loads(data)
-        reg_info = data_dict.get("amqp_creds", remote_register_endpoint_response)
-        config_str = data_dict.get("config")
-        audit_fd = data_dict.get("audit_fd")
+    data_dict = json.loads(stdin_data)
+    reg_info = data_dict.get("amqp_creds", remote_register_endpoint_response)
+    config_str = data_dict.get("config")
+    audit_fd = data_dict.get("audit_fd")
 
-        assert reg_info_found == reg_info
-        assert audit_fd_found == audit_fd
-        if config_str:
-            config_str_found = mock_load_conf.call_args[0][0]
-            assert config_str_found == config_str
-
-    else:
-        assert mock_get_config.called
-        assert mock__do_register_endpoint.called
-        assert mock_log.debug.called
-        a, k = mock_log.debug.call_args
-        assert "Invalid info on stdin" in a[0]
-        assert reg_info_found == remote_register_endpoint_response
+    assert reg_info_found == reg_info
+    assert audit_fd_found == audit_fd
+    if config_str:
+        config_str_found = mock_load_conf.call_args[0][0]
+        assert config_str_found == config_str
 
 
 @pytest.mark.parametrize("fn_count", range(-1, 5))
@@ -450,14 +502,63 @@ def test_start_ep_stdin_allowed_fns_overrides_conf(
     mock_sys = mocker.patch(f"{_MOCK_BASE}sys")
     mock_sys.stdin.closed = False
     mock_sys.stdin.isatty.return_value = False
-    mock_sys.stdin.read.return_value = json.dumps({"allowed_functions": allowed_fns})
+    mock_sys.stdin.read.return_value = json.dumps(
+        {"amqp_creds": {"foo": "bar"}, "allowed_functions": allowed_fns}
+    )
 
     make_endpoint_dir()
 
-    run_line(f"start {ep_name}")
+    run_line(f"start {ep_name} --die-with-parent")
     assert mock_ep.start_endpoint.called
     (_, _, found_conf, *_), _k = mock_ep.start_endpoint.call_args
     assert found_conf.allowed_functions == allowed_fns, "allowed field not overridden!"
+
+
+@pytest.mark.parametrize(
+    "display_name",
+    [
+        None,
+        "xyz",
+        "😎 Great display/.name",
+    ],
+)
+def test__do_register_endpoint_data_passthrough(
+    make_manager_endpoint_dir, mock_client, display_name
+):
+    class FakeGlobusAPIError(GlobusAPIError):
+        def __init__(self, http_status):
+            self.http_status = http_status
+
+        @property
+        def text(self):
+            return "Conflict"
+
+    mock_client.register_endpoint.side_effect = FakeGlobusAPIError(HTTPStatus.CONFLICT)
+
+    ep_dir = make_manager_endpoint_dir()
+    ep_conf = ManagerEndpointConfig()
+    ep_conf.allowed_functions = [uuid.uuid4() for _ in range(random.randint(1, 10))]
+    ep_conf.authentication_policy = str(uuid.uuid4())
+    ep_conf.subscription_id = str(uuid.uuid4())
+    ep_conf.admins = [uuid.uuid4() for _ in range(random.randint(1, 10))]
+    ep_conf.public = True
+    ep_conf.display_name = display_name
+
+    with pytest.raises(SystemExit) as pyt_exc:
+        cli._do_register_endpoint(ep_dir, ep_conf, None)
+    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
+
+    kwargs = mock_client.register_endpoint.call_args[1]
+
+    assert len(kwargs["allowed_functions"]) == len(ep_conf.allowed_functions)
+    assert list(kwargs["allowed_functions"]) == [
+        str(f) for f in ep_conf.allowed_functions
+    ]
+    assert kwargs["auth_policy"] == str(ep_conf.authentication_policy)
+    assert kwargs["subscription_id"] == str(ep_conf.subscription_id)
+    assert len(kwargs["admins"]) == len(ep_conf.admins)
+    assert list(kwargs["admins"]) == [str(a) for a in ep_conf.admins]
+    assert kwargs["display_name"] == display_name
 
 
 @pytest.mark.parametrize("use_uuid", (True, False))
@@ -471,13 +572,13 @@ def test_stop_endpoint(
 
 
 def test_restart_endpoint_does_start_and_stop(
-    run_line, mock_ep, make_endpoint_dir, ep_name, mock_client
+    run_line, mock_ep, mock_mep, make_manager_endpoint_dir, ep_name, mock_client
 ):
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
     run_line(f"restart {ep_name}")
 
     mock_ep.stop_endpoint.assert_called_once()
-    mock_ep.start_endpoint.assert_called_once()
+    mock_mep.start.assert_called_once()
 
 
 @responses.activate
@@ -499,7 +600,7 @@ def test__do_register_endpoint_registration_blocked(
     get_standard_compute_client,
     randomstring,
     register_endpoint_failure_response,
-    make_endpoint_dir,
+    make_manager_endpoint_dir,
     ep_uuid,
 ):
     mock_gcc = get_standard_compute_client()
@@ -510,12 +611,12 @@ def test__do_register_endpoint_registration_blocked(
     some_err = randomstring()
     register_endpoint_failure_response(ep_uuid, status_code, some_err)
 
-    ep_dir = make_endpoint_dir(ep_uuid=ep_uuid)
+    ep_dir = make_manager_endpoint_dir(ep_uuid=ep_uuid)
 
     f = io.StringIO()
     with redirect_stdout(f):
         with pytest.raises((GlobusAPIError, SystemExit)) as pyexc:
-            cli._do_register_endpoint(ep_dir, UserEndpointConfig(), ep_uuid)
+            cli._do_register_endpoint(ep_dir, ManagerEndpointConfig(), ep_uuid)
         stdout_msg = f.getvalue()
 
     assert mock_log.warning.called
@@ -536,11 +637,11 @@ def test__do_register_endpoint_registration_blocked(
 
 @pytest.mark.parametrize("with_json", (False, True))
 def test__do_register_endpoint_provided_endpoint_id(
-    mock_client, ep_uuid, make_endpoint_dir, with_json
+    mock_client, ep_uuid, make_manager_endpoint_dir, with_json
 ):
-    ep_dir = make_endpoint_dir(ep_uuid=ep_uuid if with_json else None)
+    ep_dir = make_manager_endpoint_dir(ep_uuid=ep_uuid if with_json else None)
 
-    cli._do_register_endpoint(ep_dir, UserEndpointConfig(), ep_uuid)
+    cli._do_register_endpoint(ep_dir, ManagerEndpointConfig(), ep_uuid)
 
     _a, k = mock_client.register_endpoint.call_args
     assert k["endpoint_id"] == ep_uuid
@@ -686,9 +787,7 @@ def test_configure_validates_name(mock_command_ensure, run_line):
         ["ep2", "abc 😎 /.great"],
     ],
 )
-def test_start_ep_display_name_in_config(
-    run_line, mock_command_ensure, make_endpoint_dir, display_test
-):
+def test_start_ep_display_name_in_config(run_line, mock_command_ensure, display_test):
     dir_name, display_name = display_test
 
     conf = mock_command_ensure.endpoint_config_dir / dir_name / "config.yaml"
@@ -712,7 +811,7 @@ def test_start_ep_display_name_in_config(
     ),
 )
 def test_start_ep_high_assurance_in_config(
-    run_line, mock_command_ensure, make_endpoint_dir, ep_name, set_ha
+    run_line, mock_command_ensure, ep_name, set_ha
 ):
     conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
     configure_arg = ""
@@ -734,9 +833,7 @@ def test_start_ep_high_assurance_in_config(
         assert conf_dict.get("high_assurance", False) is False
 
 
-def test_configure_ep_auth_policy_in_config(
-    run_line, mock_command_ensure, make_endpoint_dir
-):
+def test_configure_ep_auth_policy_in_config(run_line, mock_command_ensure):
     ep_name = "my-ep"
     auth_policy = str(uuid.uuid4())
     conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
@@ -749,9 +846,7 @@ def test_configure_ep_auth_policy_in_config(
     assert conf_dict["authentication_policy"] == auth_policy
 
 
-def test_configure_ep_subscription_id_in_config(
-    run_line, mock_command_ensure, make_endpoint_dir
-):
+def test_configure_ep_subscription_id_in_config(run_line, mock_command_ensure):
     ep_name = "my-ep"
     subscription_id = str(uuid.uuid4())
     conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
@@ -917,24 +1012,24 @@ def test_start_ep_incorrect_config_py(
 
 @mock.patch("globus_compute_endpoint.endpoint.config.utils.load_config_yaml")
 def test_start_ep_config_py_takes_precedence(
-    mock_load, run_line, mock_ep, make_endpoint_dir, ep_name, mock_client
+    mock_load, run_line, mock_mep, make_manager_endpoint_dir, ep_name, mock_client
 ):
-    conf_py = make_endpoint_dir() / "config.py"
+    conf_py = make_manager_endpoint_dir() / "config.py"
     conf_py.write_text(
-        "from globus_compute_endpoint.endpoint.config import UserEndpointConfig"
-        "\nconfig = UserEndpointConfig()"
+        "from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig"
+        "\nconfig = ManagerEndpointConfig()"
     )
 
     run_line(f"start {ep_name}")
-    assert mock_ep.start_endpoint.called
+    assert mock_mep.start.called
     assert not mock_load.called, "Key outcome: config.py takes precedence"
 
 
 def test_start_ep_umask_set_restrictive(
-    run_line, make_endpoint_dir, ep_name, mock_ep, mock_client
+    run_line, make_manager_endpoint_dir, ep_name, mock_mep, mock_client
 ):
     orig_umask = os.umask(0)
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
     run_line(f"start {ep_name}")
     assert os.umask(orig_umask) == 0o077
 
@@ -942,13 +1037,13 @@ def test_start_ep_umask_set_restrictive(
 def test_start_ep_detached(
     run_line,
     mock_command_ensure,
-    make_endpoint_dir,
+    make_manager_endpoint_dir,
     ep_name,
     mock_daemon,
     mock_client,
     mock_send_endpoint_startup_failure_to_amqp,
 ):
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
 
     mock_daemon_context_class = mock_daemon.DaemonContext
     mock_daemon_context_class.return_value.__enter__.side_effect = Exception(
@@ -1005,25 +1100,6 @@ def test_delete_endpoint_with_malformed_config_sc28515(
     assert conf_dir.exists() and conf_dir.is_dir()
     run_line(f"delete {ep_name} --yes --force")
     assert not conf_dir.exists()
-
-
-@pytest.mark.parametrize("die_with_parent", [True, False])
-def test_die_with_parent_detached(
-    mock_get_config,
-    run_line,
-    mock_ep,
-    die_with_parent,
-    ep_name,
-    make_endpoint_dir,
-    mock_client,
-):
-    make_endpoint_dir()
-
-    if die_with_parent:
-        run_line(f"start {ep_name} --die-with-parent")
-    else:
-        run_line(f"start {ep_name}")
-    assert mock_get_config.return_value.detach_endpoint is (not die_with_parent)
 
 
 def test_python_exec(mocker: MockFixture, run_line: t.Callable):
@@ -1092,14 +1168,14 @@ def test_get_endpoint_by_name_or_uuid_error_message(tmp_path, run_line, data):
 def test_invalid_grant_triggers_login_if_interactive(
     mocker: MockFixture,
     run_line,
-    mock_ep,
-    make_endpoint_dir,
+    mock_mep,
+    make_manager_endpoint_dir,
     mock_send_endpoint_startup_failure_to_amqp,
     ep_name,
     mock_client,
     is_tty,
 ):
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
 
     mock_resp = mock.MagicMock(
         status_code=400,
@@ -1107,8 +1183,8 @@ def test_invalid_grant_triggers_login_if_interactive(
         text='{"error":"invalid_grant"}',
     )
     mocker.patch.object(
-        mock_ep,
-        "start_endpoint",
+        mock_mep,
+        "start",
         side_effect=globus_sdk.AuthAPIError(r=mock_resp),
     )
     exc_base = "globus_compute_endpoint.exception_handling"
@@ -1126,8 +1202,8 @@ def test_invalid_grant_triggers_login_if_interactive(
 @pytest.mark.parametrize(
     "cmd,ep_method,auth_err_msg",
     [
-        ("start", "start_endpoint", '{"error":"something else"}'),
-        ("start", "start_endpoint", ""),
+        ("start", "start", '{"error":"something else"}'),
+        ("start", "start", ""),
         ("stop", "stop_endpoint", "err_msg"),
         ("delete --yes", "delete_endpoint", "err_msg"),
     ],
@@ -1135,8 +1211,9 @@ def test_invalid_grant_triggers_login_if_interactive(
 def test_handle_globus_auth_error(
     mocker: MockFixture,
     run_line,
+    mock_mep,
     mock_ep,
-    make_endpoint_dir,
+    make_manager_endpoint_dir,
     ep_name,
     cmd,
     ep_method,
@@ -1144,7 +1221,7 @@ def test_handle_globus_auth_error(
     mock_client,
     mock_send_endpoint_startup_failure_to_amqp,
 ):
-    make_endpoint_dir()
+    make_manager_endpoint_dir()
 
     mock_log = mocker.patch("globus_compute_endpoint.exception_handling.log")
     mock_resp = mock.MagicMock(
@@ -1152,11 +1229,13 @@ def test_handle_globus_auth_error(
         reason="Bad Request",
         text=auth_err_msg,
     )
-    mocker.patch.object(
-        mock_ep,
-        ep_method,
-        side_effect=globus_sdk.AuthAPIError(r=mock_resp),
-    )
+    for obj in (mock_ep, mock_mep):
+        if hasattr(obj, ep_method):
+            mocker.patch.object(
+                obj,
+                ep_method,
+                side_effect=globus_sdk.AuthAPIError(r=mock_resp),
+            )
 
     res = run_line(f"{cmd} {ep_name}", assert_exit_code=os.EX_NOPERM)
 

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -73,11 +73,8 @@ def _get_cls_kwds(cls) -> set[str]:
 
 def test_config_opts_accounted_for_in_tests():
     kwds = _get_cls_kwds(UserEndpointConfig)
-    kwds.remove("multi_user")  # special case deprecated argument
     assert set(known_user_config_opts) == kwds
     kwds = _get_cls_kwds(ManagerEndpointConfig)
-    kwds.remove("multi_user")  # special case deprecated argument
-    kwds.remove("force_mu_allow_same_user")  # special case deprecated argument
     assert set(known_manager_config_opts) == kwds
 
 
@@ -88,11 +85,13 @@ def test_extra_opts_disallowed():
         load_config_yaml(serde_yaml)
     assert "does_not_exist" in str(pyt_e.value)
 
-    conf = {"does_not_exist": True, "multi_user": True}
+    conf = {"does_not_exist": True, "multi_user": True, "display_name": "foo"}
     serde_yaml = yaml.safe_dump(conf)
     with pytest.raises(ClickException) as pyt_e:
         load_config_yaml(serde_yaml)
     assert "does_not_exist" in str(pyt_e.value)
+    assert "multi_user" in str(pyt_e.value)
+    assert "display_name" not in str(pyt_e.value)
 
 
 def test_load_user_endpoint_config_minimal():
@@ -621,7 +620,7 @@ def test_load_user_config_template_valid_extensions(
     conf_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     template_path = conf_dir / f"user_config_template{ext}"
-    template_str = "multi_user: true"
+    template_str = "display_name: foo"
     template_path.write_text(template_str)
 
     assert load_user_config_template(template_path) == template_str

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -186,7 +186,7 @@ def test_configs_repr_default_kwargs():
 def test_userconfig_repr_nondefault_kwargs(
     randomstring, kw, cls, get_random_of_datatype
 ):
-    if kw in ("engine", "detach_endpoint"):
+    if kw == "engine":
         return
 
     val = get_random_of_datatype(cls)
@@ -228,20 +228,3 @@ def test_engine_model_objects_allow_extra():
         }
     }
     UserEndpointConfigModel(**config_dict).engine.shutdown()
-
-
-@pytest.mark.parametrize("multi_user", (True, False))
-@pytest.mark.parametrize("config_class", (UserEndpointConfig, ManagerEndpointConfig))
-def test_multi_user_deprecated(multi_user, config_class):
-    with pytest.deprecated_call() as pyt_warns:
-        config_class(multi_user=multi_user)
-
-    assert "multi_user" in str(pyt_warns.list[0].message)
-
-
-@pytest.mark.parametrize("detach_endpoint", (True, False))
-def test_detach_endpoint_deprecated(detach_endpoint):
-    with pytest.deprecated_call() as pyt_warns:
-        UserEndpointConfig(detach_endpoint=detach_endpoint)
-
-    assert "detach_endpoint" in str(pyt_warns.list[0].message)

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -14,12 +14,10 @@ import uuid
 from collections import namedtuple
 from contextlib import redirect_stdout
 from datetime import datetime
-from http import HTTPStatus
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
-import requests
 import yaml
 from globus_compute_endpoint.endpoint import endpoint
 from globus_compute_endpoint.endpoint.config import (
@@ -33,7 +31,7 @@ from globus_compute_endpoint.engines import (
     ThreadPoolEngine,
 )
 from globus_compute_sdk import Client
-from globus_sdk import GlobusAPIError, NetworkError
+from globus_sdk import NetworkError
 
 _mock_base = "globus_compute_endpoint.endpoint.endpoint."
 
@@ -54,12 +52,6 @@ def mock_log():
 
 
 @pytest.fixture
-def mock_daemon():
-    with mock.patch(f"{_mock_base}daemon") as m:
-        yield m
-
-
-@pytest.fixture
 def mock_gcc(mock_reg_info):
     _gcc = mock.Mock(spec=Client)
     _gcc.register_endpoint.return_value = mock_reg_info
@@ -75,7 +67,7 @@ def mock_get_client(mock_gcc):
 
 @pytest.fixture
 def mock_launch():
-    with mock.patch(f"{_mock_base}Endpoint.daemon_launch") as m:
+    with mock.patch(f"{_mock_base}Endpoint.start_interchange") as m:
         yield m
 
 
@@ -87,7 +79,7 @@ def mock_get_config():
 
 @pytest.fixture
 def conf():
-    _conf = UserEndpointConfig(engine=ThreadPoolEngine(), detach_endpoint=False)
+    _conf = UserEndpointConfig(engine=ThreadPoolEngine())
     _conf.source_content = "# test source content"
     _conf.source_content += "\nengine:\n  type: ThreadPoolEngine"
     yield _conf
@@ -99,8 +91,7 @@ def mock_ep_data(fs, conf):
     ep_dir = pathlib.Path("/some/path/mock_endpoint")
     ep_dir.mkdir(parents=True, exist_ok=True)
     log_to_console = False
-    no_color = True
-    yield ep, ep_dir, log_to_console, no_color, conf
+    yield ep, ep_dir, log_to_console, conf
 
 
 @pytest.fixture
@@ -328,7 +319,6 @@ def test_start_without_engine(caplog, conf_dir, conf):
             endpoint_uuid=None,
             endpoint_config=conf,
             log_to_console=False,
-            no_color=True,
             reg_info={},
             ep_info={},
         )
@@ -353,7 +343,6 @@ def test_start_ha_non_compliant(caplog, randomstring, mock_print, conf_dir, conf
             endpoint_uuid=None,
             endpoint_config=conf,
             log_to_console=False,
-            no_color=True,
             reg_info={},
             ep_info={},
         )
@@ -364,47 +353,21 @@ def test_start_ha_non_compliant(caplog, randomstring, mock_print, conf_dir, conf
     assert exc_str in r.message, "Verify expected path tested"
 
 
-def test_start_endpoint_no_reg_provided_registers(
-    mock_print,
-    mock_daemon,
-    mock_launch,
-    mock_log,
-    mock_get_client,
-    mock_ep_data,
-    ep_uuid,
-):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-
-    ep_json_p = ep_dir / "endpoint.json"
-    assert not ep_json_p.exists(), "Verify test setup"
-
-    ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
-    assert mock_launch.called
-
-    ep_data = json.load(ep_json_p.open())
-    assert ep_data["endpoint_id"] == ep_uuid, "Expect id saved for reregistrations"
-
-
 def test_endpoint_needs_no_client_if_reg_info(
-    mock_get_client, mock_daemon, mock_launch, mock_ep_data, mock_reg_info, ep_uuid
+    mock_get_client, mock_launch, mock_ep_data, mock_reg_info, ep_uuid
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep.start_endpoint(
+        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+    )
     assert not mock_get_client.called, "No need for Client!"
     assert mock_launch.called, "Registration given; should start"
-
-    mock_launch.reset_mock()
-    ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
-    assert mock_get_client.called, "Need registration info, need Client"
-    assert mock_launch.called, "Collects registration; should start"
 
 
 def test_start_endpoint_redacts_url_creds_from_logs(
     mock_print,
-    mock_daemon,
     mock_launch,
     mock_log,
     mock_ep_data,
@@ -413,9 +376,11 @@ def test_start_endpoint_redacts_url_creds_from_logs(
     uname,
     pword,
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
+    ep.start_endpoint(
+        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+    )
     assert mock_launch.called, "Should launch successfully"
 
     debug_args = "\n".join(str((a, k)) for a, k in mock_log.debug.call_args_list)
@@ -425,14 +390,16 @@ def test_start_endpoint_redacts_url_creds_from_logs(
 
 
 def test_start_endpoint_populates_ep_static_info(
-    mock_print, mock_daemon, mock_ep_data, mock_reg_info, ep_uuid, randomstring
+    mock_print, mock_ep_data, mock_reg_info, ep_uuid, randomstring
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
     canary_value = randomstring()
     ep_info = {"canary": canary_value}
-    with mock.patch(f"{_mock_base}Endpoint.daemon_launch") as mock_launch:
-        ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info=ep_info)
+    with mock.patch(f"{_mock_base}Endpoint.start_interchange") as mock_launch:
+        ep.start_endpoint(
+            *ep_args, reg_info=mock_reg_info, ep_info=ep_info, die_with_parent=True
+        )
     assert mock_launch.called, "Should launch successfully"
 
     (*_, found, _audit_fd), _k = mock_launch.call_args
@@ -449,26 +416,6 @@ def test_start_endpoint_populates_ep_static_info(
     assert found["posix_pid"] == os.getpid()
     assert found["posix_sid"] == os.getsid(os.getpid())
     assert found["config_raw"] == ep_conf.source_content
-
-
-def test_start_endpoint_network_error(
-    mock_log, mock_gcc, mock_get_client, mock_ep_data, ep_uuid
-):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-
-    mock_gcc.register_endpoint.side_effect = NetworkError("foo", Exception)
-
-    f = io.StringIO()
-    f.isatty = lambda: True
-    with redirect_stdout(f):
-        with pytest.raises(SystemExit) as pytest_exc:
-            ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
-
-    assert pytest_exc.value.code == os.EX_TEMPFAIL
-    assert "exception while attempting" in mock_log.exception.call_args[0][0]
-    assert "unable to reach the Globus Compute" in mock_log.critical.call_args[0][0]
-    assert "unable to reach the Globus Compute" in f.getvalue()  # stdout
 
 
 def test_delete_endpoint_network_error(
@@ -488,91 +435,6 @@ def test_delete_endpoint_network_error(
     assert "could not be deleted from the web" in mock_log.warning.call_args[0][0]
     assert "unable to reach the Globus Compute" in mock_log.critical.call_args[0][0]
     assert "unable to reach the Globus Compute" in f.getvalue()  # stdout
-
-
-def test_register_endpoint_invalid_response(
-    mock_log, ep_uuid, other_endpoint_id, mock_gcc, mock_get_client, mock_ep_data
-):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-
-    mock_gcc.register_endpoint.return_value = {"endpoint_id": other_endpoint_id}
-
-    with pytest.raises(SystemExit) as pytest_exc:
-        ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
-
-    assert pytest_exc.value.code == os.EX_SOFTWARE
-    a, _k = mock_log.error.call_args
-    for expected in (
-        "mismatched endpoint id",
-        "Expected",
-        "received",
-        ep_uuid,
-        other_endpoint_id,
-    ):
-        assert expected in a[0], "Expect contextually helpful info in .error() call"
-
-
-@pytest.mark.parametrize(
-    "exit_code,status_code",
-    (
-        (os.EX_UNAVAILABLE, HTTPStatus.CONFLICT),
-        (os.EX_UNAVAILABLE, HTTPStatus.LOCKED),
-        (os.EX_UNAVAILABLE, HTTPStatus.NOT_FOUND),
-        (os.EX_DATAERR, HTTPStatus.BAD_REQUEST),
-        (os.EX_DATAERR, HTTPStatus.UNPROCESSABLE_ENTITY),
-        ("Error", 418),  # IM_A_TEAPOT
-    ),
-)
-def test_register_endpoint_blocked(
-    mock_log,
-    mock_gcc,
-    mock_get_client,
-    mock_ep_data,
-    randomstring,
-    exit_code,
-    status_code,
-    ep_uuid,
-):
-    """
-    Check to ensure endpoint registration escalates up with API error
-    """
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-
-    some_err = randomstring()
-    res = requests.Response()
-    res.headers = {"Content-Type": "application/json"}
-    res._content = json.dumps({"msg": some_err}).encode()
-    res.status_code = status_code
-    res.request = requests.Request("POST")
-
-    mock_gcc.register_endpoint.side_effect = GlobusAPIError(res)
-
-    f = io.StringIO()
-    f.isatty = lambda: True
-    with redirect_stdout(f):
-        with pytest.raises((GlobusAPIError, SystemExit)) as pytexc:
-            ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
-        stdout_msg = f.getvalue()
-
-    assert mock_log.warning.called
-    a, *_ = mock_log.warning.call_args
-    assert some_err in str(a), "Expected upstream response still shared"
-
-    assert some_err in stdout_msg, f"Expecting error message in stdout ({stdout_msg})"
-
-    if hasattr(pytexc.value, "text"):
-        # Globus AuthAPIError has the .text field filled in from the response
-        assert some_err in str(pytexc.value.text), "Expecting custom error text"
-    else:
-        # Otherwise it's just SystemExit(exit_code)
-        assert pytexc.value.code == exit_code, "Expecting meaningful exit code"
-
-    if exit_code == "Error":
-        # The other route tests SystemExit; nominally this route is an unhandled
-        # traceback -- good.  We should _not_ blanket hide all exceptions.
-        assert pytexc.value.http_status == status_code
 
 
 def test_list_endpoints_none_configured(mock_ep_get, table_buf):
@@ -654,29 +516,6 @@ def test_pid_file_check(fs, is_running, is_active):
     assert pid_status["active"] is is_active
 
 
-def test_daemon_creates_pid(
-    randomstring, mock_print, mock_ep_data, mock_reg_info, ep_uuid
-):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_conf.detach_endpoint = True
-
-    mock_stk = mock.MagicMock()
-    mock_stk.__enter__.return_value = mock_stk
-    mock_stk.enter_context.side_effect = (None, MemoryError)
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
-
-    assert ep_conf.detach_endpoint, "Verify test setup and raison d'etre"
-    with mock.patch(f"{_mock_base}contextlib.ExitStack", return_value=mock_stk):
-        with pytest.raises(MemoryError):
-            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
-
-    a, k = mock_stk.enter_context.call_args
-    contextmanager_generator = a[0]
-
-    # awful test, but a temporary measure until v4, when we remove daemon context
-    assert contextmanager_generator.func.__name__ == "_pidfile"
-
-
 @pytest.mark.parametrize(
     "engine_cls", (GlobusComputeEngine, ThreadPoolEngine, ProcessPoolEngine)
 )
@@ -719,17 +558,19 @@ def test_endpoint_get_metadata(mocker, engine_cls):
 def test_endpoint_sets_process_title(
     randomstring, mock_ep_data, env, mock_reg_info, ep_uuid
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_conf.environment = env
 
     orig_proc_title = randomstring()
 
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
     with mock.patch(f"{_mock_base}setproctitle", spec=True) as mock_spt:
         mock_spt.getproctitle.return_value = orig_proc_title
         mock_spt.setproctitle.side_effect = StopIteration("Sentinel")
         with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+            ep.start_endpoint(
+                *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+            )
 
     a, _k = mock_spt.setproctitle.call_args
     assert a[0].startswith(
@@ -745,18 +586,20 @@ def test_endpoint_sets_process_title(
 
 @pytest.mark.parametrize("port", [random.randint(0, 65535)])
 def test_endpoint_respects_port(mock_ep_data, port, mock_reg_info, ep_uuid):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_conf.amqp_port = port
 
     tq_url = mock_reg_info["task_queue_info"]["connection_url"]
     rq_url = mock_reg_info["result_queue_info"]["connection_url"]
     hbq_url = mock_reg_info["heartbeat_queue_info"]["connection_url"]
 
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
     with mock.patch(f"{_mock_base}update_url_port", spec=True) as mock_upd:
         mock_upd.side_effect = (None, None, StopIteration("Sentinel"))
         with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
+            ep.start_endpoint(
+                *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+            )
 
     for (a, _), exp_url in zip(mock_upd.call_args_list, (tq_url, rq_url, hbq_url)):
         assert a == (exp_url, port)
@@ -778,9 +621,9 @@ def test_endpoint_sets_owner_only_access(tmp_path, umask, mask, idmap):
 
 
 def test_always_prints_endpoint_id_to_terminal(
-    mock_daemon, mock_launch, mocker, mock_ep_data, mock_reg_info
+    mock_launch, mocker, mock_ep_data, mock_reg_info
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_id = str(uuid.uuid4())
 
     mock_dup2 = mocker.patch(f"{_mock_base}os.dup2")
@@ -793,7 +636,13 @@ def test_always_prints_endpoint_id_to_terminal(
 
     mock_sys.stdout.isatty.return_value = True
     ep.start_endpoint(
-        ep_dir, ep_id, ep_conf, log_to_console, no_color, reg_info, ep_info={}
+        ep_dir,
+        ep_id,
+        ep_conf,
+        log_to_console,
+        reg_info,
+        ep_info={},
+        die_with_parent=True,
     )
 
     assert mock_sys.stdout.write.called
@@ -804,7 +653,13 @@ def test_always_prints_endpoint_id_to_terminal(
     mock_sys.stdout.isatty.return_value = False
     mock_sys.stderr.isatty.return_value = True
     ep.start_endpoint(
-        ep_dir, ep_id, ep_conf, log_to_console, no_color, reg_info, ep_info={}
+        ep_dir,
+        ep_id,
+        ep_conf,
+        log_to_console,
+        reg_info,
+        ep_info={},
+        die_with_parent=True,
     )
 
     assert not mock_sys.stdout.write.called
@@ -813,7 +668,13 @@ def test_always_prints_endpoint_id_to_terminal(
     mock_sys.reset_mock()
     mock_sys.stderr.isatty.return_value = False
     ep.start_endpoint(
-        ep_dir, ep_id, ep_conf, log_to_console, no_color, reg_info, ep_info={}
+        ep_dir,
+        ep_id,
+        ep_conf,
+        log_to_console,
+        reg_info,
+        ep_info={},
+        die_with_parent=True,
     )
 
     assert not mock_sys.stdout.write.called
@@ -898,44 +759,40 @@ def test_get_endpoint_id(tmp_path: pathlib.Path, json_exists: bool, ep_uuid):
 
 def test_handles_provided_endpoint_id_no_json(
     mock_print,
-    mock_daemon,
     mock_launch,
-    mock_gcc,
-    mock_get_client,
-    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, bool, UserEndpointConfig],
+    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, UserEndpointConfig],
     mock_reg_info: dict,
     ep_uuid,
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console, no_color)
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    mock_gcc.register_endpoint.return_value = mock_reg_info
-    ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
+    ep.start_endpoint(
+        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+    )
 
-    _a, k = mock_gcc.register_endpoint.call_args
-    assert k["endpoint_id"] == ep_uuid
+    a, _k = mock_launch.call_args
+    assert a[0] == ep_uuid
 
 
 def test_handles_provided_endpoint_id_with_json(
     mock_print,
-    mock_daemon,
     mock_launch,
-    mock_gcc,
-    mock_get_client,
-    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, bool, UserEndpointConfig],
+    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, UserEndpointConfig],
     mock_reg_info: dict,
     ep_uuid,
 ):
-    ep, ep_dir, log_to_console, no_color, ep_conf = mock_ep_data
-    provided_ep_uuid_str = str(uuid.uuid4())
-    ep_args = (ep_dir, provided_ep_uuid_str, ep_conf, log_to_console, no_color)
+    ep, ep_dir, log_to_console, ep_conf = mock_ep_data
+    ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
     ep_json = ep_dir / "endpoint.json"
-    ep_json.write_text(json.dumps({"endpoint_id": ep_uuid}))
-    ep.start_endpoint(*ep_args, reg_info={}, ep_info={})
+    ep_json.write_text(json.dumps({"endpoint_id": str(uuid.uuid4())}))
+    ep.start_endpoint(
+        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
+    )
 
-    _a, k = mock_gcc.register_endpoint.call_args
-    assert k["endpoint_id"] == ep_uuid
+    a, _k = mock_launch.call_args
+    assert a[0] == ep_uuid
 
 
 def test_delete_remote_endpoint_no_local_offline(
@@ -954,7 +811,7 @@ def test_delete_endpoint_with_uuid_happy(
     mock_gcc,
     mock_get_client,
     mock_log,
-    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, bool, UserEndpointConfig],
+    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, UserEndpointConfig],
     ep_uuid,
 ):
     ep, ep_dir, *_, ep_config = mock_ep_data
@@ -1011,7 +868,7 @@ def test_delete_endpoint_with_uuid_errors(
     exit_code: bool,
     mock_gcc,
     mock_get_client,
-    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, bool, UserEndpointConfig],
+    mock_ep_data: tuple[Endpoint, pathlib.Path, bool, UserEndpointConfig],
 ):
     ep = mock_ep_data[0]
     ep_uuid = None if no_uuid else str(uuid.uuid4())

--- a/smoke_tests/tests/sh/test_endpoint.sh
+++ b/smoke_tests/tests/sh/test_endpoint.sh
@@ -40,7 +40,6 @@ fi
 
 cat > "$conf_dir/config.yaml" <<EOF
 environment: $env
-detach_endpoint: False
 engine:
     type: GlobusComputeEngine
     heartbeat_period: 10


### PR DESCRIPTION
# Description

Removes the ability to register and start SEPs, along with old config items that only SEPs used.

Note that this removes `detach_endpoint` a little earlier than six months after deprecation, but since that config option only applied to SEPs, there's no point in keeping it around.

## Type of change

- Code maintenance/cleanup
