### PR TITLE
More informative error message to SDK

### DIFF
--- a/changelog.d/20260406_170316_kevin_more_useful_uep_errors_over_wire.rst
+++ b/changelog.d/20260406_170316_kevin_more_useful_uep_errors_over_wire.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- For some UEP startup errors, send more information to the SDK than an opaque
+  error code.  This should make some of the "422 SEMANTICALLY_INVALID"
+  responses from the API more usable.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -48,6 +48,7 @@ from globus_compute_endpoint.endpoint.utils import (
     user_input_select,
 )
 from globus_compute_endpoint.exception_handling import handle_auth_errors
+from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_compute_endpoint.logging_config import setup_logging
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
@@ -693,7 +694,7 @@ def _pidfile(pid_path: pathlib.Path, stale_after_s: int | float):
                 " correct, then remove the PID file before starting again."
             )
             log.error(msg)
-            sys.exit(os.EX_CANTCREAT)
+            raise MessageSystemExit(os.EX_CANTCREAT, msg)
 
         else:
             log.warning(
@@ -779,18 +780,18 @@ def _do_register_endpoint(
             HTTPStatus.LOCKED,
             HTTPStatus.NOT_FOUND,
         ):
-            sys.exit(os.EX_UNAVAILABLE)
+            raise MessageSystemExit(os.EX_UNAVAILABLE, blocked_msg)
         elif e.http_status in (
             HTTPStatus.BAD_REQUEST,
             HTTPStatus.UNPROCESSABLE_ENTITY,
         ):
-            sys.exit(os.EX_DATAERR)
+            raise MessageSystemExit(os.EX_DATAERR, blocked_msg)
         raise
     except NetworkError as e:
         msg = f"Network failure; unable to register endpoint: {e}"
         log.debug("Network error while registering endpoint", exc_info=e)
         log.critical(msg)
-        sys.exit(os.EX_TEMPFAIL)
+        raise MessageSystemExit(os.EX_TEMPFAIL, msg)
 
     # Mostly to appease mypy, but also a useful text if it ever
     # *does* happen
@@ -849,7 +850,7 @@ def _do_start_endpoint(
         try:
             yield
         except (SystemExit, Exception) as e:
-            if isinstance(e, SystemExit):
+            if issubclass(type(e), SystemExit):
                 if e.code in (0, None):
                     # normal, system exit
                     raise
@@ -857,7 +858,7 @@ def _do_start_endpoint(
             if reg_info:
                 # We're quitting anyway, so just let any exceptions bubble
                 msg = (
-                    f"Failed to start or unexpected error:\n  ({type(e).__name__}) {e}"
+                    f"Failed to start or unexpected error:\n  [{type(e).__name__}] {e}"
                 )
                 send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
 

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -56,6 +56,7 @@ from globus_compute_endpoint.endpoint.utils import (
     send_endpoint_startup_failure_to_amqp,
     update_url_port,
 )
+from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
@@ -176,11 +177,12 @@ class EndpointManager:
 
         upstream_ep_uuid = reg_info.get("endpoint_id")
         if endpoint_uuid and upstream_ep_uuid != endpoint_uuid:
-            log.error(
+            msg = (
                 "Unexpected response from server: mismatched endpoint id."
                 f"\n  Expected: {endpoint_uuid}, received: {upstream_ep_uuid}"
             )
-            sys.exit(os.EX_SOFTWARE)
+            log.error(msg)
+            raise MessageSystemExit(os.EX_SOFTWARE, msg)
 
         endpoint_uuid = str(upstream_ep_uuid)  # convenience, and satisfy mypy
         self._endpoint_uuid = uuid.UUID(endpoint_uuid)
@@ -214,8 +216,9 @@ class EndpointManager:
             except PermissionError as e:
                 msg = f"({type(e).__name__}) {e}"
                 log.error(msg)
-                print(msg, file=sys.stderr)
-                sys.exit(os.EX_NOPERM)
+                if sys.stderr.isatty():
+                    print(msg, file=sys.stderr)
+                raise MessageSystemExit(os.EX_NOPERM, msg)
 
             except Exception as e:
                 msg = (
@@ -224,8 +227,9 @@ class EndpointManager:
                 )
                 log.debug(msg, exc_info=e)
                 log.error(msg)
-                print(msg, file=sys.stderr)
-                sys.exit(os.EX_CONFIG)
+                if sys.stderr.isatty():
+                    print(msg, file=sys.stderr)
+                raise MessageSystemExit(os.EX_CONFIG, msg)
 
         try:
             cq_info = reg_info["command_queue_info"]
@@ -237,11 +241,12 @@ class EndpointManager:
         except Exception as e:
             log_reg_info = _redact_url_creds(str(reg_info))
             log.debug("%s", log_reg_info)
-            log.error(
+            msg = (
                 "Invalid or unexpected registration data structure:"
-                f" ({e.__class__.__name__}) {e}"
+                f" ({type(e).__name__}) {e}"
             )
-            sys.exit(os.EX_DATAERR)
+            log.error(msg)
+            raise MessageSystemExit(os.EX_DATAERR, msg)
 
         if config.amqp_port:
             cq_info["connection_url"] = update_url_port(

--- a/compute_endpoint/globus_compute_endpoint/exceptions.py
+++ b/compute_endpoint/globus_compute_endpoint/exceptions.py
@@ -3,3 +3,12 @@ class CouldNotExecuteUserTaskError(Exception):
     generic exception class for errors while attempting to setup and run the user
     function but which does not come from the user function itself failing
     """
+
+
+class MessageSystemExit(SystemExit):
+    def __init__(self, code: int | str = 0, msg: str = ""):
+        self.msg = msg
+        super().__init__(code)
+
+    def __str__(self) -> str:
+        return self.msg

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -42,6 +42,7 @@ from globus_compute_endpoint.endpoint.config import (
 from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.endpoint.identity_mapper import MappedPosixIdentity
+from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.auth.globus_app import UserApp
@@ -377,7 +378,7 @@ def test_start_endpoint_already_running(
     pid_path.write_text("12345")
     f = io.StringIO()
     with redirect_stderr(f):
-        with pytest.raises(SystemExit) as pyt_e:
+        with pytest.raises(MessageSystemExit) as pyt_e:
             cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
     pid_path.unlink()
 
@@ -386,6 +387,9 @@ def test_start_endpoint_already_running(
     assert "Another instance " in serr, "Expect cause explained"
     assert "Refusing to start." in serr, "Expect action taken conveyed"
     assert "remove the PID file" in serr, "Expect suggested action conveyed"
+    assert "Another instance " in pyt_e.value.msg
+    assert "Refusing to start." in pyt_e.value.msg
+    assert "remove the PID file" in pyt_e.value.msg
 
 
 def test_start_endpoint_stale(
@@ -523,15 +527,17 @@ def test_start_ep_stdin_allowed_fns_overrides_conf(
     ],
 )
 def test__do_register_endpoint_data_passthrough(
-    make_manager_endpoint_dir, mock_client, display_name
+    randomstring, make_manager_endpoint_dir, mock_client, display_name
 ):
+    exp_err_reason = randomstring()
+
     class FakeGlobusAPIError(GlobusAPIError):
         def __init__(self, http_status):
             self.http_status = http_status
 
         @property
         def text(self):
-            return "Conflict"
+            return f"{exp_err_reason}"
 
     mock_client.register_endpoint.side_effect = FakeGlobusAPIError(HTTPStatus.CONFLICT)
 
@@ -544,9 +550,10 @@ def test__do_register_endpoint_data_passthrough(
     ep_conf.public = True
     ep_conf.display_name = display_name
 
-    with pytest.raises(SystemExit) as pyt_exc:
+    with pytest.raises(MessageSystemExit) as pyt_e:
         cli._do_register_endpoint(ep_dir, ep_conf, None)
-    assert int(str(pyt_exc.value)) == os.EX_UNAVAILABLE, "Verify exit due to test 404"
+    assert pyt_e.value.code == os.EX_UNAVAILABLE
+    assert exp_err_reason in pyt_e.value.msg, "Verify expected test-exit"
 
     kwargs = mock_client.register_endpoint.call_args[1]
 
@@ -615,7 +622,7 @@ def test__do_register_endpoint_registration_blocked(
 
     f = io.StringIO()
     with redirect_stdout(f):
-        with pytest.raises((GlobusAPIError, SystemExit)) as pyexc:
+        with pytest.raises((GlobusAPIError, MessageSystemExit)) as pyexc:
             cli._do_register_endpoint(ep_dir, ManagerEndpointConfig(), ep_uuid)
         stdout_msg = f.getvalue()
 
@@ -713,7 +720,7 @@ def test__do_register_endpoint_handles_network_error_scriptably(
     some_err = randomstring()
     mock_client.register_endpoint.side_effect = NetworkError(some_err, Exception())
 
-    with pytest.raises(SystemExit) as pyexc:
+    with pytest.raises(MessageSystemExit) as pyexc:
         cli._do_register_endpoint(conf_dir, ManagerEndpointConfig(), ep_uuid)
 
     assert pyexc.value.code == os.EX_TEMPFAIL, "Expecting meaningful exit code"
@@ -725,6 +732,8 @@ def test__do_register_endpoint_handles_network_error_scriptably(
     a, _ = mock_log.critical.call_args
     assert "Network failure" in a[0]
     assert some_err in a[0]
+    assert "Network failure" in pyexc.value.msg
+    assert some_err in a[0] in pyexc.value.msg
 
 
 @mock.patch(f"{_MOCK_BASE}setup_logging")

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -32,6 +32,7 @@ from globus_compute_endpoint.endpoint.rabbit_mq import (
     ResultPublisher,
 )
 from globus_compute_endpoint.endpoint.utils import _redact_url_creds
+from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_sdk import UserApp
 from pytest_mock import MockFixture
 
@@ -527,15 +528,18 @@ def test_mismatched_id_gracefully_exits(
     ep_uuid = str(uuid.uuid4())
     assert wrong_uuid != ep_uuid, "Verify test setup"
 
-    with pytest.raises(SystemExit) as pyexc:
+    with pytest.raises(MessageSystemExit) as pyt_e:
         EndpointManager(conf_dir, ep_uuid, mock_conf, mock_reg_info)
 
-    assert pyexc.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
+    assert pyt_e.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
     assert mock_log.error.called
     a = mock_log.error.call_args[0][0]
-    assert "mismatched endpoint" in a
-    assert f"Expected: {ep_uuid}" in a
-    assert f"received: {wrong_uuid}" in a
+    assert "mismatched endpoint" in a, "Expect logged"
+    assert "mismatched endpoint" in pyt_e.value.msg, "Expect available for sending"
+    assert f"Expected: {ep_uuid}" in a, "Expect logged"
+    assert f"Expected: {ep_uuid}" in pyt_e.value.msg, "Expect available for sending"
+    assert f"received: {wrong_uuid}" in a, "Expect logged"
+    assert f"received: {wrong_uuid}" in pyt_e.value.msg, "Expect available for sending"
 
 
 @pytest.mark.parametrize(
@@ -573,12 +577,14 @@ def test_handles_invalid_reg_info(
     should_succeed, mock_gcc.register_endpoint.return_value = received_data
 
     if not should_succeed:
-        with pytest.raises(SystemExit) as pyexc:
+        with pytest.raises(MessageSystemExit) as pyexc:
             EndpointManager(conf_dir, ep_uuid, mock_conf, received_data[1])
         assert pyexc.value.code == os.EX_DATAERR, "Expected meaningful exit code"
         assert mock_log.error.called
         a = mock_log.error.call_args[0][0]
         assert "Invalid or unexpected" in a
+        assert "Invalid or unexpected" in pyexc.value.msg
+
     else:
         # "null" test
         EndpointManager(conf_dir, ep_uuid, mock_conf, received_data[1])
@@ -898,11 +904,13 @@ def test_clean_exit_on_identity_collection_error(
 
 
 @pytest.mark.no_mock_pim
+@pytest.mark.parametrize("isatty", (False, True))
 def test_as_root_gracefully_handles_unreadable_identity_mapper_conf(
-    mocker, mock_log, conf_dir, mock_conf_root, identity_map_path
+    mocker, mock_log, conf_dir, mock_conf_root, identity_map_path, isatty
 ):
     mock_print = mocker.patch(f"{_MOCK_BASE}print")
     mocker.patch(f"{_MOCK_BASE}is_privileged", return_value=True)
+    mocker.patch(f"{_MOCK_BASE}sys.stderr.isatty", return_value=isatty)
 
     ep_uuid = str(uuid.uuid1())
     reg_info = {
@@ -910,25 +918,33 @@ def test_as_root_gracefully_handles_unreadable_identity_mapper_conf(
         "command_queue_info": {"connection_url": 1, "queue": 1},
     }
     identity_map_path.chmod(mode=0o000)
-    with pytest.raises(SystemExit) as pyt_exc:
+    with pytest.raises(MessageSystemExit) as pyt_e:
         EndpointManager(conf_dir, ep_uuid, mock_conf_root, reg_info)
 
-    assert pyt_exc.value.code == os.EX_NOPERM
+    assert pyt_e.value.code == os.EX_NOPERM
     assert mock_log.error.called
-    assert mock_print.called
-    for a in (mock_log.error.call_args[0][0], mock_print.call_args[0][0]):
-        assert "PermissionError" in a
+    assert mock_print.called is isatty
+
+    found_msg = mock_log.error.call_args[0][0]
+    assert "PermissionError" in found_msg
+    assert found_msg == pyt_e.value.msg
+    if isatty:
+        assert mock_print.call_args[0][0] == found_msg
 
     identity_map_path.chmod(mode=0o644)
     identity_map_path.write_text("[{asfg")
-    with pytest.raises(SystemExit) as pyt_exc:
+    with pytest.raises(MessageSystemExit) as pyt_e:
         EndpointManager(conf_dir, ep_uuid, mock_conf_root, reg_info)
 
-    assert pyt_exc.value.code == os.EX_CONFIG
+    assert pyt_e.value.code == os.EX_CONFIG
     assert mock_log.error.called
-    assert mock_print.called
-    for a in (mock_log.error.call_args[0][0], mock_print.call_args[0][0]):
-        assert "Unable to read identity mapping" in a
+    assert mock_print.called is isatty
+
+    found_msg = mock_log.error.call_args[0][0]
+    assert "Unable to read identity mapping" in found_msg
+    assert found_msg == pyt_e.value.msg
+    if isatty:
+        assert mock_print.call_args[0][0] == found_msg
 
 
 def test_iterates_even_if_no_commands(mocker, epmanager_as_root):


### PR DESCRIPTION
During initial development, the point of the exit codes was to give at least *some* indication of where the execution failed and potentially what happened (e.g., `os.EX_`).  This was when it was not clear where a UEP's logs would go, or, if the UEP died before setting up logging, when there was no possibility of getting an error message out.  We've since addressed that lapse in logging ("Write std streams to log")[1], but did not update the UEP startup failure message to the SDK to include the why ("Send UEP startup failure AMQP message")[2].

The change here is to prefer `MessageSystemExit`, where appropriate

```diff
+ from globus_compute_endpoint.exceptions import MessageSystemExit

  ...

- sys.exit(exit_code)
+ MessageSystemExit(exit_code, "text-reason for exit")
```

Which is already handled correctly in the `_send_message_on_error_exit` function of interest.

[1] 9ac0f9d7b1a0211d80e158f8a979f951316dae2c
[2] dfab7df08789580506e6d3c51c950e73bbf5de5a

[sc-48171]

## Type of change

- New feature (non-breaking change that adds functionality)