### PR TITLE
Teach endpoint_dev how to install a local globus-compute-common

### DIFF
--- a/endpoint_dev.Dockerfile
+++ b/endpoint_dev.Dockerfile
@@ -7,10 +7,22 @@ RUN apt-get install -y less socat sudo vim
 RUN mkdir -p /opt/globus-compute
 COPY . /opt/globus-compute
 
+ARG GLOBUS_COMPUTE_COMMON_DIR=""
+RUN --mount=type=bind,from=globus_compute_common,source=.,target=/build-context-common,readonly \
+	if [ -n "${GLOBUS_COMPUTE_COMMON_DIR}" ]; then \
+		if [ ! -d "/build-context-common" ] || [ -z "$(ls -A /build-context-common)" ]; then \
+			echo "Path not found or empty: ${GLOBUS_COMPUTE_COMMON_DIR}"; \
+			exit 1; \
+		fi; \
+		mkdir -p /opt/globus-compute-common; \
+		cp -R /build-context-common/. /opt/globus-compute-common; \
+	fi
+
 RUN python -m pip install -U pip
 RUN python -m pip install tox
 RUN python -m pip install -e /opt/globus-compute/compute_endpoint
 RUN python -m pip install -e /opt/globus-compute/compute_sdk
+RUN if [ -n "${GLOBUS_COMPUTE_COMMON_DIR}" ]; then python -m pip install -e /opt/globus-compute-common; fi
 
 ARG LOCAL_USER
 RUN useradd -m ${LOCAL_USER}

--- a/local_dev/compose.yaml
+++ b/local_dev/compose.yaml
@@ -9,6 +9,9 @@ services:
       args:
         LOCAL_USER: ${LOCAL_USER:-${USER}}
         PYTHON_VERSION: ${PYTHON_VERSION:-3.11}
+        GLOBUS_COMPUTE_COMMON_DIR: ${GLOBUS_COMPUTE_COMMON_DIR:-}
+      additional_contexts:
+        globus_compute_common: ${GLOBUS_COMPUTE_COMMON_DIR:-.}
     volumes:
       - ../:/opt/globus-compute
       - ./docker_data/.globus_compute:/home/${LOCAL_USER:-${USER}}/.globus_compute


### PR DESCRIPTION

# Description

The local dev Dockerfile did not previously support installing globus-compute-common from a local checkout. This adds that capability via GLOBUS_COMPUTE_COMMON_DIR and only copies/installs globus-compute-common when that argument is provided.

Compose wires the same value through as a dedicated additional build context. As with the bare Dockerfile, leaving the argument unset preserves the existing behavior and skips the package install.

## Type of change

- Code maintenance/cleanup
