### PR TITLE
Add default public visibility for MEPs

### DIFF
--- a/changelog.d/20260407_024749_lei_mep_default_public_vis_sc_49188.rst
+++ b/changelog.d/20260407_024749_lei_mep_default_public_vis_sc_49188.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+- Newly created Multi-User Compute endpoints now default to public instead of
+  private visibility.  This flag can be toggled via the ``public`` param in
+  ``config.yaml``.  *Note* Visibility or the lack thereof is *not* a security
+  feature.  This is intended to help with default discoverability only, and
+  does not affect access/usage of the endpoint, which remain unchanged,
+  configured by identity mapping.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -116,6 +116,7 @@ class Endpoint:
         display_name: str | None,
         auth_policy: str | None,
         subscription_id: str | None,
+        public_visibility: bool = False,
     ):
         config_text = original_path.read_text()
         config_dict = yaml.safe_load(config_text)
@@ -147,6 +148,11 @@ class Endpoint:
 
         if subscription_id:
             config_dict["subscription_id"] = subscription_id
+
+        # Default to public visibility only if the provided config doesn't
+        #   already specify it
+        if public_visibility and "public" not in config_dict:
+            config_dict["public"] = public_visibility
 
         # Empty file yields '{}' which is valid but may be unclear as to format
         config_text = "# The generated config file is currently empty\n"
@@ -249,6 +255,7 @@ class Endpoint:
                 display_name,
                 auth_policy,
                 subscription_id,
+                public_visibility=id_mapping,
             )
 
         finally:

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -871,6 +871,36 @@ def test_configure_ep_subscription_id_in_config(run_line, mock_command_ensure):
     assert conf_dict["subscription_id"] == subscription_id
 
 
+@pytest.mark.parametrize(
+    ("is_privileged", "mu_arg", "public_visible"),
+    (
+        (False, None, False),
+        (False, True, True),
+        (False, False, False),
+        (True, None, True),
+        (True, True, True),
+        (True, False, False),
+    ),
+)
+def test_configure_ep_public_visible(
+    run_line, mock_command_ensure, is_privileged, mu_arg, public_visible
+):
+    ep_name = "my-ep"
+    conf = mock_command_ensure.endpoint_config_dir / ep_name / "config.yaml"
+
+    with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=is_privileged):
+        mu_arg_str = f" --multi-user {mu_arg}" if mu_arg is not None else ""
+        run_line(f"configure {mu_arg_str} {ep_name}")
+
+        with open(conf) as f:
+            conf_dict = yaml.safe_load(f)
+
+        if public_visible:
+            assert conf_dict["public"] is True
+        else:
+            assert "public" not in conf_dict or conf_dict["public"] is False
+
+
 def test_configure_ep_endpoint_config_deprecated(run_line, randomstring, mock_ep):
     ep_config_arg = randomstring()
 

--- a/docs/endpoints/config_reference.rst
+++ b/docs/endpoints/config_reference.rst
@@ -327,6 +327,24 @@ endpoint process, which manages user endpoint processes.  Under the hood, all
 configuration options in this file are used to create an instance of the
 |ManagerEndpointConfig| class.
 
+- ``public``
+
+  A boolean value, dictating whether other users can discover this endpoint in
+  the Globus Compute web API and Globus `Web UI`_.  It defaults to ``true``.
+
+  .. warning::
+
+     This field does **not** indicate access/usage of the endpoint.  It determines
+     only whether this endpoint is easily discoverable via the Globus web portal
+     |nbsp| --- |nbsp| access is controlled via the ``admins`` field
+     (management of endpoint) and the identity mapping configuration (Compute usage),
+     both described below.
+
+  .. code-block:: yaml
+     :caption: ``config.yaml`` -- example public multi-user endpoint
+
+     public: true
+
 - ``identity_mapping_config_path``
 
   A path to an identity mapping configuration, per the Globus Connect Server
@@ -364,22 +382,6 @@ configuration options in this file are used to create an instance of the
      :caption: Example ``config.yaml`` with a custom user config schema path
 
      user_config_schema_path: /path/to/my_schema.json
-
-- ``public``
-
-  A boolean value, dictating whether other users can discover this endpoint in
-  the Globus Compute web API and Globus `Web UI`_.  It defaults to ``false``.
-
-  .. warning::
-
-     This field does **not** prevent access to the endpoint.  It determines only
-     whether this endpoint is easily discoverable |nbsp| --- |nbsp| do not use
-     this field as a security control.
-
-  .. code-block:: yaml
-     :caption: ``config.yaml`` -- example public multi-user endpoint
-
-     public: true
 
 - ``admins``
 

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -173,6 +173,7 @@ field to specify the identity mapping file path:
 
    amqp_port: 443
    display_name: null
+   public: true
    identity_mapping_config_path: /root/.globus_compute/my_mu_ep/example_identity_mapping_config.json
 
 Please refer to :ref:`endpoint-manager-config` for details on each field.


### PR DESCRIPTION
# Description

This adds the ``public`` param to newly configured multi-user (user mapping) endpoints with a default of ``True``.

Existing endpoint visibility is not affected, and non-privileged single-user endpoints and endpoints created with a privileged account but with ``--multi-user false`` will not contain the ``public: true`` flag.

Documentation has been changed to note the new behavior, in addition to the change log.

[sc-49188]

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update