### PR TITLE
Add known exit codes to documentation

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -246,7 +246,7 @@ class EndpointManager:
                 f" ({type(e).__name__}) {e}"
             )
             log.error(msg)
-            raise MessageSystemExit(os.EX_DATAERR, msg)
+            raise MessageSystemExit(os.EX_SOFTWARE, msg)
 
         if config.amqp_port:
             cq_info["connection_url"] = update_url_port(

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -579,7 +579,7 @@ def test_handles_invalid_reg_info(
     if not should_succeed:
         with pytest.raises(MessageSystemExit) as pyexc:
             EndpointManager(conf_dir, ep_uuid, mock_conf, received_data[1])
-        assert pyexc.value.code == os.EX_DATAERR, "Expected meaningful exit code"
+        assert pyexc.value.code == os.EX_SOFTWARE, "Expected meaningful exit code"
         assert mock_log.error.called
         a = mock_log.error.call_args[0][0]
         assert "Invalid or unexpected" in a

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -797,10 +797,80 @@ pulling out the configuration from the logs:
    $ sed -n "/Begin Compute/,/End Compute/p" ~/.globus_compute/uep.[...]/endpoint.log | less
 
 
+.. _exit_code_table:
+
+Endpoint Process Startup Errors
+-------------------------------
+
+Sometimes a provided ``user_endpoint_config`` structure will make for an invalid or
+incorrect configuration or some other error prevents the endpoint process from starting
+up.  It is not always possible to get complete and specific information back to the SDK
+about the failure, leaving the user with an opaque process exit code.  For example, this
+is a possible response from the API when an endpoint process fails to startup:
+
+.. code-block:: text
+   :caption: A possible error response; edited for clarity
+
+   globus_sdk.services.compute.errors.ComputeAPIError: (
+     'POST',
+     'https://compute.api.globus.org/v3/endpoints/[ENDPOINT_ID]/submit',
+     'Bearer',
+     422, 'SEMANTICALLY_INVALID',
+     'Request payload failed validation: Failed to start or unexpected error:\n  (SystemExit) 73'
+   )
+
+The `HTTP response code`__ of 422 is the Compute web-service saying "The user process
+did not successfully start.  Here's what the Endpoint reported."  However, the endpoint
+only reported that the user process stopped (``SystemExit``) and returned the exit code
+``73``.
+
+__ https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/422
+
+The user process log (``~/.globus_compute/uep.[ENDPOINT_ID].[UEP_ID]/endpoint.log``) and
+parent endpoint process log (``~/.globus_compute/<endpoint_name>/endpoint.log``) may
+have clues as to what wrong.  If log access is a burden (for example, shell access is
+not available), end-users may use the following table of UEP exit codes for help
+understanding some common errors:
+
+.. table:: Possible user endpoint process exit codes
+   :widths: auto
+   :align: left
+
+   +-----------------------------+---------------+-------------------------------------+
+   | Python ``os`` constant name | Integer value | Likely Reason                       |
+   +=============================+===============+=====================================+
+   | ``os.EX_DATAERR``           | 65            | Registration of the endpoint was    |
+   |                             |               | blocked by the Compute API with an  |
+   |                             |               | HTTP 400 (bad request), HTTP 422    |
+   |                             |               | (unprocessable entity) response;    |
+   |                             |               | look to the logs for more           |
+   |                             |               | information.                        |
+   +-----------------------------+---------------+-------------------------------------+
+   | ``os.EX_UNAVAILABLE``       | 69            | Registration of the endpoint was    |
+   |                             |               | blocked by the Compute API with an  |
+   |                             |               | HTTP 404 (not found), HTTP 409      |
+   |                             |               | (conflict), or HTTP 423 (locked)    |
+   |                             |               | response; look to the logs for more |
+   |                             |               | information.                        |
+   +-----------------------------+---------------+-------------------------------------+
+   | ``os.EX_SOFTWARE``          | 70            | The endpoint received an unexpected |
+   |                             |               | response from the Compute API.  This|
+   |                             |               | might happen with a very outdated   |
+   |                             |               | endpoint install.                   |
+   +-----------------------------+---------------+-------------------------------------+
+   | ``os.EX_CANTCREAT``         | 73            | Cannot create a PID file; another   |
+   |                             |               | instance of the user process may    |
+   |                             |               | still be running.                   |
+   +-----------------------------+---------------+-------------------------------------+
+
+
 Testing Templates
 -----------------
 
-Iterating on template changes by restarting the endpoint and submitting a task can be very slow. As a result, the Compute Endpoint CLI includes a :ref:`tool for rendering config templates offline, without touching the endpoint lifecycle at all. <testing-templates>`
+Iterating on template changes by restarting the endpoint and submitting a task can be
+very slow.  As a result, the Compute Endpoint CLI includes a :ref:`tool for rendering
+config templates offline, without touching the endpoint lifecycle at all.
+<testing-templates>`
 
 
 Client Identities

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -496,6 +496,32 @@ uninstall the service:
       # ...
 
 
+Common Startup Errors
+=====================
+
+Rounding out the table in § :ref:`exit_code_table`, there are a couple of well-known
+errors that administrators may additionally encounter.  Given the local access, the
+root cause of these exit codes should be evident in the ``endpoint.log`` or even on the
+console.  For completeness, however, when run as a multi-user endpoint, the following
+two exit codes are possible:
+
+.. table:: Possible endpoint process exit codes
+   :widths: auto
+   :align: left
+
+   +-----------------------------+---------------+-------------------------------------+
+   | Python ``os`` constant name | Integer value | Likely Reason                       |
+   +=============================+===============+=====================================+
+   | ``os.EX_NOPERM``            | 77            | Missing required permissions to read|
+   |                             |               | the identity mapping configuration  |
+   |                             |               | file.                               |
+   +-----------------------------+---------------+-------------------------------------+
+   | ``os.EX_CONFIG``            | 78            | Unknown problem reading or parsing  |
+   |                             |               | the identity mapping configuration  |
+   |                             |               | file.                               |
+   +-----------------------------+---------------+-------------------------------------+
+
+
 .. _pam:
 
 Pluggable Authentication Modules (PAM)


### PR DESCRIPTION
This is, unfortunately, not exhaustive but should cover the majority of failures.  Meanwhile, with the other-half of this work that also sends back more information to the SDK (in the next release), hopefully the whole interaction is improved.

(This is the documentation half of #2092.)

[sc-48171]

## Type of change

- Documentation update