### PR TITLE
Reduce stepping on template variable namespace

### DIFF
--- a/changelog.d/20260616_161918_kevin_move_reserved_variables_to_namespace.rst
+++ b/changelog.d/20260616_161918_kevin_move_reserved_variables_to_namespace.rst
@@ -1,0 +1,16 @@
+Deprecated
+^^^^^^^^^^
+
+- Moved the reserved template variables ``parent_config``, ``user_runtime``,
+  and ``mapped_identity`` into the variable ``_R``.  Access to these variables
+  as standalone entities is now deprecated, and a warning is emitted to the
+  parent endpoint log when a template uses them.
+
+Changed
+^^^^^^^
+
+- Introduced the reserved template variable ``_R`` to hold all reserved
+  variables.  The provided template variables ``parent_config``,
+  ``user_runtime``, and ``mapped_identity`` should now be accessed via the
+  ``_R`` namespace (e.g., ``{{ _R.mapped_identity.local.uname }}``) within the
+  ``user_config_template.yaml.j2`` template.

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/utils.py
@@ -23,7 +23,41 @@ RESERVED_USER_CONFIG_TEMPLATE_VARIABLES = (
     "parent_config",
     "user_runtime",
     "mapped_identity",
+    "_GC",
 )
+
+
+class DeprecatedTemplateVar:
+    def __init__(self, name: str, data):
+        self.name = name
+        self.data = data
+
+    def warn(self):
+        log.warning(
+            f"Template access to `{self.name}` is deprecated; access via `_GC`"
+            f" instead.  (i.e., _GC.{self.name})",
+            stacklevel=3,
+        )
+
+    def __getattr__(self, key):
+        self.warn()
+        d = self.data
+        val = None
+        if d:
+            try:
+                val = d[key]
+            except TypeError:
+                val = getattr(d, key)
+
+        return val
+
+    def __bool__(self):
+        self.warn()
+        return bool(self.data)
+
+    def __str__(self):
+        self.warn()
+        return str(self.data)
 
 
 def _read_config_file(config_path: pathlib.Path) -> str:
@@ -289,11 +323,20 @@ def render_config_user_template(
     _validate_user_opts(_user_opts, user_config_schema)
     _user_opts = _sanitize_user_json(_user_opts)
 
-    _render_payload = _user_opts | {
+    R = {  # "reserved", but line length woes
         "parent_config": parent_config,
         "mapped_identity": _parse_mapped_identity(mapped_identity),
         "user_runtime": _sanitize_user_json(user_runtime or {}),
     }
+    reserved_template_vars = {
+        "_GC": R,
+        "parent_config": DeprecatedTemplateVar("parent_config", R["parent_config"]),
+        "mapped_identity": DeprecatedTemplateVar(
+            "mapped_identity", R["mapped_identity"]
+        ),
+        "user_runtime": DeprecatedTemplateVar("user_runtime", R["user_runtime"]),
+    }
+    _render_payload = _user_opts | reserved_template_vars
 
     user_config_template_dir = user_config_template_path.parent
     try:

--- a/compute_endpoint/tests/unit/test_config_utils.py
+++ b/compute_endpoint/tests/unit/test_config_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import logging
 import os
 import pathlib
 import shlex
@@ -401,6 +402,29 @@ def test_render_config_passes_user_runtime(
         assert rendered_dict["user_python"] == user_runtime["python"]["version"]
     else:
         assert rendered_dict["user_python"] == "<none>"
+
+
+@pytest.mark.parametrize("reserved_word", RESERVED_USER_CONFIG_TEMPLATE_VARIABLES)
+def test_render_config_logs_deprecated_reserved_fields(
+    conf_no_engine: UserEndpointConfig,
+    mapped_ident: MappedPosixIdentity,
+    reserved_word,
+    randomstring,
+    caplog,
+):
+    caplog.set_level(logging.WARNING)
+    template = "some_key: {{ %s }}" % reserved_word
+    rendered = render_config_user_template(
+        conf_no_engine, template, pathlib.Path("/"), mapped_ident
+    )
+
+    if "_GC" == reserved_word:
+        assert len(caplog.records) == 0, "Expect no warning if using `_GC`"
+    else:
+        r = caplog.records[-1]
+        assert r.levelno == logging.WARNING
+        assert f"`{reserved_word}` is deprecated" in r.message
+        assert f"(i.e., _GC.{reserved_word})" in r.message, "Expect directed how to fix"
 
 
 def test_render_config_passes_mapped_identity(mocker, conf_no_engine):

--- a/docs/endpoints/templates.rst
+++ b/docs/endpoints/templates.rst
@@ -186,13 +186,14 @@ Reserved Variables
 ==================
 
 Every template has access to reserved variables that cannot be overridden by the
-user or admin:
+user or admin.  These are accessible from the Globus-Compute-supplied variable of
+``_GC``.
 
-- ``parent_config``: Contains the configuration values of the parent manager
+- ``_GC.parent_config``: Contains the configuration values of the parent manager
   endpoint.  This can be helpful in situations involving Python-based
   configuration files.
 
-- ``user_runtime``: Contains information about the runtime environment of the
+- ``_GC.user_runtime``: Contains information about the runtime environment of the
   user submitting tasks, such as their Python version.  The following fields are
   available:
 
@@ -218,7 +219,7 @@ user or admin:
     - ``processor``: Host processor name (e.g., ``"x86_64"``)
     - ``release``: Host OS release (e.g., ``"6.16.5-2-generic"``)
 
-- ``mapped_identity``: Contains information about the user's mapped identity.
+- ``_GC.mapped_identity``: Contains information about the user's mapped identity.
   The following fields are available:
 
   - ``local.uname``: Local user's username
@@ -238,11 +239,15 @@ user or admin:
          type: GlobusComputeEngine
          provider:
             type: SlurmProvider
-      {% if 1001 in mapped_identity.local.groups %}
+      {% if 1001 in _GC.mapped_identity.local.groups %}
             partition: {{ partition }}
       {% else %}
             partition: default
       {% endif %}
+
+.. note::
+   The variables ``parent_config``, ``user_runtime``, and ``mapped_identity`` are
+   available outside of ``_GC`` for legacy reasons, but this access is deprecated.
 
 
 Combining Templates


### PR DESCRIPTION
With the advent of another reserved variable (soon `env`), there is increasing chance of stepping on a template variable that administrators may want to utilize.  Reduce the footprint by using a very unlikely variable name (`_GC`), and placing all reserved or infrastructure template variables in there.  Administrators will thus be able to see the entire structure during development by using something silly like:

```yaml
{{ _GC }}
```

And use it productively like shown in the documentation, like:

```yaml
{{ _GC.user_runtime.platform.node }}
```

## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update