### PR TITLE
Display DeprecationWarnings instead of hide by default

### DIFF
--- a/changelog.d/20260608_121002_lei_remove_deprec_warning_50070.rst
+++ b/changelog.d/20260608_121002_lei_remove_deprec_warning_50070.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+- DeprecationWarning is now always emitted by default, instead of being hidden.  As before,
+  ``warnings.warn()`` output can be `customized <https://docs.python.org/3/library/warnings.html#warning-filter>`_.
+  e.g. ``PYTHONWARNINGS="ignore::DeprecationWarning" globus-compute-endpoint start my_endpoint``

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -470,6 +470,7 @@ def configure_endpoint(
             "--endpoint-config is deprecated; use --manager-config instead."
             " If you want to configure user endpoint processes, use --template-config.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         if manager_config is None:
@@ -479,6 +480,7 @@ def configure_endpoint(
                 "Both --endpoint-config and --manager-config were provided;"
                 " --endpoint-config will be ignored.",
                 UserWarning,
+                stacklevel=2,
             )
 
     try:

--- a/compute_sdk/globus_compute_sdk/__init__.py
+++ b/compute_sdk/globus_compute_sdk/__init__.py
@@ -1,5 +1,7 @@
 """Globus Compute : Fast function serving for clouds, clusters and supercomputers."""
 
+import warnings
+
 from globus_compute_sdk.version import __version__ as _version
 
 __author__ = "The Globus Compute Team"
@@ -16,4 +18,14 @@ __all__ = (
     "MPIFunction",
     "ShellFunction",
     "ShellResult",
+)
+
+# Without adding this filter, DeprecationWarnings are hidden by default
+# This can be overridden with
+#     PYTHONWARNINGS="module::DeprecationWarning" <python script>
+# 'module' can be one of https://docs.python.org/3/library/warnings.html#warning-filter
+warnings.filterwarnings(
+    "always",
+    category=DeprecationWarning,
+    module=r"(globus_compute_sdk|globus_compute_endpoint)(\..+)?$",
 )

--- a/compute_sdk/globus_compute_sdk/sdk/executor.py
+++ b/compute_sdk/globus_compute_sdk/sdk/executor.py
@@ -176,6 +176,7 @@ class Executor(concurrent.futures.Executor):
                 warnings.warn(
                     f"'{key}' is not utilized and will be removed in a future release",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 continue
             msg = f"'{key}' is an invalid argument for {self.__class__.__name__}"


### PR DESCRIPTION
# Description

DeprecationWarning is [ignored by default](https://docs.python.org/3/library/warnings.html#warning-categories) previously.

There were 4 instances of DeprecationWarning and 3 of UserWarning.  Instead of changing DeprecationWarning to log.warning() or similar, we can take advantage of the Python warnings module by keeping them as is, but overriding the output to 'always' so they are printed by default.

Also, use stacklevel=2 in all usages of both to be more consistent in display outout.

[sc-50070]

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Change