### PR TITLE
Emit error message to std stream

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -674,12 +674,13 @@ def _pidfile_check(pid_path: pathlib.Path, stale_after_s: int | float):
     mtime_human = time.ctime(pid_mtime)
     p_content = pid_path.read_text().strip()
     pid = p_content.split(maxsplit=1)[0]
-    log.info(
+    stderr_msg = (
         f"\n        PID path: {pid_path} (PID: {pid})"
         f"\n   Last modified: {pid_mtime:.3f} ({mtime_human})"
         f"\n    Current time: {_now:.3f} ({now_human})"
         f"\nPID file content:\n{p_content}"
     )
+    log.info(stderr_msg)
     if _now - pid_mtime <= stale_after_s:
         msg = (
             "Another instance of this endpoint is running.  (Perhaps on"
@@ -687,7 +688,8 @@ def _pidfile_check(pid_path: pathlib.Path, stale_after_s: int | float):
             " correct, then remove the PID file before starting again."
         )
         log.error(msg)
-        raise MessageSystemExit(os.EX_CANTCREAT, msg)
+        stderr_msg += f"\n\n{msg}"
+        raise MessageSystemExit(os.EX_CANTCREAT, stderr_msg)
 
     else:
         log.warning(
@@ -760,12 +762,28 @@ class _SendMessageOnErrorExit(contextlib.AbstractContextManager):
             # normal, system exit
             return
 
+        msg = f"Failed to start or unexpected error:\n  ({exc_type.__name__}) {exc_val}"
         if self.reg_info:
-            msg = (
-                f"Failed to start or unexpected error:\n  ({exc_type.__name__})"
-                f" {exc_val}"
-            )
             send_endpoint_startup_failure_to_amqp(self.reg_info, msg=msg)
+
+        if sys.version_info < (3, 12):
+            if "console" not in getattr(logging, "_handlers", {}):
+                out = None
+                if sys.stderr.isatty():
+                    out = sys.stderr
+                elif sys.stdout.isatty():
+                    out = sys.stdout
+                if out:
+                    print(msg, file=out)
+        else:
+            if not logging.getHandlerByName("console"):
+                out = None
+                if sys.stderr.isatty():
+                    out = sys.stderr
+                elif sys.stdout.isatty():
+                    out = sys.stdout
+                if out:
+                    print(msg, file=out)
 
 
 def _do_register_endpoint(

--- a/compute_endpoint/globus_compute_endpoint/logging_config.py
+++ b/compute_endpoint/globus_compute_endpoint/logging_config.py
@@ -163,18 +163,10 @@ def _get_file_dict_config(
                 file_handler.pop("backupCount", None)
 
     log_handlers = ["logfile"]
-    if console_enabled:
-        log_handlers.append("console")
 
-    return {
+    log_config = {
         "version": 1,
         "formatters": {
-            "streamfmt": {
-                "()": ComputeConsoleFormatter,
-                "debug": debug,
-                "no_color": no_color,
-                "datefmt": LOG_TS_FMT,
-            },
             "filefmt": {
                 "()": DatetimeFormatter,
                 "format": DEFAULT_FORMAT,
@@ -182,11 +174,6 @@ def _get_file_dict_config(
             },
         },
         "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "level": "DEBUG",
-                "formatter": "streamfmt",
-            },
             "logfile": file_handler,
         },
         "loggers": {
@@ -204,6 +191,22 @@ def _get_file_dict_config(
             },
         },
     }
+
+    if console_enabled:
+        log_config["formatters"]["streamfmt"] = {  # type: ignore[index]
+            "()": ComputeConsoleFormatter,
+            "debug": debug,
+            "no_color": no_color,
+            "datefmt": LOG_TS_FMT,
+        }
+        log_config["handlers"]["console"] = {  # type: ignore[index]
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "streamfmt",
+        }
+        log_handlers.append("console")
+
+    return log_config
 
 
 def _get_stream_dict_config(debug: bool, no_color: bool) -> dict:

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -1356,23 +1356,67 @@ def test_happy_path_exit_no_amqp_msg(
     ),
 )
 def test_fail_exit_sends_amqp_msg(
-    mocker,
     run_line,
     mock_ep,
     make_endpoint_dir,
+    mock_send_endpoint_startup_failure_to_amqp,
     ep_name,
     ec,
     exit_exc,
     mock_load_config_yaml,
 ):
-    mock_send = mocker.patch(f"{_MOCK_BASE}send_endpoint_startup_failure_to_amqp")
     make_endpoint_dir()
 
     stdin = json.dumps({"amqp_creds": {"some": "data"}, "ep_info": {}, "config": ""})
     mock_ep.start_endpoint.side_effect = exit_exc
     run_line(f"_start-user-endpoint {ep_name}", assert_exit_code=ec, stdin=stdin)
+
     assert mock_ep.start_endpoint.called
-    assert mock_send.called
+    assert mock_send_endpoint_startup_failure_to_amqp.called
+
+
+@pytest.mark.parametrize(
+    "exit_exc",
+    (
+        SystemExit("Death!"),
+        SystemExit(5),
+        RuntimeError("fool!"),
+        MemoryError("Oh no!"),
+        AssertionError("mistake"),
+        Exception("Generally no good."),
+    ),
+)
+@pytest.mark.parametrize("o_tty", (False, True))
+@pytest.mark.parametrize("e_tty", (False, True))
+def test_file_exit_conditionally_emits_why_to_stdstream(
+    mock_client,
+    mock_mep,
+    make_manager_endpoint_dir,
+    mock_send_endpoint_startup_failure_to_amqp,
+    ep_name,
+    exit_exc,
+    o_tty,
+    e_tty,
+):
+    make_manager_endpoint_dir(ep_name)
+    mock_mep.start.side_effect = exit_exc
+
+    # click.CliRunner swaps in its own std streams, so can't use run_line
+    stdo, stde = io.StringIO(), io.StringIO()
+    stdo.isatty = lambda: o_tty
+    stde.isatty = lambda: e_tty
+    with pytest.raises(exit_exc.__class__) as pyt_e:
+        with redirect_stdout(stdo), redirect_stderr(stde):
+            cli.app.main(args=("start", ep_name), prog_name=cli.app.name)
+
+    if e_tty:
+        assert type(pyt_e.value).__name__ in stde.getvalue()
+        assert str(pyt_e.value) in stde.getvalue()
+        assert "Failed to start" in stde.getvalue()
+    else:
+        assert (type(pyt_e.value).__name__ in stdo.getvalue()) is o_tty
+        assert (str(pyt_e.value) in stdo.getvalue()) is o_tty
+        assert ("Failed to start" in stdo.getvalue()) is o_tty
 
 
 @pytest.mark.parametrize("force", [True, False])


### PR DESCRIPTION
If the logger has not already done it, and one of the std streams is a tty, emit the reason for exit to the std stream.  The motivating use-case is when a `--detach`ed endpoint refuses to start up because of a PID file — until this commit, it would just silently return the prompt (unless the user had specified `--log-to-console`; who but the devs does that?).  No good.

## Type of change

- Documentation update