### PR TITLE
Doc: fix formatting in endpoint user guide

### DIFF
--- a/docs/endpoints/endpoints.rst
+++ b/docs/endpoints/endpoints.rst
@@ -1528,50 +1528,38 @@ Troubleshooting
 ===============
 
 If you are having issues starting an endpoint or submitting a task to Globus
-Compute, you can run self-diagnostics via the `globus-compute-diagnostic`
+Compute, you can run self-diagnostics via the ``globus-compute-diagnostic``
 script that is installed as part of the Globus Compute SDK.
 
 We recommend running the diagnostic on the same machine that the Globus Compute
 endpoint is running, so that it can gather log snippets from each of the installed
 endpoints.  If you are having trouble only when sending a task, you can run
 diagnostics from the submitting side (VM, laptop, etc) to confirm connectivity,
-preferably via the `-e ENDPOINT_UUID` option to send a simple sample task.
+preferably via the ``-e ENDPOINT_UUID`` option to send a simple sample task.
 
-Without parameters, the diagnostic will generate a .gz compressed file in the
-current directory named `globus_compute_diagnostic_YYYY-MM-DD-HH-mm-ssZ.txt.gz`
-with all test results (use `gunzip` to uncompress it).
+Without parameters, the diagnostic will generate a `GZip-compressed`_ file in
+the current directory named ``globus_compute_diagnostic_YYYY-MM-DD-HH-mm-ssZ.txt.gz``
+with all test results.
 
 
 .. code-block:: console
 
    $ globus-compute-diagnostic -h
-
-   usage: globus-compute-diagnostic [-h] [-p] [-k number] [-v] [-e ENDPOINT_UUID] [-c CONFIG_DIR]
+   usage: globus-compute-diagnostic [-h] [-p] [-k number] [-v] [-e ENDPOINT_UUID]
+                                    [-c CONFIG_DIR] [-l ENDPOINT_LOG_DIRS]
+                                    [-r RECENT_ENDPOINTS]
 
    Run diagnostics for Globus Compute
 
    options:
-     -h, --help            show this help message and exit
-     -p, --print-only      Do not generate a Gzip-compressed file. Print diagnostic results to the console instead.
-     -k number, --log-kb number
-                           Specify the number of kilobytes (KB) to read from log files. Defaults to 1024 KB (1 MB)
-                           per file.
-     -v, --verbose         When writing diagnostic output to local compressed file, also print the name of each test
-                           to stdout as they are being run, to help monitor diagnostic progress.
-     -e ENDPOINT_UUID, --endpoint-uuid ENDPOINT_UUID
-                           Test an endpoint by registering a sample function and sending a task to it using the newly
-                           registered function. An endpoint UUID is required.
-     -c CONFIG_DIR, --config-dir CONFIG_DIR
-                           Gather endpoint configuration and log info from the specified parent directory instead of
-                           the default ~/.globus_compute or what is set in $GLOBUS_COMPUTE_USER_DIR
+      [...]
 
-   This utility gathers local hardware specifications, tests connectivity to the Globus Compute web services, and
-   collates portions of local Compute Endpoint log files, if present, to a local compressed file.
-
+   This utility gathers local hardware specifications, tests connectivity to the Globus
+   Compute web services, and collates portions of local Compute Endpoint log files, if
+   present, to a local compressed file.
 
 For additional help with Globus Compute that is not addressed here, please
-reach out to our Team directly by submitting a
-[support ticket](https://www.globus.org/contact-us).
+reach out to our Team directly by submitting a `support ticket`_.
 
 
 .. |nbsp| unicode:: 0xA0
@@ -1608,3 +1596,5 @@ reach out to our Team directly by submitting a
 .. _fork(2): https://www.man7.org/linux/man-pages/man2/fork.2.html
 .. _deserializing untrusted data via pickle,: https://github.com/swisskyrepo/PayloadsAllTheThings/blob/4.1/Insecure%20Deserialization/Python.md
 .. _POSTs a REST request: https://compute.api.globus.org/redoc#tag/Endpoints/operation/submit_batch_v3_endpoints__endpoint_uuid__submit_post
+.. _GZip-compressed: https://www.gnu.org/software/gzip/manual/gzip.html
+.. _support ticket: https://www.globus.org/contact-us


### PR DESCRIPTION
While here, observe that there's no sense in duplicating the documentation available from `-h` — it's a live source that will change as we develop the tool.  Since we aren't expanding on the documentation, let the `-h` output be the single point of authority.

With thanks to @lgorenstein for the observation.

## Type of change

- Documentation update