### PR TITLE
Address --detach apparent failure

### DIFF
--- a/changelog.d/20260427_181129_kevin_sc_49802.rst
+++ b/changelog.d/20260427_181129_kevin_sc_49802.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- Address issue with ``--detach`` where a daemonization-time race-condition
+  resulted in file descriptors being incorrectly closed by the garbage
+  collector.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import gc
 import json
 import logging
 import os
@@ -768,6 +769,7 @@ def _do_register_endpoint(
             high_assurance=ep_config.high_assurance,
             admins=ep_config.admins,
         )
+        del gcc
     except GlobusAPIError as e:
         blocked_msg = f"Endpoint registration blocked.  [{e.text}]"
         log.warning(blocked_msg)
@@ -789,6 +791,11 @@ def _do_register_endpoint(
         log.debug("Network error while registering endpoint", exc_info=e)
         log.critical(msg)
         raise MessageSystemExit(os.EX_TEMPFAIL, msg)
+
+    # avoid __del__-time errors after fork(); urllib3 connectionpool doesn't like us
+    # closing fds ahead of it, but we don't have a direct avenue to tell it explicitly
+    # to let go of them.  So, encourage Python to do it via the collector.
+    gc.collect()
 
     # Mostly to appease mypy, but also a useful text if it ever
     # *does* happen


### PR DESCRIPTION
While I was unable to recreate the original traceback the reporter provided, all of the tracebacks I did create (consistently!) revolved around invalid file descriptors.  My hypothesis is that daemontools is closing all the file descriptors when daemonizing, but since the `__del__` methods around the open file descriptors aren't aware of this, they're closing other librarys' file descriptors instead.

We've seen a variant of this before to-do with the Globus SDK and embedded urllib connection pool, and the solution then was to "try harder" to shut it down.  Attempting the same here.  The idea is to strongly encourage Python to run the `__del__` methods on said client (`del gcc`, above) *now*, prior to the fork() operation, so that there's no contention.

[sc-49802]

## Type of change

- Bug fix (non-breaking change that fixes an issue)