### PR TITLE
Bump versions for 4.12.0

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "4.11.0"
+__version__ = "4.12.0a1"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/globus_compute_endpoint/version.py
+++ b/compute_endpoint/globus_compute_endpoint/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "4.12.0a1"
+__version__ = "4.12.0"
 
 # TODO: remove after a `globus-compute-sdk` release
 # this is needed because it's imported by `globus-compute-sdk` to do the version check

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==4.11.0",
+    "globus-compute-sdk==4.12.0a1",
     "globus-identity-mapping==0.5.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "requests>=2.31.0,<3",
     "globus-sdk",  # version will be bounded by `globus-compute-sdk`
-    "globus-compute-sdk==4.12.0a1",
+    "globus-compute-sdk==4.12.0",
     "globus-identity-mapping==0.5.0",
     # table printing used in list-endpoints
     "texttable>=1.6.4,<2",

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -4,7 +4,7 @@ from globus_compute_sdk.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "4.11.0"
+__version__ = "4.12.0a1"
 
 
 def compare_versions(

--- a/compute_sdk/globus_compute_sdk/version.py
+++ b/compute_sdk/globus_compute_sdk/version.py
@@ -4,7 +4,7 @@ from globus_compute_sdk.errors import VersionMismatch
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "4.12.0a1"
+__version__ = "4.12.0"
 
 
 def compare_versions(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,16 @@ Changelog
 
 .. scriv-insert-here
 
+.. _changelog-4.12.0:
+
+globus-compute-sdk & globus-compute-endpoint v4.12.0
+----------------------------------------------------
+
+Changed
+^^^^^^^
+
+- Minor changes to console output
+
 .. _changelog-4.11.0:
 
 globus-compute-sdk & globus-compute-endpoint v4.11.0


### PR DESCRIPTION
Bump versions for release of 4.12.0.

There were no changelog fragments but added a short section so 4.12.0 is not absent from changelog.