### PR TITLE
Update click and remove stderr param to avoid CVE-2026-7246

### DIFF
--- a/compute_endpoint/setup.py
+++ b/compute_endpoint/setup.py
@@ -21,7 +21,7 @@ REQUIRES = [
     # provides easy daemonization of the endpoint
     "python-daemon>=2,<3",
     # CLI parsing
-    "click>=8,<8.2.0",
+    "click>=8.3.3,<8.4.0",
     "click-option-group>=0.5.6,<1",
     "pyzmq>=24,<=28",
     # 'parsl' is a core requirement of the globus-compute-endpoint, essential to a range

--- a/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
+++ b/compute_endpoint/tests/integration/endpoint/endpoint/test_endpoint.py
@@ -65,8 +65,8 @@ def test_non_configured_endpoint(tmp_path):
     env = {"GLOBUS_COMPUTE_USER_DIR": str(tmp_path)}
     with mock.patch.dict(os.environ, env):
         result = CliRunner().invoke(app, ["start", "newendpoint"])
-        assert "newendpoint" in result.stdout
-        assert "no endpoint configuration" in result.stdout
+        assert "newendpoint" in result.stderr
+        assert "no endpoint configuration" in result.stderr
 
 
 def test_stop_remote_endpoint(mocker):

--- a/compute_endpoint/tests/unit/test_cli_behavior.py
+++ b/compute_endpoint/tests/unit/test_cli_behavior.py
@@ -278,7 +278,7 @@ engine:
 
 @pytest.fixture
 def cli_runner():
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

A [new CVE](https://explore.alas.aws.amazon.com/CVE-2026-7246.html) appeared yesterday that desginates click 8.3.2 and below as containing a command injection vulnerability.

This blocks our pip-audit build.  Simply bumping click is not sufficient, as [click 8.2.0 removes](https://github.com/pallets/click/releases/tag/8.2.0) the ``mix_stderr`` param from ``CliRunner`` and this is used by us.

Only one test is affected by mix_stderr so I'm updating the test in creating this PR so builds are unblocked while I research our usage of the param further.

## Type of change

- Code maintenance/cleanup
