### PR TITLE
Remove SEP `get_metadata`

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -4,11 +4,9 @@ import json
 import logging
 import os
 import pathlib
-import platform
 import pwd
 import re
 import shutil
-import socket
 import subprocess
 import sys
 import time
@@ -20,7 +18,6 @@ import setproctitle
 import texttable
 import yaml
 from click import ClickException
-from globus_compute_endpoint import __version__
 from globus_compute_endpoint.auth import get_globus_app_with_scopes
 from globus_compute_endpoint.endpoint.config import (
     BaseConfig,
@@ -909,19 +906,6 @@ class Endpoint:
         table._width[idx_name] = max(10, table._width[idx_name])
 
         print(table.draw(), file=ofile)
-
-    @staticmethod
-    def get_metadata(config_src: str | None) -> dict:
-        metadata: dict = {
-            "endpoint_version": __version__,
-            "python_version": platform.python_version(),
-            "hostname": socket.getfqdn(),
-            # should be more accurate than `getpass.getuser()` in non-login situations
-            "local_user": pwd.getpwuid(os.getuid()).pw_name,
-            "endpoint_config": config_src,
-        }
-
-        return metadata
 
     @staticmethod
     def _run_command(name: str, command: str):

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -26,8 +26,6 @@ from globus_compute_endpoint.endpoint.config import (
 )
 from globus_compute_endpoint.endpoint.endpoint import Endpoint
 from globus_compute_endpoint.engines import (
-    GlobusComputeEngine,
-    ProcessPoolEngine,
     ThreadPoolEngine,
 )
 from globus_compute_sdk import Client
@@ -514,44 +512,6 @@ def test_pid_file_check(fs, is_running, is_active):
     pid_status = Endpoint.check_pidfile(ep_dir)
     assert pid_status["exists"] is is_running
     assert pid_status["active"] is is_active
-
-
-@pytest.mark.parametrize(
-    "engine_cls", (GlobusComputeEngine, ThreadPoolEngine, ProcessPoolEngine)
-)
-def test_endpoint_get_metadata(mocker, engine_cls):
-    mock_data = {
-        "endpoint_version": "106.7",
-        "python_version": "3.12.7",
-        "hostname": "oneohtrix.never",
-        "local_user": "daniel",
-    }
-
-    mocker.patch(
-        "globus_compute_endpoint.endpoint.endpoint.__version__",
-        mock_data["endpoint_version"],
-    )
-    mocker.patch("platform.python_version", return_value=mock_data["python_version"])
-
-    mock_fqdn = mocker.patch("globus_compute_endpoint.endpoint.endpoint.socket.getfqdn")
-    mock_fqdn.return_value = mock_data["hostname"]
-
-    mock_pwuid = mocker.patch("globus_compute_endpoint.endpoint.endpoint.pwd.getpwuid")
-    mock_pwuid.return_value = SimpleNamespace(pw_name=mock_data["local_user"])
-
-    k = {}
-    if engine_cls is GlobusComputeEngine:
-        k["address"] = "::1"
-    test_config = UserEndpointConfig(engine=engine_cls(**k))
-    test_config.source_content = "foo: bar"
-    meta = Endpoint.get_metadata(test_config.source_content)
-
-    test_config.engine.shutdown()
-
-    for k, v in mock_data.items():
-        assert meta[k] == v
-
-    assert meta["endpoint_config"] == test_config.source_content
 
 
 @pytest.mark.parametrize("env", (None, "blar", "local", "production"))

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -14,6 +14,7 @@ import typing as t
 import uuid
 from collections import namedtuple
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest import mock
 
 import pika
@@ -455,6 +456,40 @@ def mock_ctl():
     with mock.patch(f"{_MOCK_BASE}_import_pyprctl") as m:
         m.return_value = m
         yield m
+
+
+def test_get_metadata(mocker):
+    exp_meta = {
+        "endpoint_version": "106.7",
+        "python_version": "3.14.159",
+        "hostname": "oneohtrix.never",
+        "local_user": "daniel",
+        "endpoint_config": "foo: bar",
+        "user_config_template": "{{ template }}",
+        "user_config_schema": "{'schema': true}",
+    }
+
+    mocker.patch(f"{_MOCK_BASE}__version__", exp_meta["endpoint_version"])
+    mocker.patch("platform.python_version", return_value=exp_meta["python_version"])
+    mocker.patch(f"{_MOCK_BASE}socket.getfqdn", return_value=exp_meta["hostname"])
+    mocker.patch(
+        f"{_MOCK_BASE}pwd.getpwuid",
+        return_value=SimpleNamespace(pw_name=exp_meta["local_user"]),
+    )
+    mocker.patch(
+        f"{_MOCK_BASE}load_user_config_template",
+        return_value=exp_meta["user_config_template"],
+    )
+    mocker.patch(
+        f"{_MOCK_BASE}load_user_config_schema",
+        return_value=exp_meta["user_config_schema"],
+    )
+    test_config = ManagerEndpointConfig()
+    test_config.source_content = exp_meta["endpoint_config"]
+
+    meta = EndpointManager.get_metadata(pathlib.Path(), test_config)
+
+    assert meta == exp_meta
 
 
 @pytest.mark.parametrize("env", (None, "blar", "local", "production"))


### PR DESCRIPTION
# Description

No longer needed now that SEPs cannot register themselves.

## Type of change

- Code maintenance/cleanup
