### PR TITLE
Enable backward-compatibility around UEP start

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -566,12 +566,28 @@ def configure_endpoint(
 @mep_start_options
 @common_options
 @handle_auth_errors
-def start_endpoint(*, ep_dir: pathlib.Path, **_kwargs):
+@click.option(
+    "--die-with-parent",
+    hidden=True,
+    type=click.BOOL,
+    is_flag=True,
+    default=False,
+)
+def start_endpoint(*, ep_dir: pathlib.Path, die_with_parent: bool, **_kwargs):
     state = CommandState.ensure()
-    _start_endpoint_manager(
-        ep_dir=ep_dir,
-        endpoint_uuid=state.endpoint_uuid,
-    )
+    # for backward compatibility with EndpointManager versions that run
+    # `gce start --die-with-parent` instead of `gce _start-user-endpoint`.
+    # deprecated; to be removed in 6 months (roughly Oct 2026)
+    if die_with_parent:
+        _start_user_endpoint(
+            ep_dir=ep_dir,
+            endpoint_uuid=state.endpoint_uuid,
+        )
+    else:
+        _start_endpoint_manager(
+            ep_dir=ep_dir,
+            endpoint_uuid=state.endpoint_uuid,
+        )
 
 
 @app.command(name="_start-user-endpoint", hidden=True)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint_manager.py
@@ -60,6 +60,7 @@ from globus_compute_endpoint.exceptions import MessageSystemExit
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.auth_client import ComputeAuthClient
 from globus_compute_sdk.sdk.compute_dir import ensure_compute_dir
+from packaging.version import Version
 
 if t.TYPE_CHECKING:
     from pika.spec import BasicProperties
@@ -1140,6 +1141,31 @@ class EndpointManager:
             os.umask(umask)
             exit_code += 1
 
+            user_opts = kwargs.get("user_opts", {})
+            user_runtime = kwargs.get("user_runtime", {})
+            user_config = render_config_user_template(
+                self._config,
+                template_str,
+                self.user_config_template_path,
+                ident,
+                user_config_schema,
+                user_opts,
+                user_runtime,
+            )
+
+            if py_version := user_runtime.get("python", {}).get("version"):
+                env.setdefault("GC_USER_PYTHON_VERSION", py_version)
+            if gce_version := user_runtime.get("globus_compute_sdk_version"):
+                env.setdefault("GC_USER_SDK_VERSION", gce_version)
+                # assuming (as in the TMEP case) that if this env var is set, the UEP
+                # will run on this version of GCE. therefore, update proc args here
+                # for backward compatibility with UEP code that expects
+                # `gce start --die-with-parent` instead of `gce _start-user-endpoint`.
+                # deprecated; to be removed in 6 months (roughly Oct 2026)
+                if Version(gce_version) < Version("4.10.0"):
+                    proc_args[1] = "start"
+                    proc_args.append("--die-with-parent")
+
             # some Q&D verification for admin debugging purposes
             if not shutil.which(proc_args[0]):
                 log.warning(
@@ -1167,23 +1193,6 @@ class EndpointManager:
             ep_dir = gc_dir / ep_name
             ep_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
             ep_log = ep_dir / "endpoint.log"
-
-            user_opts = kwargs.get("user_opts", {})
-            user_runtime = kwargs.get("user_runtime", {})
-            user_config = render_config_user_template(
-                self._config,
-                template_str,
-                self.user_config_template_path,
-                ident,
-                user_config_schema,
-                user_opts,
-                user_runtime,
-            )
-
-            if py_version := user_runtime.get("python", {}).get("version"):
-                env.setdefault("GC_USER_PYTHON_VERSION", py_version)
-            if gce_version := user_runtime.get("globus_compute_sdk_version"):
-                env.setdefault("GC_USER_SDK_VERSION", gce_version)
 
             exit_code += 1
             _conf = yaml.safe_load(user_config)

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -1021,6 +1021,26 @@ def test_config_yaml_display_none(run_line, gc_dir, display_name):
     assert conf.display_name is None, conf.display_name
 
 
+@pytest.mark.parametrize("die_with_parent", [True, False])
+def test_start_ep_handles_die_with_parent(
+    run_line, make_endpoint_dir, ep_name, die_with_parent, mocker
+):
+    mock__start_user_endpoint = mocker.patch(f"{_MOCK_BASE}_start_user_endpoint")
+    mock__start_endpoint_manager = mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
+
+    make_endpoint_dir()
+
+    cmd = f"start {ep_name}" + (" --die-with-parent" if die_with_parent else "")
+    run_line(cmd)
+
+    if die_with_parent:
+        assert mock__start_user_endpoint.called, "Only the UEP should start"
+        assert not mock__start_endpoint_manager.called, "Only the UEP should start"
+    else:
+        assert not mock__start_user_endpoint.called, "Only the manager should start"
+        assert mock__start_endpoint_manager.called, "Only the manager should start"
+
+
 def test_start_ep_incorrect_config_yaml(
     run_line, mock_command_ensure, make_endpoint_dir, ep_name
 ):

--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -355,7 +355,7 @@ def command_payload(ident):
                 "python": {
                     "version": "3.4.2",
                 },
-                "globus_compute_sdk_version": "2.90.2",
+                "globus_compute_sdk_version": "4.10.0",
             },
         },
     }
@@ -1822,6 +1822,27 @@ def test_start_endpoint_children_correct_command(successful_exec_from_mocked_roo
     assert a[0] == "globus-compute-endpoint", "Sanity check"
     assert k["args"][0] == a[0], "Expect transparency for admin"
     assert k["args"][1] == "_start-user-endpoint", "trust CLI does the work"
+
+
+def test_start_endpoint_children_backward_compatible_command(
+    command_payload, successful_exec_from_mocked_root, mock_props
+):
+    mock_os, *_, em = successful_exec_from_mocked_root
+
+    # arbitrary version less than 4.10.0
+    command_payload["kwargs"]["user_runtime"]["globus_compute_sdk_version"] = "0.0.0"
+    queue_item = (1, mock_props, json.dumps(command_payload).encode())
+    em._command_queue.get.side_effect = [queue_item, queue.Empty()]
+
+    with pytest.raises(SystemExit) as pyexc:
+        em._event_loop()
+
+    assert pyexc.value.code == _GOOD_EC, "Q&D: verify we exec'ed, based on '+= 1'"
+    a, k = mock_os.execvpe.call_args
+    assert a[0] == "globus-compute-endpoint", "Sanity check"
+    assert k["args"][0] == a[0], "Expect transparency for admin"
+    assert k["args"][1] == "start", "Expect older CLI commmand name"
+    assert k["args"][-1] == "--die-with-parent", "Expect differentiating flag"
 
 
 def test_start_endpoint_children_have_own_session(successful_exec_from_mocked_root):


### PR DESCRIPTION
# Description

When refactoring the endpoint CLI start code, the `die-with-parent` flag was removed, and the codepath to start a UEP was moved into its own `_start-user-endpoint` command. This is all fine and dandy on a system where MEPs and UEPs run in sync as the same version, but in any case where they can diverge (eg, the tutorial endpoint), that leads to breakages.

This commit adds code to handle both backward- and forward- compatibility. The change in `endpoint_manager.py` makes it easier for new MEPs to start UEPs running old versions of the code, while the change in `cli.py` teaches newer versions of the code how to handle the previous "protocol."

## Type of change

- Bug fix (non-breaking change that fixes an issue)
