### PR TITLE
Remove psutil requirement for SDK

### DIFF
--- a/compute_sdk/globus_compute_sdk/sdk/hardware_report.py
+++ b/compute_sdk/globus_compute_sdk/sdk/hardware_report.py
@@ -30,16 +30,22 @@ def _format_psmem(psdata) -> str:
 
 @display_name("psutil.virtual_memory()")
 def mem_info() -> str:
-    import psutil  # import here bc psutil is installed with endpoint but not sdk
+    try:
+        import psutil  # psutil installed with endpoint, not sdk
 
-    return _format_psmem(psutil.virtual_memory())
+        return _format_psmem(psutil.virtual_memory())
+    except ImportError:
+        return "Python module `psutil` not installed; virtual memory info not available"
 
 
 @display_name("psutil.swap_memory()")
 def swap_info() -> str:
-    import psutil  # import here bc psutil is installed with endpoint but not sdk
+    try:
+        import psutil  # psutil installed with endpoint, not sdk
 
-    return _format_psmem(psutil.swap_memory())
+        return _format_psmem(psutil.swap_memory())
+    except ImportError:
+        return "Python module `psutil` not installed; virtual memory info not available"
 
 
 @display_name("python_runtime_host_info")

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -24,7 +24,6 @@ REQUIRES = [
     # 3 below for color highlighting related console print
     "colorama>=0.4.6,<1",
     "rich>=13.7.1,<15",
-    "psutil<6",
     "exceptiongroup>=1.2.2",  # until we drop support for python < 3.11
 ]
 DOCS_REQUIRES = [
@@ -34,6 +33,7 @@ DOCS_REQUIRES = [
 
 TEST_REQUIRES = [
     "flake8==3.8.0",
+    "psutil",
     "pytest>=7.2",
     "pytest-mock",
     "pyfakefs",

--- a/compute_sdk/tests/unit/test_hardware_report.py
+++ b/compute_sdk/tests/unit/test_hardware_report.py
@@ -1,22 +1,19 @@
 import logging
 import shlex
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from globus_compute_sdk.sdk.hardware_report import (
     _run_command,
     cpu_info,
+    mem_info,
     run_hardware_report,
+    swap_info,
 )
 
 _MOCK_BASE = "globus_compute_sdk.sdk.hardware_report."
 _NON_PORTABLE_COMMANDS = [cpu_info(), "lshw", "nvidia-smi"]
-
-
-@pytest.fixture(autouse=True)
-def mock_mem_info(mocker):
-    # mem_info depends on psutil which is not installed on sdk
-    mocker.patch(f"{_MOCK_BASE}mem_info", lambda: None)
 
 
 @pytest.mark.parametrize("missing_command", _NON_PORTABLE_COMMANDS)
@@ -56,3 +53,17 @@ def test_run_command_handles_missing_commands(mocker, caplog, missing_command):
         else:
             assert output == command_arg0
             assert f"{command_arg0} was not found in the PATH" not in caplog.text
+
+
+@pytest.mark.parametrize("psutil_using_func", (mem_info, swap_info))
+def test_missing_psutil_handled_gracefully(psutil_using_func):
+    ps_mock = mock.Mock()
+    with mock.patch.dict("sys.modules", {"psutil": ps_mock}):
+        with mock.patch(f"{_MOCK_BASE}_format_psmem", side_effect=MemoryError):
+            with pytest.raises(MemoryError):
+                psutil_using_func()
+
+    with mock.patch.dict("sys.modules", {"psutil": None}):
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            r = psutil_using_func()
+    assert "`psutil` not installed" in r


### PR DESCRIPTION
The diagnostic tool *did* use the `psutil` library, but we can make it optional. In so doing, that removes a C-based Python module, and may make using the SDK in other environments more tenable.

To the reviewer, the key change of interest is in removing `psutil` as a dependency of the SDK package.

## Type of change

- Breaking change
  - This won't die for folks, but for those who run the `globus-compute-diagnostic` tool having only installed the Compute SDK, the two memory sections will have a replacement message instead.