### PR TITLE
Remove unused test-fixture branch

### DIFF
--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_interchange_with_rabbit.py
@@ -41,14 +41,8 @@ def run_interchange_process(
             endpoint_id=endpoint_uuid, global_state={}, task_statuses={}
         )
 
-        if hasattr(request, "param") and request.param:
-            config = request.param
-        else:
-            config = UserEndpointConfig(engine=None)
-        config.engine = mock_exe
-
         ix = EndpointInterchange(
-            config=config,
+            config=UserEndpointConfig(engine=mock_exe),
             endpoint_id=endpoint_uuid,
             reg_info=reg_info,
             ep_info={},


### PR DESCRIPTION
The only test that made use of the request params for this fixture was removed in Mar, 2025[1].

[1] fa04597446bad500a4cef0cffb88269e7e4ca97b

## Type of change

- Code maintenance/cleanup