### PR TITLE
Fix typo in changelog fragment

### DIFF
--- a/changelog.d/20260616_161918_kevin_move_reserved_variables_to_namespace.rst
+++ b/changelog.d/20260616_161918_kevin_move_reserved_variables_to_namespace.rst
@@ -2,15 +2,15 @@ Deprecated
 ^^^^^^^^^^
 
 - Moved the reserved template variables ``parent_config``, ``user_runtime``,
-  and ``mapped_identity`` into the variable ``_R``.  Access to these variables
+  and ``mapped_identity`` into the variable ``_GC``.  Access to these variables
   as standalone entities is now deprecated, and a warning is emitted to the
   parent endpoint log when a template uses them.
 
 Changed
 ^^^^^^^
 
-- Introduced the reserved template variable ``_R`` to hold all reserved
+- Introduced the reserved template variable ``_GC`` to hold all reserved
   variables.  The provided template variables ``parent_config``,
   ``user_runtime``, and ``mapped_identity`` should now be accessed via the
-  ``_R`` namespace (e.g., ``{{ _R.mapped_identity.local.uname }}``) within the
+  ``_GC`` namespace (e.g., ``{{ _GC.mapped_identity.local.uname }}``) within the
   ``user_config_template.yaml.j2`` template.


### PR DESCRIPTION
# Description

`_R` -> `_GC`

## Type of change

- Documentation update