### PR TITLE
Address Pika's just-released bug

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -35,7 +35,8 @@ REQUIRES = [
     # of different features and functions
     # pin exact versions because it does not use semver
     "parsl==2026.4.20",
-    "pika>=1.2.0",
+    # May 2026: Parsl 1.4.0 just released; has an as-yet undiagnosed iteration bug
+    "pika>=1.2,<1.4",
     "pyprctl<0.2.0",
     "setproctitle>=1.3.2,<1.4",
     "pyyaml>=6.0,<7.0",

--- a/compute_sdk/setup.py
+++ b/compute_sdk/setup.py
@@ -18,7 +18,8 @@ REQUIRES = [
     # packaging, allowing version parsing
     # set a version floor but no ceiling as the library offers a stable API under CalVer
     "packaging>=21.1",
-    "pika>=1.2",
+    # May 2026: Parsl 1.4.0 just released; has an as-yet undiagnosed iteration bug
+    "pika>=1.2,<1.4",
     "tblib==1.7.0",
     "texttable>=1.6.7",
     # 3 below for color highlighting related console print


### PR DESCRIPTION
Pika released 1.4.0 yesterday.  A slew of changes after 3 years!  But apparently also a bug or perhaps a changed expectation across the version boundary:

```python
>    for consumer_tag in self._consumers.keys():
E    RuntimeError: dictionary changed size during iteration
```
    
For the release next week, give 1.4.0 some time to settle, and we'll drop this constraint at a future date

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintenance/cleanup