### PR TITLE
Move precommit to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,20 +16,15 @@ repos:
   rev: v3.21.2
   hooks:
     - id: pyupgrade
-      args: ["--py39-plus"]
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 26.3.1
+      args: ["--py310-plus"]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.12
   hooks:
-    - id: black
-- repo: https://github.com/PyCQA/isort
-  rev: 9.0.0a3
-  hooks:
-    - id: isort
-      # explicitly pass settings file so that isort does not try to deduce
-      # which settings to use based on a file's directory
-      args: ["--settings-path", ".isort.cfg"]
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.3.0
-  hooks:
-    - id: flake8
-      additional_dependencies: ['flake8-bugbear==22.10.27']
+    - id: ruff-check
+      types_or: [ python ]
+      args: [ --select, I ]
+    - id: ruff-check
+      types_or: [ python ]
+      args: [ --fix ]
+    - id: ruff-format
+      types_or: [ python ]

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -371,8 +371,7 @@ def version_command():
     type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
     default=None,
     help=(
-        "Specify a custom identity mapping configuration"
-        " (identity_mapping_config.json)"
+        "Specify a custom identity mapping configuration (identity_mapping_config.json)"
     ),
 )
 @optgroup.option(
@@ -1112,7 +1111,7 @@ def create_or_choose_auth_project(ac: AuthClient) -> str:
                 "Please select a project to contain new auth policy "
                 "(leave blank to create a new one):"
             ),
-            [f'id: {proj["id"]}, name: {proj["display_name"]}' for proj in projects],
+            [f"id: {proj['id']}, name: {proj['display_name']}" for proj in projects],
         )
         if proj_selected:
             return proj_selected.split()[1][:-1]
