### PR TITLE
Add email contact argument to configure and default config.yaml

### DIFF
--- a/changelog.d/20260709_121006_lei_add_email_sc_49781.rst
+++ b/changelog.d/20260709_121006_lei_add_email_sc_49781.rst
@@ -1,0 +1,29 @@
+New Functionality
+^^^^^^^^^^^^^^^^^
+
+- When configuring a new endpoint, a new argument, ``--contact-email``, is
+  now available.  A value is required for multi-user and optional for
+  single-user Compute endpoints.
+  Providing it gives Compute users an initial point of contact to
+  reach out to for support.
+
+  Usage example:
+
+  .. code-block:: console
+
+     $ gce configure --contact-email admin@example.edu test_endpoint
+
+  The value will be stored in ``config.yaml`` as ``email`` and can be updated there:
+
+  .. code-block:: yaml
+
+     display_name: Compute Endpoint for example.edu
+     email: admin@example.edu
+     subscription_id: ...
+     admins:
+       ...
+
+  Existing multi-user endpoint admins will have to add the ``email`` field and value
+  to their ``config.yaml`` if they update globus-compute-endpoint to the latest version.
+  Note that this new field is optional for single-user (non identity-mapping)
+  compute endpoints.

--- a/compute_endpoint/globus_compute_endpoint/cli.py
+++ b/compute_endpoint/globus_compute_endpoint/cli.py
@@ -335,6 +335,11 @@ def version_command():
         " https://docs.globus.org/api/auth/developer-guide/#authentication-policies."
     ),
 )
