### PR TITLE
auto fix imports by default using ruff-check 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
       args: [ --select, I ]
     - id: ruff-check
       types_or: [ python ]
-      args: [ --fix ]
+      args: [ --fix, --select, I ]
     - id: ruff-format
       types_or: [ python ]


### PR DESCRIPTION
The existing pre-commit script doesn't actually auto fix imports, as just passing in --fixed doesn't work:

```
...
Found 1 error.
[*] 1 fixable with the `--fix` option.

ruff check...............................................................Passed
ruff format..............................................................Passed
```

We actually need [--fix, --select, I] to make it work as intended (first pass displays the error, the second pass fixes)