### PR TITLE
Endpoint platform packages: install symlinks to all setup.py entry_points

### DIFF
--- a/changelog.d/20260507_135952_chris_sc_40747.rst
+++ b/changelog.d/20260507_135952_chris_sc_40747.rst
@@ -1,0 +1,6 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- The ``globus-compute-diagnostic`` and ``globus-idm-validator`` tools, which are
+  installed alongside the endpoint, are now available on the PATH after installing
+  the ``globus-compute-agent`` package.

--- a/compute_endpoint/packaging/Makefile
+++ b/compute_endpoint/packaging/Makefile
@@ -28,6 +28,11 @@ PIP_NAME_S := $(shell echo $(PIP_NAME_D) | tr '-' '\n' | cut -c1 | tr -d '\n')
 SDK_NAME_D := $(shell cd ../../compute_sdk; "$(VENV_PY)" setup.py --name)
 SDK_NAME_U := $(shell echo $(SDK_NAME_D) | tr '-' '_')
 
+# Need to manually link all setup.py entry_points as part of the install.
+# Does not include gce, which is specially handled as an alias to the package_shim
+# to ensure it picks up on any customizations (see PIP_NAME_S)
+PKG_ENTRY_POINTS := globus-compute-diagnostic globus-idm-validator
+
 PKG_VERSION := $(shell cd ../; "$(VENV_PY)" setup.py --version | tr '-' '~')
 PKG_WHEEL := $(PIP_NAME_U)-$(PKG_VERSION)-py$(PY_MAJOR_VERSION)-none-any.whl
 PKG_SOURCE_DIR := $(PIP_NAME_U)-$(PKG_VERSION)
@@ -73,6 +78,7 @@ show_vars:   ##-For debugging, show the Makefile variables; will install a venv
 	@echo "PIP_NAME_S           : $(PIP_NAME_S)"
 	@echo "PKG_NAME             : $(PKG_NAME)"
 	@echo "PKG_VERSION          : $(PKG_VERSION)"
+	@echo "PKG_ENTRY_POINTS     : $(PKG_ENTRY_POINTS)"
 	@echo "PREREQS_DIR          : $(PREREQS_DIR)"
 	@echo "PREREQS_TARBALL_NAME : $(PREREQS_TARBALL_NAME)"
 	@echo "PKG_SOURCE_DIR       : $(PKG_SOURCE_DIR)"
@@ -201,6 +207,7 @@ _setup_dist_for_deb:
 	    -e "s/@PIP_NAME_D@/$(PIP_NAME_D)/g" \
 	    -e "s/@PIP_NAME_S@/$(PIP_NAME_S)/g" \
 	    -e "s/@VIRTUALENV@/$(VIRTUALENV)/g" \
+	    -e "s/@PKG_ENTRY_POINTS@/$(PKG_ENTRY_POINTS)/g" \
 	)
 
 setup_dist_for_deb: dist _setup_dist_for_deb  ##-Place Debian-build required files in dist/
@@ -238,6 +245,7 @@ _setup_dist_for_rpm:
 	    -e "s/@PREREQS_TARBALL_NAME@/$(PREREQS_TARBALL_NAME)/g" \
 	    -e "s/@PIP_NAME_D@/$(PIP_NAME_D)/g" \
 	    -e "s/@PIP_NAME_S@/$(PIP_NAME_S)/g" \
+	    -e "s/@PKG_ENTRY_POINTS@/$(PKG_ENTRY_POINTS)/g" \
 	    -e "s/@PACKAGE_SOURCE_DIR@/$(PKG_SOURCE_DIR)/" \
 	    -e "s/@PREREQS_DIR@/$(PREREQS_DIR)/" \
 	    < ../fedora/$(PKG_NAME).spec.in > ./$(PKG_NAME).spec \

--- a/compute_endpoint/packaging/debian/rules
+++ b/compute_endpoint/packaging/debian/rules
@@ -72,6 +72,9 @@ override_dh_auto_install:
 	rm -rf $(DEST_VIRTUAL_ENV)/systemd \
 	  $(DEST_VIRTUAL_ENV)/lib/python*/site-packages/tests; \
 	sed -i "$(DEST_VIRTUAL_ENV)/bin/activate" -e "s|^VIRTUAL_ENV=.*|VIRTUAL_ENV=$(VIRTUAL_ENV)|"; \
+	for entrypoint in @PKG_ENTRY_POINTS@; do \
+		ln -sf "$(VIRTUAL_ENV)/bin/$$entrypoint" "$(DEST_ROOT)$(_sbindir)/$$entrypoint"; \
+	done; \
 	ln -s "python$$($(PYTHON3) -c 'import sys; print("{}.{}".format(*sys.version_info))')" "$(DEST_VIRTUAL_ENV)/lib/python"; \
 	:
 

--- a/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
+++ b/compute_endpoint/packaging/fedora/globus-compute-agent.spec.in
@@ -87,6 +87,10 @@ install -m 755 "%{_builddir}/@PACKAGE_SOURCE_DIR@"/package_shim.sh "${RPM_BUILD_
 sed -i "${RPM_BUILD_ROOT}%{_sbindir}/%{package_executable}" -e "s|@VIRTUAL_ENV@|%{VIRTUAL_ENV}|"
 ln -sf "%{package_executable}" "${RPM_BUILD_ROOT}%{_sbindir}/%{package_alias}"
 
+for entrypoint in @PKG_ENTRY_POINTS@; do
+    ln -sf "%{VIRTUAL_ENV}/bin/${entrypoint}" "${RPM_BUILD_ROOT}%{_sbindir}/${entrypoint}"
+done
+
 %pre
 
 %post
@@ -104,6 +108,7 @@ ln -sf "%{package_executable}" "${RPM_BUILD_ROOT}%{_sbindir}/%{package_alias}"
 %{VIRTUAL_ENV}/*
 %{_sbindir}/%{package_executable}
 %{_sbindir}/%{package_alias}
+%{expand:%%(for ep in @PKG_ENTRY_POINTS@; do echo "%{_sbindir}/$ep"; done)}
 
 %changelog
 * Mon May 02 2024 Globus Toolkit <support@globus.org> - @PACKAGE_VERSION@-%{release}


### PR DESCRIPTION
# Description

Recent work covered `gce`, but `globus-compute-diagnostic` and `globus-idm-validator` also need a specific mechanism for getting on the user's PATH. This commit adds a variable to track any scripts defined in a setup.py's entry_points field, and modifies the package installs to include symlinks to those entry_point scripts.

[sc-40747]

## Type of change

- New feature (non-breaking change that adds functionality)