@@ -1359,9 +1358,7 @@ def _do_render_user_config(
 
     if parent_config_file is not None:
         try:
-            parent_config = load_config_yaml(
-                parent_config_file.read()
-            )  # type: ignore[assignment]
+            parent_config = load_config_yaml(parent_config_file.read())  # type: ignore[assignment]
         except Exception as e:
             raise ClickExceptionWithContext(
                 f"Invalid parent config data in {parent_config_file.name}."

--- a/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
+++ b/compute_endpoint/globus_compute_endpoint/engines/globus_compute.py
@@ -126,9 +126,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
         self.strategy = strategy
 
         self.container_type = container_type
-        assert (
-            self.container_type in VALID_CONTAINER_TYPES
-        ), f"{self.container_type} is not a valid container_type"
+        assert self.container_type in VALID_CONTAINER_TYPES, (
+            f"{self.container_type} is not a valid container_type"
+        )
         self.container_uri = container_uri
         self.container_cmd_options = container_cmd_options
 
@@ -240,9 +240,9 @@ class GlobusComputeEngine(GlobusComputeEngineBase):
                 options=self.container_cmd_options or "",
             )
         elif self.container_type == "custom":
-            assert (
-                self.container_cmd_options
-            ), "GCE.container_cmd_options is required for GCE.container_type=custom"
+            assert self.container_cmd_options, (
+                "GCE.container_cmd_options is required for GCE.container_type=custom"
+            )
             template = self.container_cmd_options.replace(
                 "{EXECUTOR_RUNDIR}", str(self.run_dir)
             )

--- a/compute_endpoint/tests/integration/conftest.py
+++ b/compute_endpoint/tests/integration/conftest.py
@@ -414,7 +414,6 @@ def ensure_task_queue(pika_conn_params, tod_session_num, request):
 
     with pika.BlockingConnection(pika_conn_params) as mq_conn:
         with mq_conn.channel() as chan:
-
             yield _do_ensure
 
             for q_name in queues_created:

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange.py
@@ -290,9 +290,9 @@ def test_hard_idle_honored(
         m[0][0].startswith("[possibly idle; shut down in ")
         for m in mock_spt.call_args_list
     )
-    assert (
-        num_updates == idle_limit - idle_soft_limit
-    ), "expect process title updated; reflects status"
+    assert num_updates == idle_limit - idle_soft_limit, (
+        "expect process title updated; reflects status"
+    )
 
 
 def test_shutdown_lost_task_race_condition_sc36175(

--- a/compute_endpoint/tests/unit/engine/test_base.py
+++ b/compute_endpoint/tests/unit/engine/test_base.py
@@ -157,9 +157,9 @@ def test_submit_specifies_deserializers(eng_args, task_bytes, endpoint_uuid, tas
 
     eng.submit(f, task_bytes, {})
 
-    assert exp_task_deser == set(
-        k["kwargs"]["task_deserializers"]
-    ), eng.serde.allowed_deserializer_types
+    assert exp_task_deser == set(k["kwargs"]["task_deserializers"]), (
+        eng.serde.allowed_deserializer_types
+    )
 
 
 def test_expected_abstract_methods(eng_args):

--- a/compute_endpoint/tests/unit/test_boot_persistence.py
+++ b/compute_endpoint/tests/unit/test_boot_persistence.py
@@ -26,11 +26,13 @@ def fake_ep_dir(fs: fakefs.FakeFilesystem, ep_name) -> pathlib.Path:
     ep_dir = pathlib.Path.home() / ".globus_compute" / ep_name
     fs.create_dir(ep_dir)
     ep_config = Endpoint._config_file_path(ep_dir)
-    ep_config.write_text("""
+    ep_config.write_text(
+        """
 display_name: null
 engine:
     type: ThreadPoolEngine
-        """.strip())
+        """.strip()
+    )
     return ep_dir
 
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -225,11 +225,13 @@ def make_endpoint_dir(gc_dir, ep_name):
             ep_json = ep_dir / "endpoint.json"
             ep_json.write_text(json.dumps({"endpoint_id": ep_uuid}))
         ep_config = Endpoint._config_file_path(ep_dir)
-        ep_config.write_text("""
+        ep_config.write_text(
+            """
 display_name: null
 engine:
     type: ThreadPoolEngine
-            """.strip())
+            """.strip()
+        )
         return ep_dir
 
     return func
@@ -246,15 +248,20 @@ def make_manager_endpoint_dir(gc_dir, ep_name):
         ep_config = Endpoint._config_file_path(ep_dir)
         ep_template = Endpoint.user_config_template_path(ep_dir)
         ep_schema = Endpoint.user_config_schema_path(ep_dir)
-        ep_config.write_text("""
+        ep_config.write_text(
+            """
 display_name: null
-            """.strip())
-        ep_template.write_text("""
+            """.strip()
+        )
+        ep_template.write_text(
+            """
 heartbeat_period: {{ heartbeat }}
 engine:
     type: ThreadPoolEngine
-            """.strip())
-        ep_schema.write_text("""
+            """.strip()
+        )
+        ep_schema.write_text(
+            """
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
@@ -262,7 +269,8 @@ engine:
     "heartbeat": { "type": "number" }
   }
 }
-            """.strip())
+            """.strip()
+        )
         return ep_dir
 
     return func
@@ -515,9 +523,9 @@ def test_start_uep_stdin_allowed_fns_overrides_conf(
     run_line(f"_start-user-endpoint {ep_name}")
     assert mock_ep.start_endpoint.called
     _, k = mock_ep.start_endpoint.call_args
-    assert (
-        k["endpoint_config"].allowed_functions == allowed_fns
-    ), "allowed field not overridden!"
+    assert k["endpoint_config"].allowed_functions == allowed_fns, (
+        "allowed field not overridden!"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1101,9 +1109,9 @@ def test_start_ep_detached(
 
     assert mock_daemon_context_class.called, "Expect DaemonContext was created"
     daemon_constructor_kwargs = mock_daemon_context_class.call_args.kwargs
-    assert (
-        daemon_constructor_kwargs.get("detach_process") is True
-    ), "Expect DaemonContext is told to detach, not use its own heuristic"
+    assert daemon_constructor_kwargs.get("detach_process") is True, (
+        "Expect DaemonContext is told to detach, not use its own heuristic"
+    )
 
     assert res.exception is not None, "Expect *an* exception was raised"
     assert "early exit" in str(res.exception), "Expect the *correct* exception"

--- a/compute_endpoint/tests/unit/test_command_queue_subscriber.py
+++ b/compute_endpoint/tests/unit/test_command_queue_subscriber.py
@@ -129,9 +129,9 @@ def test_cqs_connect_limit_very_high_sc30467():
     cq = cqs.CommandQueueSubscriber(
         queue_info=None, command_queue=None, stop_event=None
     )
-    assert (
-        cq.connect_attempt_limit >= 5000
-    ), "Some very high limit as RMQ can be down for awhile; SC-30467"
+    assert cq.connect_attempt_limit >= 5000, (
+        "Some very high limit as RMQ can be down for awhile; SC-30467"
+    )
 
 
 def test_cqs_gracefully_handles_unexpected_exception(mock_log, mock_rnd):

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -177,9 +177,9 @@ def test_provider_container_compatibility(
 def test_configs_repr_default_kwargs():
     assert repr(UserEndpointConfig()) == "UserEndpointConfig()"
     defs = f"pam={PamConfiguration(enable=False)!r}"
-    assert (
-        repr(ManagerEndpointConfig()) == f"ManagerEndpointConfig({defs})"
-    ), "mep is on base"
+    assert repr(ManagerEndpointConfig()) == f"ManagerEndpointConfig({defs})", (
+        "mep is on base"
+    )
 
 
 @pytest.mark.parametrize("kw,cls", known_user_config_opts.items())

--- a/compute_endpoint/tests/unit/test_endpoint_unit.py
+++ b/compute_endpoint/tests/unit/test_endpoint_unit.py
@@ -525,9 +525,9 @@ def test_endpoint_sets_process_title(
             ep.start_endpoint(*ep_args, reg_info=mock_reg_info, ep_info={})
 
     a, _k = mock_spt.setproctitle.call_args
-    assert a[0].startswith(
-        "Globus Compute Endpoint"
-    ), "Expect easily identifiable process name"
+    assert a[0].startswith("Globus Compute Endpoint"), (
+        "Expect easily identifiable process name"
+    )
     assert f"{ep_uuid}, {ep_dir.name}" in a[0], "Expect easily match process to ep conf"
     if not env:
         assert " - " not in a[0], "Default is not 'do not show env' for prod"

--- a/compute_endpoint/tests/unit/test_endpointinterchange.py
+++ b/compute_endpoint/tests/unit/test_endpointinterchange.py
@@ -189,9 +189,9 @@ def test_heartbeat_includes_static_info(ei, mock_rp, mock_tqs, mock_pack, mock_e
 
     # Note that this is the "hooked up" test.  The content of `get_status_report`
     # is verified by the engine-specific unit tests.
-    assert (
-        ei.engine.get_status_report.call_count == num_hbs_until_quit + 1
-    ), f"Should be {num_hbs_until_quit} heartbeats and a final sign off"
+    assert ei.engine.get_status_report.call_count == num_hbs_until_quit + 1, (
+        f"Should be {num_hbs_until_quit} heartbeats and a final sign off"
+    )
     for a, k in mock_pack.call_args_list:
         assert all(a[0].global_state[k] == v for k, v in mock_ep_info.items())
 

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -511,9 +511,9 @@ def test_sets_process_title(
     assert mock_spt.setproctitle.called, "Sanity check"
 
     a, *_ = mock_spt.setproctitle.call_args
-    assert a[0].startswith(
-        "Globus Compute Endpoint"
-    ), "Expect easily identifiable process name"
+    assert a[0].startswith("Globus Compute Endpoint"), (
+        "Expect easily identifiable process name"
+    )
     assert "*(" in a[0], "Expected asterisk as subtle clue of 'manager process'"
     assert f"{ep_uuid}, {conf_dir.name}" in a[0], "Can find process by conf"
 
@@ -1666,9 +1666,9 @@ def test_non_root_keeps_original_environment(
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
 
-    assert (
-        pyexc.value.code == _GOOD_UNPRIVILEGED_EC
-    ), "Q&D: verify we exec'ed, based on '+= 1'"
+    assert pyexc.value.code == _GOOD_UNPRIVILEGED_EC, (
+        "Q&D: verify we exec'ed, based on '+= 1'"
+    )
     _, k = mock_os.execvpe.call_args
     env = k["env"]
     assert all(env[k] and env[k] == expected_env[k] for k in exp_keys)
@@ -1799,9 +1799,9 @@ def test_warns_if_executable_not_found(
 
     assert mock_log.error.called
     a, _k = mock_log.error.call_args
-    assert (
-        "Unable to start user endpoint" in a[0]
-    ), "Expect attempt to log, even if fds closed"
+    assert "Unable to start user endpoint" in a[0], (
+        "Expect attempt to log, even if fds closed"
+    )
     assert f" [exit code: {ec};" in a[0], "Expect exit code for debugging"
     assert exc_text in a[0]
 
@@ -2047,9 +2047,9 @@ def test_run_as_same_user_does_not_change_uid(successful_exec_from_mocked_root):
     with pytest.raises(SystemExit) as pyexc:
         em._event_loop()
 
-    assert (
-        pyexc.value.code == _GOOD_UNPRIVILEGED_EC
-    ), "Q&D: verify we exec'ed, but no privilege drop"
+    assert pyexc.value.code == _GOOD_UNPRIVILEGED_EC, (
+        "Q&D: verify we exec'ed, but no privilege drop"
+    )
 
     assert not mock_os.initgroups.called
     assert not mock_os.setresuid.called

--- a/compute_endpoint/tests/unit/test_identity_mapper.py
+++ b/compute_endpoint/tests/unit/test_identity_mapper.py
@@ -139,9 +139,9 @@ def test_atomically_loads_new_configurations(mocker, conf_p):
         yield False
 
         assert isinstance(pim.identity_mappings, list)
-        assert "py_or_sh_or_rb_or_exe_or" in str(
-            pim.identity_mappings
-        ), "bad config; expect not changed"
+        assert "py_or_sh_or_rb_or_exe_or" in str(pim.identity_mappings), (
+            "bad config; expect not changed"
+        )
 
         conf_p.write_text("[]")
         yield False

--- a/compute_endpoint/tests/unit/test_pam.py
+++ b/compute_endpoint/tests/unit/test_pam.py
@@ -31,9 +31,9 @@ def test_pamh_username_limits_length(randomstring, name_len):
     assert pamh.max_username_len > 0
 
     pamh.username = randomstring(pamh.max_username_len + 1)
-    assert (
-        len(pamh.username) == pamh.max_username_len
-    ), "Like ssh, protect buggy PAM implementations from themselves"
+    assert len(pamh.username) == pamh.max_username_len, (
+        "Like ssh, protect buggy PAM implementations from themselves"
+    )
 
 
 def test_pamh_start_does_not_clobber_existing_session(pamh):

--- a/compute_endpoint/tests/unit/test_result_publisher.py
+++ b/compute_endpoint/tests/unit/test_result_publisher.py
@@ -99,9 +99,9 @@ def test_rp_stops_if_unable_to_connect(mocker, randomstring, attempt_limit):
 def test_rp_connect_limit_very_high_sc30467(randomstring):
     queue_info = {"queue": randomstring(), **q_info}
     rp = ResultPublisher(queue_info=queue_info)
-    assert (
-        rp.connect_attempt_limit >= 5000
-    ), "Some very high limit as RMQ can be down for awhile; SC-30467"
+    assert rp.connect_attempt_limit >= 5000, (
+        "Some very high limit as RMQ can be down for awhile; SC-30467"
+    )
 
 
 def test_rp_new_channel_resets_delivery_index():
@@ -281,9 +281,9 @@ def test_rp_publish_enqueues_message(randomstring):
     msg = b"abc"
     f = rp.publish(msg)
 
-    assert (
-        not rp._awaiting_confirmation
-    ), "publish() *enqueues*, but doesn't upstream publish yet"
+    assert not rp._awaiting_confirmation, (
+        "publish() *enqueues*, but doesn't upstream publish yet"
+    )
 
     f_enqueued, msg_enqueued = rp._outstanding.get()
 

--- a/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
+++ b/compute_sdk/globus_compute_sdk/sdk/auth/whoami.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 
+from globus_sdk import AuthAPIError, GlobusApp
+
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.utils.printing import print_table
-from globus_sdk import AuthAPIError, GlobusApp
 
 NOT_LOGGED_IN_MSG = "Unable to retrieve user information. Please log in again."
 

--- a/compute_sdk/globus_compute_sdk/sdk/batch.py
+++ b/compute_sdk/globus_compute_sdk/sdk/batch.py
@@ -7,6 +7,8 @@ import uuid
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 
+from globus_sdk import __version__ as __version_globus__
+
 from globus_compute_sdk.sdk.utils.uuid_like import (
     UUID_LIKE_T,
     as_optional_uuid,
@@ -14,7 +16,6 @@ from globus_compute_sdk.sdk.utils.uuid_like import (
 )
 from globus_compute_sdk.serialize import ComputeSerializer
 from globus_compute_sdk.version import __version__
-from globus_sdk import __version__ as __version_globus__
 
 _default_serde = ComputeSerializer()
 

--- a/compute_sdk/globus_compute_sdk/sdk/client.py
+++ b/compute_sdk/globus_compute_sdk/sdk/client.py
@@ -12,6 +12,7 @@ import warnings
 
 import globus_sdk
 from globus_compute_common.sdk_version_sharing import user_agent_substring
+
 from globus_compute_sdk.errors import (
     SerializationError,
     TaskExecutionFailed,

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import colorama
+from rich import get_console
+from rich.console import Console
+
 from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.sdk._environments import (
     get_amqp_service_host,
@@ -33,8 +36,6 @@ from globus_compute_sdk.sdk.utils.sample_function import (
     sdk_tutorial_sample_simple_function,
 )
 from globus_compute_sdk.serialize.concretes import DillCodeTextInspect
-from rich import get_console
-from rich.console import Console
 
 OUTPUT_FILENAME = "globus_compute_diagnostic_{}.txt.gz"
 # How long to wait for any individual diagnostic before timing out
@@ -64,7 +65,7 @@ def cat(
     def kernel() -> None:
         for filename in files:
             cat_cmd = "cat " + filename
-            print(f'{cat_cmd}\n{"=" * len(cat_cmd)}')
+            print(f"{cat_cmd}\n{'=' * len(cat_cmd)}")
             if os.path.exists(filename):
                 with open(filename, "rb") as f:
                     if max_bytes:
@@ -77,7 +78,7 @@ def cat(
                 print(f" | {indented_content}")
             else:
                 print_warning(f"No file named {filename}\n")
-            print(f'{"-" * len(cat_cmd)}\n')
+            print(f"{'-' * len(cat_cmd)}\n")
 
     return kernel
 

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -19,6 +19,7 @@ from concurrent.futures import InvalidStateError
 import pika
 from globus_compute_common import messagepack
 from globus_compute_common.messagepack.message_types import Result
+
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.client import Client

--- a/compute_sdk/globus_compute_sdk/sdk/shell_function.py
+++ b/compute_sdk/globus_compute_sdk/sdk/shell_function.py
@@ -3,7 +3,6 @@ import typing as t
 
 
 class ShellResult:
-
     def __init__(
         self,
         cmd: str,
@@ -68,7 +67,6 @@ class ShellResult:
 
 
 class ShellFunction:
-
     def __init__(
         self,
         cmd: str,

--- a/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
+++ b/compute_sdk/globus_compute_sdk/sdk/utils/__init__.py
@@ -7,9 +7,10 @@ from itertools import islice
 from pathlib import Path
 
 import dill
-import globus_compute_sdk.version as sdk_version
 import packaging.version
 from packaging.version import Version
+
+import globus_compute_sdk.version as sdk_version
 
 
 def chunk_by(iterable: t.Iterable, size) -> t.Iterable[tuple]:
@@ -81,12 +82,12 @@ def check_version(task_details: dict | None, check_py_micro: bool = True) -> str
         if python_mismatch or sdk_dill != worker_dill:
             return (
                 "\nEnvironment differences detected between local SDK and "
-                f"endpoint {worker_epid} workers:\n"
-                f"\t    SDK: Python {sdk_py}/Dill {sdk_dill}\n"
-                f"\tWorkers: Python {worker_py}/Dill {worker_dill}\n"
-                f"This may cause serialization issues.  See "
-                "https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html#avoiding-serialization-errors "  # noqa"
-                "for more information."
+                f"endpoint {worker_epid} workers:"
+                f"\n\t    SDK: Python {sdk_py}/Dill {sdk_dill}"
+                f"\n\tWorkers: Python {worker_py}/Dill {worker_dill}"
+                f"\nThis may cause serialization issues.  See"
+                " https://globus-compute.readthedocs.io/en/latest/sdk/executor_user_guide.html#avoiding-serialization-errors"
+                " for more information."
             )
     return None
 

--- a/compute_sdk/globus_compute_sdk/serialize/concretes.py
+++ b/compute_sdk/globus_compute_sdk/serialize/concretes.py
@@ -9,6 +9,7 @@ import typing as t
 from collections import OrderedDict
 
 import dill
+
 from globus_compute_sdk.errors import DeserializationError, SerializationError
 from globus_compute_sdk.serialize.base import (
     ComboSerializationStrategy,

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -1,5 +1,6 @@
-from globus_compute_sdk.errors import VersionMismatch
 from packaging.version import Version
+
+from globus_compute_sdk.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/

--- a/compute_sdk/parsl/app/errors.py
+++ b/compute_sdk/parsl/app/errors.py
@@ -1,7 +1,8 @@
 import logging
+from collections.abc import Callable
 from functools import wraps
 from types import TracebackType
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, TypeVar
 
 import dill
 from tblib import Traceback
@@ -37,7 +38,7 @@ R = TypeVar("R")
 
 def wrap_error(
     func: Callable[..., R],
-) -> Callable[..., Union[R, RemoteExceptionWrapper]]:
+) -> Callable[..., R | RemoteExceptionWrapper]:
     @wraps(func)  # type: ignore
     def wrapper(*args: object, **kwargs: object) -> Any:
         import sys

--- a/compute_sdk/tests/unit/test_client.py
+++ b/compute_sdk/tests/unit/test_client.py
@@ -354,9 +354,9 @@ def test_register_function(gcc: gc.Client, serde: ComputeSerializer):
     assert data["function_name"] == funk.__name__
     assert data["function_code"] is not None
     assert data["description"] == inspect.getdoc(funk)
-    assert (
-        data["meta"]["python_version"] == metadata["python_version"]
-    ), "Expect to match the *running* Python version"
+    assert data["meta"]["python_version"] == metadata["python_version"], (
+        "Expect to match the *running* Python version"
+    )
     assert data["meta"]["sdk_version"] == metadata["sdk_version"]
     assert data["meta"]["serde_identifier"] == metadata["serde_identifier"]
 

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -510,7 +510,7 @@ def test_diagnostic_base_dir_GC_HOME_or_config_param(
         else:
             with pytest.raises(SystemExit) as se:
                 do_diagnostic_base(diag_args)
-            assert se.type == SystemExit
+            assert se.type is SystemExit
             assert se.value.code == os.EX_NOINPUT
 
 

--- a/compute_sdk/tests/unit/test_executor.py
+++ b/compute_sdk/tests/unit/test_executor.py
@@ -892,9 +892,9 @@ def test_reload_tasks_all_completed(gce: Executor):
 
     assert len(client_futures) == num_tasks
     assert sum(1 for fut in client_futures if fut.done()) == num_tasks
-    assert (
-        _RESULT_WATCHERS.get(gce.task_group_id) is None
-    ), "Should NOT start watcher: all tasks done!"
+    assert _RESULT_WATCHERS.get(gce.task_group_id) is None, (
+        "Should NOT start watcher: all tasks done!"
+    )
 
 
 @pytest.mark.parametrize(

--- a/compute_sdk/tests/unit/test_shell_functions.py
+++ b/compute_sdk/tests/unit/test_shell_functions.py
@@ -310,7 +310,6 @@ def test_stdout_naming(run_in_tmp_dir, monkeypatch):
     assert os.path.join(run_in_tmp_dir, task_id) not in result.stdout
     assert run_in_tmp_dir.name in result.stdout
     for std_file in os.listdir(run_in_tmp_dir):
-
         assert len(std_file.split(".")) == 3
         assert std_file.split(".")[-1] in ["stdout", "stderr"]
         assert std_file.split(".")[0] == task_id

--- a/smoke_tests/tests/test_running_functions.py
+++ b/smoke_tests/tests/test_running_functions.py
@@ -85,12 +85,12 @@ def test_executor(compute_client, endpoint, tutorial_function_id, timeout_s: int
             for f in concurrent.futures.as_completed(futures, timeout=timeout_s):
                 results.append(f.result())
 
-            assert (
-                len(results) == num_tasks
-            ), f"Expected {num_tasks} results; received: {len(results)}"
-            assert all(
-                "Hello World!" == item for item in results
-            ), f"Invalid result: {results}"
+            assert len(results) == num_tasks, (
+                f"Expected {num_tasks} results; received: {len(results)}"
+            )
+            assert all("Hello World!" == item for item in results), (
+                f"Invalid result: {results}"
+            )
 
         futures = list(gce.reload_tasks())
         assert len(futures) == submit_count * num_tasks
@@ -98,6 +98,6 @@ def test_executor(compute_client, endpoint, tutorial_function_id, timeout_s: int
         results = []
         for f in concurrent.futures.as_completed(futures, timeout=timeout_s):
             results.append(f.result())
-        assert all(
-            "Hello World!" == item for item in results
-        ), f"Invalid result: {results}"
+        assert all("Hello World!" == item for item in results), (
+            f"Invalid result: {results}"
+        )

--- a/smoke_tests/tests/test_version.py
+++ b/smoke_tests/tests/test_version.py
@@ -15,9 +15,9 @@ def test_web_service(compute_client, endpoint, compute_test_config):
     if api_min_version is not None:
         parsed_min = Version(api_min_version)
         parsed_service = Version(service_version)
-        assert (
-            parsed_service >= parsed_min
-        ), f"Expected API version >={api_min_version}, got {service_version}"
+        assert parsed_service >= parsed_min, (
+            f"Expected API version >={api_min_version}, got {service_version}"
+        )
 
 
 def say_hello():
@@ -34,6 +34,6 @@ def test_ep_status(compute_client, endpoint):
     """Test whether the tutorial EP is online and reporting status"""
     response = compute_client.get_endpoint_status(endpoint)
 
-    assert (
-        response["status"] == "online"
-    ), f"Expected tutorial EP to be online, got:{response['status']}"
+    assert response["status"] == "online", (
+        f"Expected tutorial EP to be online, got:{response['status']}"
+    )


### PR DESCRIPTION
I'm less concerned about the speed (but it is *much* faster), and more concerned with it _working at all_.  Current PRs are dying on the precommit external, and looks like in the flake8 codes.  I don't see any reference to supporting 3.14 in the flake8 changelogs, but I also don't see many flake8 bug reports or other messages.  Regardless, `ruff` works, and also incorporates `isort` and `black`.  Meanwhile, I think it's arguably more correct in a couple of cases.  So ... notwithstanding some of the git-churn, trying on Ruff for size.

Also, while here, drop Python3.9 support in pyupgrade.

To the reviewer: The key change is in `.pre-commit-config.yaml`.  Everything else is an automated change from `ruff`.

## Type of change

- Code maintenance/cleanup