### PR TITLE
Fix diagnostic handling of empty directory

### DIFF
--- a/changelog.d/20260709_175553_kevin_sc_49941.rst
+++ b/changelog.d/20260709_175553_kevin_sc_49941.rst
@@ -1,0 +1,5 @@
+Bug Fixes
+^^^^^^^^^
+
+- ``globus-compute-diagnostic`` no longer crashes when encountering an empty
+  directory

--- a/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
+++ b/compute_sdk/globus_compute_sdk/sdk/diagnostic.py
@@ -303,7 +303,7 @@ def get_recent_endpoints(base_dir: Path, ep_names: list) -> list[Path]:
     for ep in ep_list:
         if ep.is_dir() and ep.name in ep_names:
             latest_ts = max(
-                ep.stat().st_mtime, *(p.stat().st_mtime for p in ep.iterdir())
+                (ep.stat().st_mtime, *(p.stat().st_mtime for p in ep.iterdir()))
             )
             ep_list_by_ts.append([latest_ts, ep])
     return [e[1] for e in sorted(ep_list_by_ts, reverse=True)]

--- a/compute_sdk/tests/unit/test_diagnostic.py
+++ b/compute_sdk/tests/unit/test_diagnostic.py
@@ -11,7 +11,11 @@ import sys
 from unittest import mock
 
 import pytest
-from globus_compute_sdk.sdk.diagnostic import cat, do_diagnostic_base
+from globus_compute_sdk.sdk.diagnostic import (
+    cat,
+    do_diagnostic_base,
+    get_recent_endpoints,
+)
 from globus_compute_sdk.sdk.hardware_report import (
     mem_info,
     python_runtime_host_info,
@@ -544,3 +548,18 @@ def test_mem_swap_info():
 
     assert "iB " in minfo, "Expect humanization of output"
     assert "iB " in sinfo, "Expect humanization of output"
+
+
+def test_get_recent_endpoints(fs):
+    base_dir = pathlib.Path("/gc_dir")
+
+    not_empty = base_dir / "not_empty_dir"
+    not_empty.mkdir(parents=True)
+    (not_empty / "some_file").touch()
+    recent_dirs = get_recent_endpoints(base_dir, [])
+    assert not_empty in recent_dirs
+
+    empty = base_dir / "empty_dir"
+    empty.mkdir()
+    recent_dirs = get_recent_endpoints(base_dir, [])
+    assert empty in recent_dirs, "Expect no crash; if empty recent, it's in list"


### PR DESCRIPTION
An oversight in a generator and Python syntax.  `max()` expects more than one item, which it wasn't getting if a directory was empty.  Force what `max()` receives to be an iterable by wrapping it all in a generator.

## Type of change

- Bug fix (non-breaking change that fixes an issue)