### PR TITLE
Refactor endpoint CLI start

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -95,7 +95,6 @@ class CommandState:
         self.no_color = False
         self.log_to_console = False
         self.endpoint_uuid = None
-        self.die_with_parent = False
         self.detach = False
 
     @classmethod
@@ -168,19 +167,12 @@ def common_options(f):
     return f
 
 
-def start_options(f):
+def mep_start_options(f):
     f = click.option(
         "--endpoint-uuid",
         default=None,
         callback=set_param_to_config,
         help="The UUID to register with the Globus Compute services",
-    )(f)
-    f = click.option(
-        "--die-with-parent",
-        is_flag=True,
-        hidden=True,
-        callback=set_param_to_config,
-        help="Shutdown if parent process goes away",
     )(f)
     f = click.option(
         "--detach",
@@ -571,34 +563,26 @@ def configure_endpoint(
 
 @app.command(name="start", help="Start an endpoint")
 @name_or_uuid_arg
-@start_options
+@mep_start_options
 @common_options
 @handle_auth_errors
 def start_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
-    """Start an endpoint
-
-    This function will do:
-    1. Connect to the broker service, and register itself
-    2. Get connection info from broker service
-    3. Start the interchange as a daemon
-
-    |                      Broker service       |
-    |               -----2----> Forwarder       |
-    |    /register <-----3----+   ^             |
-    +-----^-----------------------+-------------+
-          |     |                 |
-          1     4                 6
-          |     v                 |
-    +-----+-----+-----+           v
-    |      Start      |---5---> EndpointInterchange
-    |     Endpoint    |         daemon
-    +-----------------+
-    """
     state = CommandState.ensure()
-    _do_start_endpoint(
+    _start_endpoint_manager(
         ep_dir=ep_dir,
         endpoint_uuid=state.endpoint_uuid,
-        die_with_parent=state.die_with_parent,
+    )
+
+
+@app.command(name="_start-user-endpoint", hidden=True)
+@name_or_uuid_arg
+@common_options
+@handle_auth_errors
+def start_user_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
+    state = CommandState.ensure()
+    _start_user_endpoint(
+        ep_dir=ep_dir,
+        endpoint_uuid=state.endpoint_uuid,
     )
 
 
@@ -789,12 +773,14 @@ def _do_register_endpoint(
     return reg_info
 
 
-def _do_start_endpoint(
+def _start_endpoint_manager(
     *,
     ep_dir: pathlib.Path,
     endpoint_uuid: str | None,
-    die_with_parent: bool = False,
 ):
+    if not _has_multi_user:
+        raise ClickException("multi-user endpoints are not supported on this system")
+
     os.umask(0o077)
     state = CommandState.ensure()
     if ep_dir.is_dir():
@@ -805,34 +791,7 @@ def _do_start_endpoint(
             no_color=state.no_color,
         )
 
-    _no_fn_list_canary = -15  # an arbitrary random integer; invalid as an allow_list
-    ep_info = {}
     reg_info = {}
-    config_str: str | None = None
-    audit_fd: int | None = None
-    fn_allow_list: list[str] | None | int = _no_fn_list_canary
-    if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
-        try:
-            stdin_data = json.loads(sys.stdin.read())
-
-            if not isinstance(stdin_data, dict):
-                type_name = stdin_data.__class__.__name__
-                raise ValueError(
-                    "Expecting JSON dictionary with endpoint info; got"
-                    f" {type_name} instead"
-                )
-
-            ep_info = stdin_data.get("ep_info", {})
-            reg_info = stdin_data.get("amqp_creds", {})
-            config_str = stdin_data.get("config")
-            audit_fd = stdin_data.get("audit_fd")
-            fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
-
-            del stdin_data  # clarity for intended scope
-
-        except Exception as e:
-            exc_type = e.__class__.__name__
-            log.debug("Invalid info on stdin -- (%s) %s", exc_type, e)
 
     @contextlib.contextmanager
     def _send_message_on_error_exit():
@@ -856,10 +815,133 @@ def _do_start_endpoint(
     with contextlib.ExitStack() as stk:
         stk.enter_context(_send_message_on_error_exit())
         try:
-            if config_str is not None:
-                ep_config = load_config_yaml(config_str)
-            else:
-                ep_config = get_config(ep_dir)
+            ep_config = get_config(ep_dir)
+
+            if not state.debug and ep_config.debug:
+                setup_logging(
+                    logfile=ep_dir / "endpoint.log",
+                    debug=ep_config.debug,
+                    console_enabled=state.log_to_console,
+                    no_color=state.no_color,
+                )
+
+        except Exception as e:
+            if isinstance(e, ClickException):
+                raise
+
+            # We've likely not exported to the log, so at least put _something_ in the
+            # logs for the human to debug; motivated by SC-28607
+            exc_type = type(e).__name__
+            msg = (
+                "Failed to find or parse endpoint configuration.  Endpoint will not"
+                f" start. ({exc_type}) {e}"
+            )
+            log.critical(msg)
+            raise
+
+        if not isinstance(ep_config, ManagerEndpointConfig):
+            raise ClickException(
+                f"Configuration for endpoint {ep_dir.name} contains an `engine` field;"
+                " endpoint will not start. (Hint: move the `engine` block to"
+                " `user_config_template.yaml.j2`)"
+            )
+
+        reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)
+
+        # detach after reading config and registration so errors are still printed to
+        # terminal, but otherwise as early as possible so any files created aren't lost
+        # during daemonization
+        if state.detach:
+            print(f"> Endpoint <{ep_dir.name}> starting in detached mode.")
+            daemon_context = daemon.DaemonContext(
+                working_directory=ep_dir,
+                umask=0o002,
+                # DaemonContext tries to not detach when the parent pid is 1 because
+                # it assumes that means the parent is `init`, but that prevents users
+                # from detaching in `docker run` context, so force the issue
+                detach_process=True,
+            )
+            stk.enter_context(daemon_context)
+
+            setup_logging(
+                logfile=ep_dir / "endpoint.log",
+                debug=ep_config.debug or state.debug,
+                console_enabled=state.log_to_console,
+                no_color=state.no_color,
+            )
+
+        pid_path = Endpoint.pid_path(ep_dir)
+        stk.enter_context(_pidfile(pid_path, ep_config.heartbeat_period * 3))
+
+        epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
+        epm.start()
+
+
+def _start_user_endpoint(
+    *,
+    ep_dir: pathlib.Path,
+    endpoint_uuid: str | None,
+):
+    os.umask(0o077)
+    state = CommandState.ensure()
+    if ep_dir.is_dir():
+        setup_logging(
+            logfile=ep_dir / "endpoint.log",
+            debug=state.debug,
+            console_enabled=state.log_to_console,
+            no_color=state.no_color,
+        )
+
+    _no_fn_list_canary = -15  # an arbitrary random integer; invalid as an allow_list
+    ep_info: dict
+    reg_info: dict
+    config_str: str
+    audit_fd: int | None = None
+    fn_allow_list: list[str] | None | int = _no_fn_list_canary
+    if sys.stdin and not (sys.stdin.closed or sys.stdin.isatty()):
+        try:
+            stdin_data = json.loads(sys.stdin.read())
+
+            ep_info = stdin_data["ep_info"]
+            reg_info = stdin_data["amqp_creds"]
+            config_str = stdin_data["config"]
+            audit_fd = stdin_data.get("audit_fd")
+            fn_allow_list = stdin_data.get("allowed_functions", _no_fn_list_canary)
+
+            del stdin_data  # clarity for intended scope
+
+        except Exception as e:
+            exc_type = e.__class__.__name__
+            log.debug("Invalid info on stdin -- (%s) %s", exc_type, e)
+            raise ClickException(
+                "Missing or invalid endpoint information from stdin. (Hint: this"
+                " command is not meant to be invoked manually; it should only be run"
+                " by an endpoint manager process.)"
+            ) from e
+
+    @contextlib.contextmanager
+    def _send_message_on_error_exit():
+        try:
+            yield
+        except (SystemExit, Exception) as e:
+            if issubclass(type(e), SystemExit):
+                if e.code in (0, None):
+                    # normal, system exit
+                    raise
+
+            if reg_info:
+                # We're quitting anyway, so just let any exceptions bubble
+                msg = (
+                    f"Failed to start or unexpected error:\n  [{type(e).__name__}] {e}"
+                )
+                send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
+
+            raise
+
+    with contextlib.ExitStack() as stk:
+        stk.enter_context(_send_message_on_error_exit())
+        try:
+            ep_config = load_config_yaml(config_str)
             del config_str
 
             if fn_allow_list != _no_fn_list_canary:
@@ -887,69 +969,25 @@ def _do_start_endpoint(
             log.critical(msg)
             raise
 
-        if not reg_info:
-            if isinstance(ep_config, ManagerEndpointConfig):
-                reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)
-            else:
-                raise ClickException(
-                    "This endpoint is not template capable and will not start."
-                    " (hint: globus-compute-endpoint migrate-to-template-capable)"
-                )
-
-        # detach after reading config and registration so errors are still printed to
-        # terminal, but otherwise as early as possible so any files created aren't lost
-        # during daemonization
-        if state.detach:
-            print(f"> Endpoint <{ep_dir.name}> starting in detached mode.")
-            daemon_context = daemon.DaemonContext(
-                working_directory=ep_dir,
-                umask=0o002,
-                # DaemonContext tries to not detach when the parent pid is 1 because
-                # it assumes that means the parent is `init`, but that prevents users
-                # from detaching in `docker run` context, so force the issue
-                detach_process=True,
-            )
-            stk.enter_context(daemon_context)
-
-            setup_logging(
-                logfile=ep_dir / "endpoint.log",
-                debug=ep_config.debug or state.debug,
-                console_enabled=state.log_to_console,
-                no_color=state.no_color,
+        if not isinstance(ep_config, UserEndpointConfig):
+            raise ClickException(
+                f"Configuration for endpoint {ep_dir.name} is missing an `engine`"
+                " field; endpoint will not start. (Hint: is "
+                "`user_config_template.yaml.j2` missing an `engine` block?)"
             )
 
         pid_path = Endpoint.pid_path(ep_dir)
         stk.enter_context(_pidfile(pid_path, ep_config.heartbeat_period * 3))
 
-        if isinstance(ep_config, ManagerEndpointConfig):
-            if not _has_multi_user:
-                raise ClickException(
-                    "multi-user endpoints are not supported on this system"
-                )
-            epm = EndpointManager(ep_dir, endpoint_uuid, ep_config, reg_info)
-            epm.start()
-        else:
-            assert isinstance(ep_config, UserEndpointConfig)
-
-            if not die_with_parent:
-                bname = os.path.basename(sys.argv[0])
-                print(
-                    "\nThis endpoint is not template capable.  To add that capability,"
-                    " run:\n\n"
-                    f"    $ {bname} migrate-to-template-capable {ep_dir.name}\n",
-                    flush=True,
-                )
-
-            get_cli_endpoint(ep_config).start_endpoint(
-                ep_dir,
-                endpoint_uuid,
-                ep_config,
-                state.log_to_console,
-                reg_info,
-                ep_info,
-                die_with_parent,
-                audit_fd,
-            )
+        get_cli_endpoint(ep_config).start_endpoint(
+            endpoint_dir=ep_dir,
+            endpoint_uuid=endpoint_uuid,
+            endpoint_config=ep_config,
+            log_to_console=state.log_to_console,
+            reg_info=reg_info,
+            ep_info=ep_info,
+            audit_fd=audit_fd,
+        )
 
 
 @app.command("stop")
@@ -973,15 +1011,14 @@ def _do_stop_endpoint(*, ep_dir: pathlib.Path, remote: bool = False) -> None:
 @app.command("restart")
 @name_or_uuid_arg
 @common_options
-@start_options
+@mep_start_options
 def restart_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
     """Restarts an endpoint"""
     state = CommandState.ensure()
     _do_stop_endpoint(ep_dir=ep_dir)
-    _do_start_endpoint(
+    _start_endpoint_manager(
         ep_dir=ep_dir,
         endpoint_uuid=state.endpoint_uuid,
-        die_with_parent=state.die_with_parent,
     )
 
 

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -721,6 +721,31 @@ def _pidfile(pid_path: pathlib.Path, stale_after_s: int | float):
             pass
 
 
+class _SendMessageOnErrorExit(contextlib.AbstractContextManager):
+    def __init__(self, reg_info: dict | None = None) -> None:
+        self.reg_info = reg_info
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ):
+        if exc_type is None or exc_val is None or exc_tb is None:
+            return
+
+        if isinstance(exc_val, SystemExit) and exc_val.code in (0, None):
+            # normal, system exit
+            return
+
+        if self.reg_info:
+            msg = (
+                f"Failed to start or unexpected error:\n  ({exc_type.__name__})"
+                f" {exc_val}"
+            )
+            send_endpoint_startup_failure_to_amqp(self.reg_info, msg=msg)
+
+
 def _do_register_endpoint(
     ep_dir: pathlib.Path, ep_config: ManagerEndpointConfig, ep_uuid: str | None
 ) -> dict:
@@ -791,29 +816,9 @@ def _start_endpoint_manager(
             no_color=state.no_color,
         )
 
-    reg_info = {}
-
-    @contextlib.contextmanager
-    def _send_message_on_error_exit():
-        try:
-            yield
-        except (SystemExit, Exception) as e:
-            if issubclass(type(e), SystemExit):
-                if e.code in (0, None):
-                    # normal, system exit
-                    raise
-
-            if reg_info:
-                # We're quitting anyway, so just let any exceptions bubble
-                msg = (
-                    f"Failed to start or unexpected error:\n  [{type(e).__name__}] {e}"
-                )
-                send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
-
-            raise
-
     with contextlib.ExitStack() as stk:
-        stk.enter_context(_send_message_on_error_exit())
+        error_exit_ctx = _SendMessageOnErrorExit()
+        stk.enter_context(error_exit_ctx)
         try:
             ep_config = get_config(ep_dir)
 
@@ -847,6 +852,7 @@ def _start_endpoint_manager(
             )
 
         reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)
+        error_exit_ctx.reg_info = reg_info
 
         # detach after reading config and registration so errors are still printed to
         # terminal, but otherwise as early as possible so any files created aren't lost
@@ -919,27 +925,8 @@ def _start_user_endpoint(
                 " by an endpoint manager process.)"
             ) from e
 
-    @contextlib.contextmanager
-    def _send_message_on_error_exit():
-        try:
-            yield
-        except (SystemExit, Exception) as e:
-            if issubclass(type(e), SystemExit):
-                if e.code in (0, None):
-                    # normal, system exit
-                    raise
-
-            if reg_info:
-                # We're quitting anyway, so just let any exceptions bubble
-                msg = (
-                    f"Failed to start or unexpected error:\n  [{type(e).__name__}] {e}"
-                )
-                send_endpoint_startup_failure_to_amqp(reg_info, msg=msg)
-
-            raise
-
     with contextlib.ExitStack() as stk:
-        stk.enter_context(_send_message_on_error_exit())
+        stk.enter_context(_SendMessageOnErrorExit(reg_info))
         try:
             ep_config = load_config_yaml(config_str)
             del config_str

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -17,7 +17,6 @@ import psutil
 import setproctitle
 import texttable
 import yaml
-from click import ClickException
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import (
     BaseConfig,
@@ -476,7 +475,6 @@ class Endpoint:
         log_to_console: bool,
         reg_info: dict,
         ep_info: dict,
-        die_with_parent: bool = False,
         audit_fd: int | None = None,
     ):
         ostream = None
@@ -557,13 +555,6 @@ class Endpoint:
         ptitle += f" [{setproctitle.getproctitle()}]"
         setproctitle.setproctitle(ptitle)
 
-        if die_with_parent:
-            parent_pid = os.getppid()
-        else:
-            raise ClickException(
-                "This endpoint is not template capable and will not start. "
-                "(hint: globus-compute-endpoint migrate-to-template-capable)"
-            )
         if ostream:
             msg = f"Starting endpoint; registered ID: {endpoint_uuid}"
             if log_to_console:
@@ -584,6 +575,7 @@ class Endpoint:
             start_unix=now_tz.timestamp(),
         )
 
+        parent_pid = os.getppid()
         Endpoint.start_interchange(
             endpoint_uuid,
             endpoint_dir,

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -981,9 +981,8 @@ class EndpointManager:
 
         proc_args = [
             "globus-compute-endpoint",
-            "start",
+            "_start-user-endpoint",
             ep_name,
-            "--die-with-parent",
             *args,
         ]
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -387,7 +387,7 @@ def test_start_endpoint_already_running(
     f = io.StringIO()
     with redirect_stderr(f):
         with pytest.raises(MessageSystemExit) as pyt_e:
-            cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
+            cli._start_endpoint_manager(ep_dir=ep_dir, endpoint_uuid=None)
     pid_path.unlink()
 
     serr = f.getvalue()
@@ -410,24 +410,12 @@ def test_start_endpoint_stale(
     os.utime(pid_path, (stale_time, stale_time))
     f = io.StringIO()
     with redirect_stderr(f):
-        cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
+        cli._start_endpoint_manager(ep_dir=ep_dir, endpoint_uuid=None)
 
     serr = f.getvalue()
     assert "Previous endpoint instance" in serr, "Expect 'who' in warning"
     assert "failed to shutdown cleanly" in serr, "Expect 'what' in warning"
     assert "Removing PID file" in serr, "Expect action taken in warning"
-
-
-@pytest.mark.parametrize("is_uep", (False, True))
-def test_cannot_start_sep(
-    mock_ep, mock_command_ensure, gc_dir, make_endpoint_dir, is_uep, mock_client
-):
-    ep_dir = make_endpoint_dir()
-    with pytest.raises(ClickException) as pyt_e:
-        cli._do_start_endpoint(ep_dir=ep_dir, endpoint_uuid=None)
-
-    assert "not template capable" in str(pyt_e.value)
-    assert "will not start" in str(pyt_e.value)
 
 
 @pytest.mark.parametrize("cli_cmd", ["configure"])
@@ -441,29 +429,36 @@ def test_endpoint_uuid_name_not_supported(run_line, cli_cmd):
 
 
 @pytest.mark.parametrize(
-    "stdin_data",
+    "reg_info,config_str,ep_info,audit_fd",
     [
-        json.dumps({"amqp_creds": {"foo": "bar"}}),
-        json.dumps({"amqp_creds": {"baz": "qux"}, "config": ""}),
-        json.dumps({"amqp_creds": {"a": 1}, "config": "myconfig"}),
-        json.dumps({"amqp_creds": {"b": 2}, "config": "myconfig", "audit_fd": 1}),
+        ({"foo": "bar"}, "", {}, None),
+        ({"baz": "qux"}, "", {"endpoint_id": str(uuid.uuid4())}, 1),
+        ({"a": 1}, "myconfig", {}, 1),
+        ({"b": 2}, "myconfig", {"endpoint_id": str(uuid.uuid4())}, None),
     ],
 )
-def test_start_ep_reads_stdin(
+def test_start_user_ep_reads_stdin(
     mocker,
     run_line,
     mock_ep,
     mock_get_config,
     make_endpoint_dir,
-    stdin_data,
     ep_name,
+    reg_info,
+    config_str,
+    ep_info,
+    audit_fd,
 ):
     mock_load_conf = mocker.patch(f"{_MOCK_BASE}load_config_yaml")
     mock_load_conf.return_value = mock_get_config.return_value
 
-    remote_register_endpoint_response = {}
-    mock__do_register_endpoint = mocker.patch(f"{_MOCK_BASE}_do_register_endpoint")
-    mock__do_register_endpoint.return_value = remote_register_endpoint_response
+    data_dict = {
+        "amqp_creds": reg_info,
+        "config": config_str,
+        "ep_info": ep_info,
+        "audit_fd": audit_fd,
+    }
+    stdin_data = json.dumps(data_dict)
 
     mock_sys = mocker.patch(f"{_MOCK_BASE}sys")
     mock_sys.stdin.closed = False
@@ -472,30 +467,24 @@ def test_start_ep_reads_stdin(
 
     make_endpoint_dir()
 
-    run_line(f"start {ep_name} --die-with-parent")
+    run_line(f"_start-user-endpoint {ep_name}")
     assert mock_ep.start_endpoint.called
-    s_ep_a, _ = mock_ep.start_endpoint.call_args
-    reg_info_found = s_ep_a[4]
-    audit_fd_found = s_ep_a[7]
+    _, s_ep_k = mock_ep.start_endpoint.call_args
+    config_str_found = mock_load_conf.call_args[0][0]
 
-    data_dict = json.loads(stdin_data)
-    reg_info = data_dict.get("amqp_creds", remote_register_endpoint_response)
-    config_str = data_dict.get("config")
-    audit_fd = data_dict.get("audit_fd")
-
-    assert reg_info_found == reg_info
-    assert audit_fd_found == audit_fd
-    if config_str:
-        config_str_found = mock_load_conf.call_args[0][0]
-        assert config_str_found == config_str
+    assert config_str == config_str_found
+    assert reg_info == s_ep_k["reg_info"]
+    assert ep_info == s_ep_k["ep_info"]
+    assert audit_fd == s_ep_k["audit_fd"]
 
 
 @pytest.mark.parametrize("fn_count", range(-1, 5))
-def test_start_ep_stdin_allowed_fns_overrides_conf(
+def test_start_uep_stdin_allowed_fns_overrides_conf(
     mocker,
     run_line,
     mock_ep,
     mock_get_config,
+    mock_load_config_yaml,
     make_endpoint_dir,
     ep_name,
     fn_count,
@@ -513,15 +502,22 @@ def test_start_ep_stdin_allowed_fns_overrides_conf(
     mock_sys.stdin.closed = False
     mock_sys.stdin.isatty.return_value = False
     mock_sys.stdin.read.return_value = json.dumps(
-        {"amqp_creds": {"foo": "bar"}, "allowed_functions": allowed_fns}
+        {
+            "amqp_creds": {"foo": "bar"},
+            "ep_info": {},
+            "config": "",
+            "allowed_functions": allowed_fns,
+        }
     )
 
     make_endpoint_dir()
 
-    run_line(f"start {ep_name} --die-with-parent")
+    run_line(f"_start-user-endpoint {ep_name}")
     assert mock_ep.start_endpoint.called
-    (_, _, found_conf, *_), _k = mock_ep.start_endpoint.call_args
-    assert found_conf.allowed_functions == allowed_fns, "allowed field not overridden!"
+    _, k = mock_ep.start_endpoint.call_args
+    assert (
+        k["endpoint_config"].allowed_functions == allowed_fns
+    ), "allowed field not overridden!"
 
 
 @pytest.mark.parametrize(
@@ -750,9 +746,9 @@ def test_debug_configurable(
     ep_dir = gc_dir / ep_name
     ep_dir.mkdir(parents=True)
     config = {"debug": False, "engine": {"type": "ThreadPoolEngine"}}
-    data = {"config": yaml.safe_dump(config)}
+    data = {"amqp_creds": {}, "ep_info": {}, "config": yaml.safe_dump(config)}
 
-    run_line(f"start {ep_name}", stdin=json.dumps(data), assert_exit_code=None)
+    run_line(f"_start-user-endpoint {ep_name}", stdin=json.dumps(data))
 
     _a, k = mock_setup_log.call_args
     assert mock_command_ensure.debug is False, "Verify test setup"
@@ -763,7 +759,7 @@ def test_debug_configurable(
     config["debug"] = True
     data["config"] = yaml.safe_dump(config)
 
-    run_line(f"start {ep_name}", stdin=json.dumps(data), assert_exit_code=None)
+    run_line(f"_start-user-endpoint {ep_name}", stdin=json.dumps(data))
 
     _a, k = mock_setup_log.call_args
     assert mock_command_ensure.debug is False, "Verify test setup"
@@ -779,9 +775,9 @@ def test_cli_debug_overrides_config(
     ep_dir = gc_dir / ep_name
     ep_dir.mkdir(parents=True)
     config = {"debug": False, "engine": {"type": "ThreadPoolEngine"}}
-    data = {"config": yaml.safe_dump(config)}
+    data = {"amqp_creds": {}, "ep_info": {}, "config": yaml.safe_dump(config)}
 
-    run_line(f"start {ep_name}", stdin=json.dumps(data), assert_exit_code=None)
+    run_line(f"_start-user-endpoint {ep_name}", stdin=json.dumps(data))
 
     _a, k = mock_setup_log.call_args
     assert mock_command_ensure.debug is True, "Verify test setup"
@@ -1179,15 +1175,15 @@ def test_name_or_uuid_decorator(tmp_path, mocker, run_line, name, uuid):
         # dummy config.yaml so that Endpoint._get_ep_dirs finds this
         (ep_conf_dir / "config.yaml").write_text("")
 
-    mock__do_start_endpoint = mocker.patch(f"{_MOCK_BASE}_do_start_endpoint")
+    mock__start_epm = mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
 
     run_line(f"-c {gc_conf_dir} start {name}")
     run_line(f"-c {gc_conf_dir} start {uuid}")
 
-    assert mock__do_start_endpoint.call_count == 2
+    assert mock__start_epm.call_count == 2
 
     first_result, second_result = (
-        call.kwargs["ep_dir"] for call in mock__do_start_endpoint.call_args_list
+        call.kwargs["ep_dir"] for call in mock__start_epm.call_args_list
     )
 
     assert first_result == second_result
@@ -1304,14 +1300,15 @@ def test_happy_path_exit_no_amqp_msg(
     make_endpoint_dir,
     ep_name,
     exit_exc,
+    mock_load_config_yaml,
 ):
     mock_send = mocker.patch(f"{_MOCK_BASE}send_endpoint_startup_failure_to_amqp")
     make_endpoint_dir()
 
-    stdin = json.dumps({"amqp_creds": {"some": "data"}})
+    stdin = json.dumps({"amqp_creds": {"some": "data"}, "ep_info": {}, "config": ""})
     if exit_exc is not None:
         mock_ep.start_endpoint.side_effect = exit_exc
-    run_line(f"start {ep_name}", assert_exit_code=0, stdin=stdin)
+    run_line(f"_start-user-endpoint {ep_name}", assert_exit_code=0, stdin=stdin)
     assert mock_ep.start_endpoint.called
     assert not mock_send.called
 
@@ -1335,13 +1332,14 @@ def test_fail_exit_sends_amqp_msg(
     ep_name,
     ec,
     exit_exc,
+    mock_load_config_yaml,
 ):
     mock_send = mocker.patch(f"{_MOCK_BASE}send_endpoint_startup_failure_to_amqp")
     make_endpoint_dir()
 
-    stdin = json.dumps({"amqp_creds": {"some": "data"}})
+    stdin = json.dumps({"amqp_creds": {"some": "data"}, "ep_info": {}, "config": ""})
     mock_ep.start_endpoint.side_effect = exit_exc
-    run_line(f"start {ep_name}", assert_exit_code=ec, stdin=stdin)
+    run_line(f"_start-user-endpoint {ep_name}", assert_exit_code=ec, stdin=stdin)
     assert mock_ep.start_endpoint.called
     assert mock_send.called
 

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -357,9 +357,7 @@ def test_endpoint_needs_no_client_if_reg_info(
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    ep.start_endpoint(
-        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-    )
+    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
     assert not mock_get_client.called, "No need for Client!"
     assert mock_launch.called, "Registration given; should start"
 
@@ -376,9 +374,7 @@ def test_start_endpoint_redacts_url_creds_from_logs(
 ):
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
-    ep.start_endpoint(
-        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-    )
+    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
     assert mock_launch.called, "Should launch successfully"
 
     debug_args = "\n".join(str((a, k)) for a, k in mock_log.debug.call_args_list)
@@ -395,9 +391,7 @@ def test_start_endpoint_populates_ep_static_info(
     canary_value = randomstring()
     ep_info = {"canary": canary_value}
     with mock.patch(f"{_mock_base}Endpoint.start_interchange") as mock_launch:
-        ep.start_endpoint(
-            *ep_args, reg_info=mock_reg_info, ep_info=ep_info, die_with_parent=True
-        )
+        ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info=ep_info)
     assert mock_launch.called, "Should launch successfully"
 
     (*_, found, _audit_fd), _k = mock_launch.call_args
@@ -528,9 +522,7 @@ def test_endpoint_sets_process_title(
         mock_spt.getproctitle.return_value = orig_proc_title
         mock_spt.setproctitle.side_effect = StopIteration("Sentinel")
         with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(
-                *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-            )
+            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
 
     a, _k = mock_spt.setproctitle.call_args
     assert a[0].startswith(
@@ -557,9 +549,7 @@ def test_endpoint_respects_port(mock_ep_data, port, mock_reg_info, ep_uuid):
     with mock.patch(f"{_mock_base}update_url_port", spec=True) as mock_upd:
         mock_upd.side_effect = (None, None, StopIteration("Sentinel"))
         with pytest.raises(StopIteration, match="Sentinel"):
-            ep.start_endpoint(
-                *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-            )
+            ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
 
     for (a, _), exp_url in zip(mock_upd.call_args_list, (tq_url, rq_url, hbq_url)):
         assert a == (exp_url, port)
@@ -602,7 +592,6 @@ def test_always_prints_endpoint_id_to_terminal(
         log_to_console,
         reg_info,
         ep_info={},
-        die_with_parent=True,
     )
 
     assert mock_sys.stdout.write.called
@@ -619,7 +608,6 @@ def test_always_prints_endpoint_id_to_terminal(
         log_to_console,
         reg_info,
         ep_info={},
-        die_with_parent=True,
     )
 
     assert not mock_sys.stdout.write.called
@@ -634,7 +622,6 @@ def test_always_prints_endpoint_id_to_terminal(
         log_to_console,
         reg_info,
         ep_info={},
-        die_with_parent=True,
     )
 
     assert not mock_sys.stdout.write.called
@@ -727,9 +714,7 @@ def test_handles_provided_endpoint_id_no_json(
     ep, ep_dir, log_to_console, ep_conf = mock_ep_data
     ep_args = (ep_dir, ep_uuid, ep_conf, log_to_console)
 
-    ep.start_endpoint(
-        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-    )
+    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
 
     a, _k = mock_launch.call_args
     assert a[0] == ep_uuid
@@ -747,9 +732,7 @@ def test_handles_provided_endpoint_id_with_json(
 
     ep_json = ep_dir / "endpoint.json"
     ep_json.write_text(json.dumps({"endpoint_id": str(uuid.uuid4())}))
-    ep.start_endpoint(
-        *ep_args, reg_info=mock_reg_info, ep_info={}, die_with_parent=True
-    )
+    ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
 
     a, _k = mock_launch.call_args
     assert a[0] == ep_uuid

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -1812,7 +1812,7 @@ def test_warns_if_executable_not_found(
     assert not k.get("fork", True)
 
 
-def test_start_endpoint_children_die_with_parent(successful_exec_from_mocked_root):
+def test_start_endpoint_children_correct_command(successful_exec_from_mocked_root):
     mock_os, *_, em = successful_exec_from_mocked_root
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
@@ -1821,7 +1821,7 @@ def test_start_endpoint_children_die_with_parent(successful_exec_from_mocked_roo
     a, k = mock_os.execvpe.call_args
     assert a[0] == "globus-compute-endpoint", "Sanity check"
     assert k["args"][0] == a[0], "Expect transparency for admin"
-    assert any("--die-with-parent" == i for i in k["args"]), "trust flag does the work"
+    assert k["args"][1] == "_start-user-endpoint", "trust CLI does the work"
 
 
 def test_start_endpoint_children_have_own_session(successful_exec_from_mocked_root):

--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -748,9 +748,9 @@ many lines about processes starting and stopping:
 
 .. code-block:: text
 
-   [...] Creating new user endpoint (pid: 3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
+   [...] Creating new user endpoint (pid: 3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint _start-user-endpoint uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a]
    [...] Command process successfully forked for 'harper' (Globus effective identity: b072d17b-08fd-4ada-8949-1fddca189b5e).
-   [...] Command stopped normally (3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint start uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a --die-with-parent]
+   [...] Command stopped normally (3867325) [(harper, uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a) globus-compute-endpoint _start-user-endpoint uep.4ade2ce0-9c00-4d8c-b996-4dff8fbb4bd0.e9097f8f-dcfc-3bc0-1b42-0b4ad5e3922a]
 
 
 Debugging User Endpoint Processes
@@ -762,7 +762,7 @@ In particular, the command executed by the manager endpoint process is:
 .. code-block:: python
    :caption: arguments to ``os.execvpe``
 
-   proc_args = ["globus-compute-endpoint", "start", ep_name, "--die-with-parent"]
+   proc_args = ["globus-compute-endpoint", "_start-user-endpoint", ep_name]
 
 Note the lack of the ``--debug`` flag; by default, user endpoint processes will
 not emit DEBUG level logs.  To place them into debug mode, use the ``debug``


### PR DESCRIPTION
# Description

When templating and user switching were initially implemented, it made sense to comingle their startup behaviors. With old-style SEPs out of the picture, however, there isn't much startup behavior shared between MEPs and UEPs anymore.

## Type of change

- Code maintenance/cleanup
