### PR TITLE
Leave noisy traceback to debug

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -798,8 +798,9 @@ def _do_register_endpoint(
             sys.exit(os.EX_DATAERR)
         raise
     except NetworkError as e:
-        log.exception("Network error while registering endpoint")
-        log.critical(f"Network failure; unable to register endpoint: {e}")
+        msg = f"Network failure; unable to register endpoint: {e}"
+        log.debug("Network error while registering endpoint", exc_info=e)
+        log.critical(msg)
         sys.exit(os.EX_TEMPFAIL)
 
     # Mostly to appease mypy, but also a useful text if it ever

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -616,11 +616,14 @@ def test__do_register_endpoint_handles_network_error_scriptably(
         cli._do_register_endpoint(conf_dir, ManagerEndpointConfig(), ep_uuid)
 
     assert pyexc.value.code == os.EX_TEMPFAIL, "Expecting meaningful exit code"
-    assert mock_log.exception.called, "Expected usable traceback"
+    assert mock_log.debug.called
+
+    _, k = mock_log.debug.call_args
+    assert "exc_info" in k, "Expected usable traceback"
     assert mock_log.critical.called
-    a = mock_log.critical.call_args[0][0]
-    assert "Network failure" in a
-    assert some_err in a
+    a, _ = mock_log.critical.call_args
+    assert "Network failure" in a[0]
+    assert some_err in a[0]
 
 
 @mock.patch(f"{_MOCK_BASE}setup_logging")


### PR DESCRIPTION
As a network error, the *likely* problem is contained in the stringification of the exception.  Still emit that, but save the traceback for when more digging is necessary.

## Type of change

- Code maintenance/cleanup