### PR TITLE
Bump parsl to latest to include pbspro job status fix #4085

### DIFF
--- a/changelog.d/20260424_104408_lei_bump_parsl_2025_04_20.rst
+++ b/changelog.d/20260424_104408_lei_bump_parsl_2025_04_20.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- Bumps parsl from `2026.2.23`_ to `2026.4.20`_ which includes a fix to
+  PBSProProvider job status parsing

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -34,7 +34,7 @@ REQUIRES = [
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range
     # of different features and functions
     # pin exact versions because it does not use semver
-    "parsl==2026.2.23",
+    "parsl==2026.4.20",
     "pika>=1.2.0",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3688,6 +3688,7 @@ New Functionality
 .. |SlurmProvider| replace:: ``SlurmProvider``
 .. _SlurmProvider: https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html
 
+.. _2026.4.20: https://pypi.org/project/parsl/2026.4.20/
 .. _2026.2.23: https://pypi.org/project/parsl/2026.2.23/
 .. _2026.1.5: https://pypi.org/project/parsl/2026.1.5/
 .. _2025.12.1: https://pypi.org/project/parsl/2025.12.1/


### PR DESCRIPTION
# Description

Bumps parsl to latest 2026.04.20 which includes a [fix to pbspro job status](https://github.com/Parsl/parsl/pull/4085).  

Also see slack conversation [here](https://globus.slack.com/archives/C0896RYMBGX/p1775769377684599) and [here](https://globus.slack.com/archives/C0896RYMBGX/p1777002662848429).

## Type of change

- Bug fix (non-breaking change that fixes an issue)