### PR TITLE
remove obsolete docker compose 'version' param

### DIFF
--- a/local_dev/compose.yaml
+++ b/local_dev/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.10"
 name: globus-compute-endpoint
 services:
 


### PR DESCRIPTION
# Description

The ``version`` keyword is obsolete as of [docker compose v2](https://github.com/mailcow/mailcow-dockerized/issues/5797).

Using this just produces a warning message, removing it gets rid of the warning:

```
$ docker compose up -d
WARN[0000] /Users/lei/glob/globus-compute/local_dev/compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Type of change

- Code maintenance/cleanup
