### PR TITLE
Fail on warnings when building docs locally

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= --fail-on-warning
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
# Description

When using sphinx-build to build docs locally, if there is a warning that will fail GH Actions check-docs, it may not be as visible locally amidst other log messages.  This adds the [--fail-on-warning](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W) flag to make the issue more visible locally.

Before, when using `autobuild.sh`:

```
...
copying extra files... done
copying assets: done
writing output... [100%] tutorials/stage_data_with_transfer
generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [100%] _static/images/compute-model.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.                                            <--- easy to miss

The HTML pages are in _build/html.


Running Sphinx v7.4.7
...
```

With the flag:

```
...
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] endpoints/config_reference

Warning, treated as error:
/Users/lei/glob/globus-compute/docs/endpoints/config_reference.rst:164:Inline literal start-string without end-string.
make: *** [html] Error 2


Running Sphinx v7.4.7
...
```

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintenance/cleanup
