### PR TITLE
Catch Timeout exception when stopping endpoints

### DIFF
--- a/changelog.d/20260518_144358_lei_forced_del_err_sc_45767.rst
+++ b/changelog.d/20260518_144358_lei_forced_del_err_sc_45767.rst
@@ -1,0 +1,6 @@
+Bug Fixes
+^^^^^^^^^
+
+- A user-unfriendly Timeout stacktrace Exception may be displayed to the
+  user when force deleting an endpoint in unusual circumstances.  The
+  stacktrace is now replaced with a suggestion to retry the delete command.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -661,7 +661,14 @@ class Endpoint:
 
             # Give parent process chance to clean itself up
             parent.terminate()
-            parent.wait(timeout=grace_period_s)
+            try:
+                parent.wait(timeout=grace_period_s)
+            except psutil.TimeoutExpired:
+                log.warning(
+                    f"Encountered timeout attempting to stop endpoint {ep_name},"
+                    " Please try deleting the endpoint again with the --force flag"
+                )
+                sys.exit(-1)
 
             # After grace period, give children 1 second, before pulling the plug
             terminated, alive = psutil.wait_procs(processes, timeout=grace_period_s)

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -4,6 +4,7 @@ import random
 import shutil
 from unittest import mock
 
+import psutil
 import pytest
 import requests
 import responses
@@ -155,6 +156,33 @@ def test_endpoint_teardown_execution(mocker, tmp_path, randomstring):
 
     info_txt = "\n".join(a[0] for a, _k in mock_log.info.call_args_list)
     assert tmp_file_content in info_txt
+
+
+def test_endpoint_psutil_timeout(conf_dir, mocker, ep_uuid):
+    mocker.patch.object(shutil, "rmtree")
+
+    endpoint.Endpoint.configure_endpoint(conf_dir, None)
+
+    mock_gcc = mocker.Mock()
+    mocker.patch(f"{_MOCK_BASE}Endpoint.get_funcx_client").return_value = mock_gcc
+
+    mock_gcc.get_endpoint_status.return_value = {"status": "online"}
+    mocker.patch(
+        f"{_MOCK_BASE}Endpoint.check_pidfile",
+        return_value={"exists": "True", "active": True},
+    )
+    pid_path = endpoint.Endpoint.pid_path(conf_dir)
+    pid_path.write_text("12345")
+
+    mock_psutil = mocker.patch(f"{_MOCK_BASE}psutil.Process")
+    mock_psutil.return_value.wait.side_effect = psutil.TimeoutExpired(10)
+
+    with pytest.raises(SystemExit), mock.patch(f"{_MOCK_BASE}log") as mock_log:
+        endpoint.Endpoint.delete_endpoint(
+            conf_dir, ep_config=None, force=True, ep_uuid=ep_uuid
+        )
+    a, _k = mock_log.warning.call_args
+    assert "Please try deleting the endpoint again" in a[0], "expecting rephrasing"
 
 
 @pytest.mark.parametrize("web_svc_ok", (True, False))


### PR DESCRIPTION
# Description

In some situations, when deleting an endpoint, the system utilities package psutil may raise a Timeout Exception when the parent process is still alive 10s after calling parent.terminate().

It isn't trivial to reproduce this error, so this PR attempts to catch the Exception and prints a standard Error message telling the user to try deleting again, a more friendly message.

Addresses [sc-45767]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
