### PR TITLE
Address recent CI error

### DIFF
--- a/compute_endpoint/tests/integration/conftest.py
+++ b/compute_endpoint/tests/integration/conftest.py
@@ -405,6 +405,7 @@ def ensure_task_queue(pika_conn_params, tod_session_num, request):
             queue_opts = {"queue": f"task_{queue_id}.tasks"}
         # play nice with dev/test resources; auto clean
         queue_opts.setdefault("arguments", {"x-expires": 30 * 1000})
+        queue_opts.setdefault("durable", True)
 
         with pika.BlockingConnection(pika_conn_params) as mq_conn:
             with mq_conn.channel() as chan:


### PR DESCRIPTION
In Aug 2021, [Rabbit deprecated non-durable and non-exclusive queues](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements).  As of 4.3.0, they're now enforcing it by default.  It's "just tests" so "meh," but go ahead and make the problematic test queues durable as the better part of valor.

## Type of change

- Code maintenance/cleanup