+@click.option(
+    "--contact-email",
+    type=click.STRING,
+    help="The email address to contact for the administrators of the endpoint",
+)
 @optgroup.group(
     "Configuration File Overrides",
     help=(
@@ -443,6 +448,7 @@ def configure_endpoint(
     user_env_config: pathlib.Path | None,
     multi_user: bool | None,
     high_assurance: bool,
+    contact_email: str,
     display_name: str | None,
     auth_policy: str | None,
     auth_policy_mfa_required: bool,
@@ -489,6 +495,12 @@ def configure_endpoint(
         raise ClickException(str(e))
 
     id_mapping = is_privileged() if multi_user is None else multi_user
+
+    if id_mapping and not contact_email:
+        raise ClickException(
+            "Email must be specified via --contact-email for multi-user endpoints"
+        )
+
     if id_mapping_config is not None and not id_mapping:
         raise ClickException(
             "--id-mapping-config requires multi user support (hint: --multi-user true)"
@@ -560,6 +572,7 @@ def configure_endpoint(
         display_name=display_name,
         auth_policy=auth_policy,
         subscription_id=subscription_id,
+        contact_email=contact_email,
     )
 
 
@@ -901,6 +914,11 @@ def _start_endpoint_manager(
                 f"Configuration for endpoint {ep_dir.name} contains an `engine` field;"
                 " endpoint will not start. (Hint: move the `engine` block to"
                 " `user_config_template.yaml.j2`)"
+            )
+        elif not ep_config.email and is_privileged():
+            raise ClickException(
+                f"Multi-user endpoints require a contact email"
+                " address.  (Hint: add an `email` field to config.yaml)"
             )
 
         reg_info = _do_register_endpoint(ep_dir, ep_config, endpoint_uuid)

--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/config.py
@@ -403,6 +403,7 @@ class ManagerEndpointConfig(BaseConfig):
         audit_log_path: os.PathLike | str | None = None,
         pam: PamConfiguration | None = None,
         mu_child_ep_grace_period_s: float = 30.0,
+        email: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -424,6 +425,8 @@ class ManagerEndpointConfig(BaseConfig):
         self.audit_log_path = _tmp  # type: ignore[assignment]
 
         self.pam = pam or PamConfiguration(enable=False)
+
+        self.email = email
 
     @property
     def user_config_template_path(self) -> pathlib.Path | None:

--- a/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/endpoint.py
@@ -113,6 +113,7 @@ class Endpoint:
         auth_policy: str | None,
         subscription_id: str | None,
         public_visibility: bool = False,
+        contact_email: str | None = None,
     ):
         config_text = original_path.read_text()
         config_dict = yaml.safe_load(config_text)
@@ -128,6 +129,9 @@ class Endpoint:
 
         if display_name:
             config_dict["display_name"] = display_name
+
+        if contact_email:
+            config_dict["email"] = contact_email
 
         if id_mapping:
             config_dict["identity_mapping_config_path"] = str(
@@ -170,6 +174,7 @@ class Endpoint:
         display_name: str | None = None,
         auth_policy: str | None = None,
         subscription_id: str | None = None,
+        contact_email: str | None = None,
     ) -> None:
         """Initialize a clean endpoint dir
 
@@ -251,6 +256,7 @@ class Endpoint:
                 display_name,
                 auth_policy,
                 subscription_id,
+                contact_email=contact_email,
                 public_visibility=id_mapping,
             )
 
@@ -270,6 +276,7 @@ class Endpoint:
         display_name: str | None = None,
         auth_policy: str | None = None,
         subscription_id: str | None = None,
+        contact_email: str | None = None,
     ):
         ep_name = conf_dir.name
         if conf_dir.exists():
@@ -290,6 +297,7 @@ class Endpoint:
                 display_name,
                 auth_policy,
                 subscription_id,
+                contact_email,
             )
         except Exception:
             # Clean up the new EP directory as it may be incomplete/corrupt

--- a/compute_endpoint/tests/unit/conftest.py
+++ b/compute_endpoint/tests/unit/conftest.py
@@ -66,6 +66,7 @@ known_manager_config_opts = {
     "local_compute_services": True,
     "environment": str,
     "high_assurance": True,
+    "email": str,
 }
 
 

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -817,17 +817,98 @@ def test_start_ep_display_name_in_config(
     dir_name, display_name = display_test
 
     conf = gc_dir / dir_name / "config.yaml"
-    open("/tmp/err.txt", "a").write(f"XXX {conf=}\n")
     configure_arg = ""
     if display_name is not None:
         configure_arg = f" --display-name '{display_name}'"
     run_line(f"configure {dir_name}{configure_arg}")
 
-    open("/tmp/err.txt", "a").write(f"YYY {dir_name=} {conf=}")
     with open(conf) as f:
         conf_dict = yaml.safe_load(f)
 
     assert conf_dict["display_name"] == display_name
+
+
+@pytest.mark.parametrize(
+    ("is_privileged", "mu_flag"),
+    [
+        # All variations that do not result in id-mapping
+        [True, False],
+        [False, False],
+        [False, None],
+    ],
+)
+def test_email_not_required_for_non_identity_mapping(
+    run_line, gc_dir, make_endpoint_dir, is_privileged, mu_flag
+):
+    conf = gc_dir / "some_ep" / "config.yaml"
+
+    configure_arg = f" --multi-user {mu_flag}" if mu_flag is not None else ""
+
+    with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=is_privileged):
+        run_line(f"configure some_ep {configure_arg}")
+
+    with open(conf) as f:
+        conf_dict = yaml.safe_load(f)
+        assert "email" not in conf_dict
+
+
+@pytest.mark.parametrize(
+    ("is_privileged", "mu_flag"),
+    [
+        # All variations that configures a multi-user (id-mapping) EP
+        [True, True],
+        [False, True],
+        [True, None],
+    ],
+)
+def test_multi_user_errors_without_email(
+    run_line, gc_dir, make_endpoint_dir, is_privileged, mu_flag
+):
+    configure_arg = f" --multi-user {mu_flag}" if mu_flag is not None else ""
+
+    with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=is_privileged):
+        res = run_line(f"configure ep_name {configure_arg}", assert_exit_code=1)
+    assert "Email must be specified" in res.stderr, "Expect error message"
+
+
+def test_email_in_config_after_configure(
+    run_line, gc_dir, make_endpoint_dir, randomstring
+):
+    conf = gc_dir / "some_ep" / "config.yaml"
+
+    email = randomstring()
+
+    run_line(f"configure some_ep --contact-email {email}")
+    with open(conf) as f:
+        conf_dict = yaml.safe_load(f)
+
+    assert conf_dict["email"] == email
+
+
+def test_start_ep_config_missing_email_not_privileged_ok(
+    mocker, run_line, mock_command_ensure, make_endpoint_dir, ep_name
+):
+    conf = make_endpoint_dir() / "config.yaml"
+
+    conf.write_text("display_name:\n  foo")
+
+    mocker.patch(f"{_MOCK_BASE}_start_endpoint_manager")
+
+    with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=False):
+        res = run_line(f"start {ep_name}")
+    assert f"require a contact email" not in res.stderr
+
+
+def test_start_ep_config_missing_email_error_privileged(
+    run_line, mock_command_ensure, make_endpoint_dir, ep_name
+):
+    conf = make_endpoint_dir() / "config.yaml"
+
+    conf.write_text("display_name:\n  foo")
+
+    with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=True):
+        res = run_line(f"start {ep_name}", assert_exit_code=1)
+    assert f"Multi-user endpoints require a contact email" in res.stderr
 
 
 @pytest.mark.parametrize(
@@ -905,7 +986,7 @@ def test_configure_ep_public_visible_by_default(
 
     mu_arg_str = f" --multi-user {mu_arg}" if mu_arg is not None else ""
     with mock.patch(f"{_MOCK_BASE}is_privileged", return_value=is_privileged):
-        run_line(f"configure {mu_arg_str} {ep_name}")
+        run_line(f"configure --contact-email a@xyz.com {mu_arg_str} {ep_name}")
 
     with open(conf) as f:
         conf_dict = yaml.safe_load(f)
@@ -968,7 +1049,7 @@ def test_configure_ep_config_options(
 ):
     gc_dir.mkdir(parents=True, exist_ok=True)
 
-    cmd = f"configure {randomstring()}"
+    cmd = f"configure --contact-email a@xyz.com {randomstring()}"
     if manager_config:
         manager_config = gc_dir / manager_config
         manager_config.touch()

--- a/docs/endpoints/config_reference.rst
+++ b/docs/endpoints/config_reference.rst
@@ -345,6 +345,18 @@ configuration options in this file are used to create an instance of the
 
      public: true
 
+- ``email``
+
+  A string value that will be visible to endpoint users as an initial point
+  of contact to reach out to for support.  This stores the value provided via
+  the ``--contact-email`` argument when configuring a multi-user endpoint.
+  ``email`` is allowed but not required for non identity-mapping endpoints.
+
+  .. code-block:: yaml
+     :caption: ``config.yaml`` -- example email
+
+     email: admin@example.edu
+
 - ``identity_mapping_config_path``
 
   A path to an identity mapping configuration, per the Globus Connect Server

--- a/docs/endpoints/multi_user.rst
+++ b/docs/endpoints/multi_user.rst
@@ -143,7 +143,7 @@ properly generate the :ref:`multi-user-config-yaml` and
 
 .. code-block:: console
 
-   # gce configure my_mu_ep
+   # gce configure --contact-email admin@example.edu my_mu_ep
    Created profile for endpoint named <my_mu_ep>
 
        Configuration file: /root/.globus_compute/my_mu_ep/config.yaml
@@ -164,16 +164,17 @@ properly generate the :ref:`multi-user-config-yaml` and
 ``config.yaml``
 ---------------
 
-The default multi-user endpoint ``config.yaml`` file contains one additional
-field to specify the identity mapping file path:
+The default multi-user endpoint ``config.yaml`` file contains two additional
+fields, to specify the contact email and identity mapping file path respectively
 
 .. code-block:: yaml
    :caption: The default multi-user ``config.yaml`` configuration
-   :emphasize-lines: 3
+   :emphasize-lines: 4-5
 
    amqp_port: 443
    display_name: null
    public: true
+   email: admin@example.edu
    identity_mapping_config_path: /root/.globus_compute/my_mu_ep/example_identity_mapping_config.json
 
 Please refer to :ref:`endpoint-manager-config` for details on each field.


### PR DESCRIPTION
# Description

Add contact email for endpoints, required for multi-user endpoints, as an argument when configuring a new endpoint.

This adds the argument to ``gce configure`` and stores it in the generated config.yaml.  It will be sent in the endpoint config metadata but not yet added as a standalone field in the Compute API/webapp.

## Type of change

- New feature (non-breaking change that adds functionality)
