### PR TITLE
Skip None values when dispatching from config

### DIFF
--- a/compute_endpoint/globus_compute_endpoint/endpoint/config/dispatch.py
+++ b/compute_endpoint/globus_compute_endpoint/endpoint/config/dispatch.py
@@ -46,7 +46,8 @@ class TypeDispatcher(abc.ABC, t.Generic[T]):
             )
 
         try:
-            instance = obj(**data)
+            # exclude None values to match the old Pydantic v1 `exclude_none=True` behavior
+            instance = obj(**{k: v for k, v in data.items() if v is not None})
         except Exception as e:
             raise ValueError(str(e)) from e
         return t.cast(T, instance)

--- a/compute_endpoint/tests/unit/test_endpoint_config.py
+++ b/compute_endpoint/tests/unit/test_endpoint_config.py
@@ -225,6 +225,13 @@ def test_dispatcher_does_not_mutate_input_dict():
     assert provider_cfg == provider_cfg_orig
 
 
+def test_dispatcher_excludes_none():
+    provider = ProviderDispatcher.build_instance(
+        {"type": "LocalProvider", "worker_init": None}
+    )
+    assert provider.worker_init == "", "None should fall through to default"
+
+
 @pytest.mark.parametrize(
     "cls",
     (


### PR DESCRIPTION
# Description

YAML fields such as worker_init: can deserialize to None. Under Pydantic v1, exclude_none=True prevented those None values from reaching parsl constructors; this restores that behavior by skipping None values during TypeDispatcher config loading.

Fixes a bug raised by QA (with thanks to James):

```
$ time globus-compute-diagnostic -e 8afef3c4-bc22-49ef-b0e2-0cd787c31b94
globus-compute-endpoint is installed at /home/ec2-user/COMPUTE_20260713_1256/bin/globus-compute-endpoint
Some diagnostic commands require being logged in.
Traceback (most recent call last):
  File "/home/ec2-user/COMPUTE_20260713_1256/bin/globus-compute-diagnostic", line 8, in <module>
    sys.exit(do_diagnostic())
             ^^^^^^^^^^^^^^^
  File "/home/ec2-user/COMPUTE_20260713_1256/lib64/python3.12/site-packages/globus_compute_sdk/sdk/diagnostic.py", line 690, in do_diagnostic
    return do_diagnostic_base(sys.argv[1:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/COMPUTE_20260713_1256/lib64/python3.12/site-packages/globus_compute_sdk/sdk/diagnostic.py", line 675, in do_diagnostic_base
    run_all_diags_wrapper(
  File "/home/ec2-user/COMPUTE_20260713_1256/lib64/python3.12/site-packages/globus_compute_sdk/sdk/diagnostic.py", line 548, in run_all_diags_wrapper
    result = fut.result(timeout=DIAG_TIMEOUT_S)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
globus_compute_sdk.errors.error_types.TaskExecutionFailed:
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Traceback (most recent call last):
   File "/usr/lib64/python3.12/concurrent/futures/_base.py", line 401, in __get_result
     raise self._exception
 parsl.executors.errors.BadStateException: Executor GlobusComputeEngine-HighThroughputExecutor failed due to: Error 1:
 	Failed to start block 0: unsupported operand type(s) for +: 'NoneType' and 'str'
 Error 2:
 	Failed to start block 1: unsupported operand type(s) for +: 'NoneType' and 'str'
 ```

## Type of change

- Bug fix (non-breaking change that fixes an issue)