### PR TITLE
Check kill/killpg call order in shutdown loop

### DIFF
--- a/compute_endpoint/tests/unit/test_endpointmanager_unit.py
+++ b/compute_endpoint/tests/unit/test_endpointmanager_unit.py
@@ -776,6 +776,21 @@ def test_children_signaled_at_shutdown(
     for killpg_call, exp_args in zip(killpg, killpg_expected_calls):
         assert killpg_call[0] == exp_args, "Expected SIGKILL only for os.killpg"
 
+    # First os.killpg() should be before the SIGTERM/SIGKILL loop, but all other
+    # os.killpg() should be after os.kill()
+    kill_called = False
+    killpg_call_count = 0
+    for c in mock_os.mock_calls:
+        if c[0] == "kill":
+            assert killpg_call_count < 2, (
+                "os.kill should not be called after 2nd os.killpg"
+            )
+            kill_called = True
+        elif c[0] == "killpg":
+            if killpg_call_count > 0:
+                assert kill_called, "subsequent os.killpg calls should follow os.kill"
+            killpg_call_count += 1
+
 
 def test_restarts_running_endpoint_with_cached_args(epmanager_as_root, mock_log):
     *_, mock_os, _mock_pwd, em = epmanager_as_root


### PR DESCRIPTION
# Description

The previous [PR-2138](https://github.com/globus/globus-compute/pull/2138) included tests that ensured kill/killpg are called with the correct arguments, but didn't check the call order (SIGTERM kill on pid should be before SIGKILL killpg on pgid).

This adds checking in the test to confirm the order, excluding the first killpg prior to the loop.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
